### PR TITLE
fix: require corroboration for probable matches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,8 @@ override a manual inclusion or exclusion.
   fan album/game names need provenance before publication.
 - Membership in an official Touhou pack or a Touhou-only tournament is
   verified.
-- A Touhou mapper tag plus matching known artist/game/theme metadata is
-  probable.
+- A Touhou mapper tag plus a known Touhou artist and independent historical
+  Touhou collection membership is probable.
 - A known Touhou circle alone is only a candidate because circles also release
   original and non-Touhou music.
 - Historical collection membership is evidence for discovery, not automatic

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ files, songs, backgrounds, or other copyrighted assets.
 | State | Meaning |
 | --- | --- |
 | `verified` | Recognized Touhou Project/game source, official Touhou pack, Touhou-only tournament, or manual verification. |
-| `probable` | Multiple independent signals agree, such as Touhou tags plus known Touhou metadata. |
+| `probable` | Multiple independent signals agree: Touhou tags, a known artist, and curated collection membership. |
 | `candidate` | Historical collection membership or one weaker signal; needs review. |
 | `excluded` | Manually confirmed false positive, retained to prevent rediscovery. |
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -72,10 +72,27 @@ class ClassifierTests(unittest.TestCase):
         self.assertEqual(item.confidence, "candidate")
         self.assertIn("known_touhou_artist", item.evidence)
 
-    def test_tags_plus_known_artist_are_probable(self):
+    def test_tags_plus_known_artist_without_collection_stay_candidate(self):
         item = Entry(1, artist="ShibayanRecords", evidence=["discovery_query:Touhou"])
         apply_classification(item, tags="touhou zun arrangement")
+        self.assertEqual(item.confidence, "candidate")
+
+    def test_tags_plus_known_artist_and_collection_are_probable(self):
+        item = Entry(1, artist="ShibayanRecords", evidence=["osucollector:1402"])
+        apply_classification(item, tags="touhou zun arrangement")
         self.assertEqual(item.confidence, "probable")
+
+    def test_zun_composed_seihou_track_stays_candidate(self):
+        item = Entry(
+            2374876,
+            artist="ZUN",
+            title="Shoujo Shinsei ~ Pandora's Box",
+            source="秋霜玉",
+            evidence=["discovery_query:ZUN"],
+        )
+        apply_classification(item, tags="touhou zun")
+        self.assertEqual(item.confidence, "candidate")
+        self.assertNotIn("known_touhou_metadata", item.evidence)
 
 
 if __name__ == "__main__":

--- a/touhou_osu/classifier.py
+++ b/touhou_osu/classifier.py
@@ -88,7 +88,6 @@ TOUHOU_GAME_TITLE_TOKENS = (
     "東方獣王園",
     "東方錦上京",
 )
-TOUHOU_METADATA_TOKENS = ("touhou", "東方", *TOUHOU_GAME_TITLE_TOKENS)
 TOUHOU_TAG_TOKENS = ("touhou", "東方project", "team shanghai alice", "上海アリス幻樂団")
 KNOWN_ARTISTS = {
     "zun",
@@ -150,8 +149,8 @@ def classify(entry: Entry, *, tags: str = "") -> Classification:
 
     tags_match = contains_any(tags, TOUHOU_TAG_TOKENS)
     artist_match = normalize(entry.artist) in {normalize(item) for item in KNOWN_ARTISTS}
-    metadata_match = artist_match or contains_any(f"{entry.artist} {entry.title}", TOUHOU_METADATA_TOKENS)
-    if tags_match and metadata_match:
+    curated_collection_match = any(item.startswith("osucollector:") for item in evidence)
+    if tags_match and artist_match and curated_collection_match:
         evidence.update(("mapper_tags", "known_touhou_metadata"))
         return Classification("probable", tuple(sorted(evidence)))
 


### PR DESCRIPTION
## What changed

- require mapper tags, an exact known artist, and independent osu!Collector Touhou collection evidence for `probable`
- keep known artists found only by broad discovery queries as candidates
- add a regression test for the ZUN-composed Seihou track from Shuusou Gyoku
- update the documented confidence rule

## Why

The second discovery run correctly rejected Hakkenden but exposed that `ZUN + mapper tag` alone could publish a Seihou Project track as probable.

## Validation

- `make check` (21 tests)
- `make build`