### PR TITLE
fix: aggregate discovery evidence before classification

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,86 @@
+import argparse
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from touhou_osu.catalog import Catalog
+from touhou_osu.cli import command_discover
+from touhou_osu.models import Entry
+
+
+class FakeOsuApi:
+    responses = {
+        "Touhou": [
+            {
+                "id": 42,
+                "artist": "ShibayanRecords",
+                "title": "Fall in the Dark",
+                "creator": "mapper",
+                "source": "",
+                "status": "ranked",
+                "tags": "touhou arrangement",
+                "beatmaps": [{"mode": "osu"}],
+            }
+        ],
+        "東方Project": [
+            {
+                "id": 42,
+                "artist": "ShibayanRecords",
+                "title": "Fall in the Dark",
+                "creator": "mapper",
+                "source": "",
+                "status": "ranked",
+                "tags": "touhou arrangement",
+                "beatmaps": [{"mode": "osu"}],
+            }
+        ],
+    }
+
+    @classmethod
+    def from_env(cls):
+        return cls()
+
+    def search(self, query, *, max_pages):
+        return iter(self.responses[query])
+
+
+class DiscoveryTests(unittest.TestCase):
+    def test_combines_queries_with_existing_collection_evidence_before_classification(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            catalog_path = root / "catalog.json"
+            config_path = root / "seeds.json"
+            Catalog(
+                [Entry(42, artist="ShibayanRecords", evidence=["osucollector:1402"])]
+            ).save(catalog_path)
+            config_path.write_text(
+                json.dumps({"discovery_queries": ["Touhou", "東方Project"]}), encoding="utf-8"
+            )
+            args = argparse.Namespace(
+                catalog=catalog_path,
+                config=config_path,
+                max_pages=4,
+                write=True,
+            )
+
+            with patch("touhou_osu.cli.OsuApi", FakeOsuApi):
+                self.assertEqual(command_discover(args), 0)
+
+            entry = Catalog.load(catalog_path).entries[42]
+            self.assertEqual(entry.confidence, "probable")
+            self.assertEqual(
+                entry.evidence,
+                [
+                    "discovery_query:Touhou",
+                    "discovery_query:東方Project",
+                    "known_touhou_metadata",
+                    "mapper_tags",
+                    "osucollector:1402",
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/touhou_osu/cli.py
+++ b/touhou_osu/cli.py
@@ -79,18 +79,24 @@ def command_discover(args: argparse.Namespace) -> int:
     catalog = load_catalog(args.catalog)
     config = load_config(args.config)
     api = OsuApi.from_env()
-    changed = 0
-    seen: set[int] = set()
+    discovered: dict[int, dict] = {}
+    discovery_evidence: dict[int, set[str]] = {}
     for query in config.get("discovery_queries", []):
         for raw in api.search(query, max_pages=args.max_pages):
             beatmapset_id = int(raw["id"])
-            if beatmapset_id in seen:
-                continue
-            seen.add(beatmapset_id)
-            entry = entry_from_osu(raw, evidence=[f"discovery_query:{query}"], confidence="candidate")
-            _, did_change = catalog.merge(entry)
-            changed += did_change
-    print(f"Discovery examined {len(seen)} unique beatmapsets; {changed} entries changed")
+            discovered[beatmapset_id] = raw
+            discovery_evidence.setdefault(beatmapset_id, set()).add(f"discovery_query:{query}")
+
+    changed = 0
+    for beatmapset_id in sorted(discovered):
+        current = catalog.entries.get(beatmapset_id)
+        evidence = set(discovery_evidence[beatmapset_id])
+        if current:
+            evidence.update(current.evidence)
+        entry = entry_from_osu(discovered[beatmapset_id], evidence=sorted(evidence), confidence="candidate")
+        _, did_change = catalog.merge(entry)
+        changed += did_change
+    print(f"Discovery examined {len(discovered)} unique beatmapsets; {changed} entries changed")
     if args.write:
         catalog.save(args.catalog)
         print(f"Wrote {args.catalog}")


### PR DESCRIPTION
## What changed

- aggregate duplicate API results across every configured discovery query
- combine discovery evidence with existing catalog provenance before classification
- classify and merge each beatmapset once, deterministically by ID
- add an integration test covering multiple query hits plus existing collection evidence

## Why

The conservative probable rule requires independent collection provenance, but discovery previously classified each API record before merging that existing evidence. As a result, no newly examined entry could satisfy the intended three-signal rule.

## Validation

- `make check` (22 tests)
- `make build`