### PR TITLE
fix: make Touhou source classification conservative

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,11 @@ override a manual inclusion or exclusion.
 
 ## Classification rules
 
-- A source explicitly naming Touhou/東方 or a Touhou game is verified.
+- An exact Touhou Project alias or a recognized official Touhou game title in
+  the source is verified.
+- Longer unrecognized source names containing `Touhou` or `東方` stay
+  candidates until reviewed. These words also occur in unrelated works, and
+  fan album/game names need provenance before publication.
 - Membership in an official Touhou pack or a Touhou-only tournament is
   verified.
 - A Touhou mapper tag plus matching known artist/game/theme metadata is

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ files, songs, backgrounds, or other copyrighted assets.
 
 | State | Meaning |
 | --- | --- |
-| `verified` | Explicit Touhou source, official Touhou pack, Touhou-only tournament, or manual verification. |
+| `verified` | Recognized Touhou Project/game source, official Touhou pack, Touhou-only tournament, or manual verification. |
 | `probable` | Multiple independent signals agree, such as Touhou tags plus known Touhou metadata. |
 | `candidate` | Historical collection membership or one weaker signal; needs review. |
 | `excluded` | Manually confirmed false positive, retained to prevent rediscovery. |

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -11,6 +11,56 @@ class ClassifierTests(unittest.TestCase):
         self.assertEqual(item.confidence, "verified")
         self.assertIn("osu_source", item.evidence)
 
+    def test_known_game_source_is_verified(self):
+        item = Entry(
+            1,
+            source="東方永夜抄 ～ Imperishable Night.",
+            evidence=["discovery_query:source=東方Project"],
+            confidence="candidate",
+        )
+        apply_classification(item)
+        self.assertEqual(item.confidence, "verified")
+        self.assertIn("osu_source", item.evidence)
+
+    def test_unrelated_romanized_touhou_source_stays_candidate(self):
+        item = Entry(
+            1,
+            artist="Faylan",
+            title="God FATE (TV Size)",
+            source="Hakkenden Touhou Hakken Ibun",
+            evidence=["discovery_query:source=Touhou"],
+            confidence="candidate",
+        )
+        apply_classification(item, tags="hakkenden touhou hakken ibun anime")
+        self.assertEqual(item.confidence, "candidate")
+        self.assertNotIn("osu_source", item.evidence)
+
+    def test_unrelated_japanese_touhou_source_stays_candidate(self):
+        item = Entry(
+            1,
+            artist="Tetsuya Kakihara",
+            title="String of pain (TV Size)",
+            source="八犬伝－東方八犬異聞－",
+            evidence=["discovery_query:東方"],
+            confidence="candidate",
+        )
+        apply_classification(item, tags="東方八犬異聞 anime")
+        self.assertEqual(item.confidence, "candidate")
+        self.assertNotIn("osu_source", item.evidence)
+
+    def test_unreviewed_fan_source_stays_candidate(self):
+        item = Entry(
+            1,
+            artist="IOSYS",
+            title="Utage wa Eien ni",
+            source="Touhou Suisui Suusuu",
+            evidence=["discovery_query:source=Touhou"],
+            confidence="candidate",
+        )
+        apply_classification(item)
+        self.assertEqual(item.confidence, "candidate")
+        self.assertNotIn("osu_source", item.evidence)
+
     def test_official_pack_is_verified(self):
         item = Entry(1, evidence=["official_pack:FQ55"], confidence="candidate")
         apply_classification(item)

--- a/touhou_osu/classifier.py
+++ b/touhou_osu/classifier.py
@@ -8,24 +8,87 @@ from dataclasses import dataclass
 
 from .models import Entry
 
-TOUHOU_SOURCE_TOKENS = (
+EXACT_TOUHOU_SOURCES = (
     "touhou",
+    "touhou project",
     "東方",
+    "東方project",
+    "東方プロジェクト",
+)
+
+# Source metadata is strong enough for automatic verification only when it
+# names a known Touhou game.  In particular, do not treat arbitrary strings
+# containing the words "Touhou" or "東方" as proof: titles such as
+# "Hakkenden: Touhou Hakken Ibun" are unrelated to Touhou Project.
+TOUHOU_GAME_TITLE_TOKENS = (
+    "highly responsive to prayers",
+    "story of eastern wonderland",
+    "phantasmagoria of dim.dream",
+    "lotus land story",
+    "mystic square",
     "embodiment of scarlet devil",
     "perfect cherry blossom",
+    "immaterial and missing power",
     "imperishable night",
     "phantasmagoria of flower view",
+    "shoot the bullet",
     "mountain of faith",
+    "scarlet weather rhapsody",
     "subterranean animism",
     "undefined fantastic object",
+    "touhou hisoutensoku",
+    "double spoiler",
+    "great fairy wars",
     "ten desires",
+    "hopeless masquerade",
     "double dealing character",
+    "impossible spell card",
+    "urban legend in limbo",
     "legacy of lunatic kingdom",
+    "antinomy of common flowers",
     "hidden star in four seasons",
+    "violet detector",
     "wily beast and weakest creature",
+    "sunken fossil world",
     "unconnected marketeers",
+    "100th black market",
     "unfinished dream of all living ghost",
+    "fossilized wonders",
+    "東方靈異伝",
+    "東方封魔録",
+    "東方夢時空",
+    "東方幻想郷",
+    "東方怪綺談",
+    "東方紅魔郷",
+    "東方妖々夢",
+    "東方萃夢想",
+    "東方永夜抄",
+    "東方花映塚",
+    "東方文花帖",
+    "東方風神録",
+    "東方緋想天",
+    "東方地霊殿",
+    "東方星蓮船",
+    "東方非想天則",
+    "ダブルスポイラー",
+    "妖精大戦争",
+    "東方神霊廟",
+    "東方心綺楼",
+    "東方輝針城",
+    "弾幕アマノジャク",
+    "東方深秘録",
+    "東方紺珠伝",
+    "東方憑依華",
+    "東方天空璋",
+    "秘封ナイトメアダイアリー",
+    "東方鬼形獣",
+    "東方剛欲異聞",
+    "東方虹龍洞",
+    "バレットフィリア達の闇市場",
+    "東方獣王園",
+    "東方錦上京",
 )
+TOUHOU_METADATA_TOKENS = ("touhou", "東方", *TOUHOU_GAME_TITLE_TOKENS)
 TOUHOU_TAG_TOKENS = ("touhou", "東方project", "team shanghai alice", "上海アリス幻樂団")
 KNOWN_ARTISTS = {
     "zun",
@@ -58,6 +121,13 @@ def contains_any(value: str, tokens: tuple[str, ...] | set[str]) -> bool:
     return any(normalize(token) in normalized for token in tokens)
 
 
+def is_explicit_touhou_source(value: str) -> bool:
+    normalized = normalize(value).strip(" .,:：;_-~～")
+    if normalized in {normalize(source) for source in EXACT_TOUHOU_SOURCES}:
+        return True
+    return contains_any(normalized, TOUHOU_GAME_TITLE_TOKENS)
+
+
 @dataclass(frozen=True)
 class Classification:
     confidence: str
@@ -74,13 +144,13 @@ def classify(entry: Entry, *, tags: str = "") -> Classification:
     if any(item.startswith(("official_pack:", "tournament:", "tmc:")) for item in evidence):
         return Classification("verified", tuple(sorted(evidence)))
 
-    if contains_any(entry.source, TOUHOU_SOURCE_TOKENS):
+    if is_explicit_touhou_source(entry.source):
         evidence.add("osu_source")
         return Classification("verified", tuple(sorted(evidence)))
 
     tags_match = contains_any(tags, TOUHOU_TAG_TOKENS)
     artist_match = normalize(entry.artist) in {normalize(item) for item in KNOWN_ARTISTS}
-    metadata_match = artist_match or contains_any(f"{entry.artist} {entry.title}", TOUHOU_SOURCE_TOKENS)
+    metadata_match = artist_match or contains_any(f"{entry.artist} {entry.title}", TOUHOU_METADATA_TOKENS)
     if tags_match and metadata_match:
         evidence.update(("mapper_tags", "known_touhou_metadata"))
         return Classification("probable", tuple(sorted(evidence)))


### PR DESCRIPTION
## What changed

- verify only exact Touhou Project aliases and recognized official game titles
- keep unknown longer `Touhou` / `東方` source names as candidates
- add English and Japanese Hakkenden regression coverage
- document the conservative publication rule

## Why

The first automated discovery PR classified `Hakkenden: Touhou Hakken Ibun` anime songs as Touhou Project maps because source matching used unrestricted substrings.

## Validation

- `make check` (19 tests)
- `make build`
- offline audit against PR #1 data: 730/758 source-verified entries retained, 28 ambiguous sources returned to review, all four Hakkenden entries rejected