### PR TITLE
fix: cap weekly discovery changes

### DIFF
--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -27,7 +27,7 @@ jobs:
             echo "::notice::Set OSU_CLIENT_ID and OSU_CLIENT_SECRET repository secrets to enable discovery."
             exit 0
           fi
-          python -m touhou_osu discover --write
+          python -m touhou_osu discover --write --max-changes 50
           if ! git diff --quiet -- data/catalog.json; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
@@ -44,7 +44,7 @@ jobs:
           git commit -m "data: discover Touhou beatmap candidates"
           git push --force origin "$branch"
           pr_number=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
-          body="Automated weekly osu! API discovery. Review confidence and evidence before merging."
+          body="Automated weekly osu! API discovery, capped at 50 meaningful catalog changes. Review confidence and evidence before merging; remaining matches roll into later weeks."
           if [[ -n "$pr_number" ]]; then
             gh pr edit "$pr_number" --title "data: weekly Touhou discovery" --body "$body"
           else

--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ python -m touhou_osu discover --write
 
 On GitHub, add the same values as Actions secrets named `OSU_CLIENT_ID` and
 `OSU_CLIENT_SECRET`. The weekly workflow searches the configured Touhou aliases
-with cursor pagination and opens a review PR when the catalog changes. The
-monthly workflow reconciles osu! metadata and statuses. Neither workflow merges
-its own PR.
+with cursor pagination and opens a review PR when the catalog changes. Each run
+is capped at 50 meaningful catalog changes, ordered by confidence; remaining
+matches roll into later weeks. The monthly workflow reconciles osu! metadata
+and statuses. Neither workflow merges its own PR.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for manual review and correction rules.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,32 +11,7 @@ from touhou_osu.models import Entry
 
 
 class FakeOsuApi:
-    responses = {
-        "Touhou": [
-            {
-                "id": 42,
-                "artist": "ShibayanRecords",
-                "title": "Fall in the Dark",
-                "creator": "mapper",
-                "source": "",
-                "status": "ranked",
-                "tags": "touhou arrangement",
-                "beatmaps": [{"mode": "osu"}],
-            }
-        ],
-        "東方Project": [
-            {
-                "id": 42,
-                "artist": "ShibayanRecords",
-                "title": "Fall in the Dark",
-                "creator": "mapper",
-                "source": "",
-                "status": "ranked",
-                "tags": "touhou arrangement",
-                "beatmaps": [{"mode": "osu"}],
-            }
-        ],
-    }
+    responses = {}
 
     @classmethod
     def from_env(cls):
@@ -48,6 +23,17 @@ class FakeOsuApi:
 
 class DiscoveryTests(unittest.TestCase):
     def test_combines_queries_with_existing_collection_evidence_before_classification(self):
+        raw = {
+            "id": 42,
+            "artist": "ShibayanRecords",
+            "title": "Fall in the Dark",
+            "creator": "mapper",
+            "source": "",
+            "status": "ranked",
+            "tags": "touhou arrangement",
+            "beatmaps": [{"mode": "osu"}],
+        }
+        FakeOsuApi.responses = {"Touhou": [raw], "東方Project": [raw]}
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             catalog_path = root / "catalog.json"
@@ -62,6 +48,7 @@ class DiscoveryTests(unittest.TestCase):
                 catalog=catalog_path,
                 config=config_path,
                 max_pages=4,
+                max_changes=50,
                 write=True,
             )
 
@@ -80,6 +67,58 @@ class DiscoveryTests(unittest.TestCase):
                     "osucollector:1402",
                 ],
             )
+
+    def test_caps_meaningful_changes_without_date_only_churn(self):
+        def raw(beatmapset_id, *, source="Touhou Project"):
+            return {
+                "id": beatmapset_id,
+                "artist": "ZUN",
+                "title": f"Theme {beatmapset_id}",
+                "creator": "mapper",
+                "source": source,
+                "status": "ranked",
+                "tags": "touhou",
+                "beatmaps": [{"mode": "osu"}],
+            }
+
+        FakeOsuApi.responses = {"Touhou": [raw(1, source="unknown"), raw(10), raw(20), raw(30)]}
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            catalog_path = root / "catalog.json"
+            config_path = root / "seeds.json"
+            Catalog(
+                [
+                    Entry(
+                        10,
+                        artist="ZUN",
+                        title="Theme 10",
+                        creator="mapper",
+                        source="Touhou Project",
+                        status="ranked",
+                        modes=["osu"],
+                        evidence=["discovery_query:Touhou", "osu_source"],
+                        confidence="verified",
+                        last_checked="2020-01-01",
+                    )
+                ]
+            ).save(catalog_path)
+            config_path.write_text(json.dumps({"discovery_queries": ["Touhou"]}), encoding="utf-8")
+            args = argparse.Namespace(
+                catalog=catalog_path,
+                config=config_path,
+                max_pages=4,
+                max_changes=2,
+                write=True,
+            )
+
+            with patch("touhou_osu.cli.OsuApi", FakeOsuApi):
+                self.assertEqual(command_discover(args), 0)
+
+            catalog = Catalog.load(catalog_path)
+            self.assertEqual(set(catalog.entries), {10, 20, 30})
+            self.assertEqual(catalog.entries[10].last_checked, "2020-01-01")
+            self.assertEqual(catalog.entries[20].confidence, "verified")
+            self.assertEqual(catalog.entries[30].confidence, "verified")
 
 
 if __name__ == "__main__":

--- a/touhou_osu/cli.py
+++ b/touhou_osu/cli.py
@@ -19,6 +19,7 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CATALOG = ROOT / "data" / "catalog.json"
 DEFAULT_CONFIG = ROOT / "config" / "seeds.json"
 DEFAULT_OUTPUT = ROOT / "dist"
+DISCOVERY_CONFIDENCE_ORDER = {"verified": 0, "probable": 1, "candidate": 2, "excluded": 3}
 
 
 def load_catalog(path: Path) -> Catalog:
@@ -76,6 +77,8 @@ def command_import_seeds(args: argparse.Namespace) -> int:
 
 
 def command_discover(args: argparse.Namespace) -> int:
+    if args.max_changes < 0:
+        raise RuntimeError("--max-changes must be zero or greater")
     catalog = load_catalog(args.catalog)
     config = load_config(args.config)
     api = OsuApi.from_env()
@@ -87,16 +90,34 @@ def command_discover(args: argparse.Namespace) -> int:
             discovered[beatmapset_id] = raw
             discovery_evidence.setdefault(beatmapset_id, set()).add(f"discovery_query:{query}")
 
-    changed = 0
+    prepared = []
     for beatmapset_id in sorted(discovered):
         current = catalog.entries.get(beatmapset_id)
         evidence = set(discovery_evidence[beatmapset_id])
         if current:
             evidence.update(current.evidence)
         entry = entry_from_osu(discovered[beatmapset_id], evidence=sorted(evidence), confidence="candidate")
-        _, did_change = catalog.merge(entry)
+        checked_on = entry.last_checked
+        if current:
+            # Reconciliation owns routine freshness updates. Weekly discovery
+            # should not create a diff solely because today's date changed.
+            entry.last_checked = current.last_checked
+        prepared.append((DISCOVERY_CONFIDENCE_ORDER[entry.confidence], beatmapset_id, entry, checked_on))
+
+    changed = 0
+    processed = 0
+    for _, _, entry, checked_on in sorted(prepared):
+        if args.max_changes and changed >= args.max_changes:
+            break
+        merged, did_change = catalog.merge(entry)
+        processed += 1
+        if did_change:
+            merged.last_checked = checked_on
         changed += did_change
-    print(f"Discovery examined {len(discovered)} unique beatmapsets; {changed} entries changed")
+    limit_note = ""
+    if args.max_changes and changed >= args.max_changes and processed < len(prepared):
+        limit_note = f"; change limit {args.max_changes} reached, remainder deferred"
+    print(f"Discovery examined {len(discovered)} unique beatmapsets; {changed} entries changed{limit_note}")
     if args.write:
         catalog.save(args.catalog)
         print(f"Wrote {args.catalog}")
@@ -167,6 +188,12 @@ def parser() -> argparse.ArgumentParser:
             item.add_argument("--workers", type=int, default=4)
         else:
             item.add_argument("--max-pages", type=int, default=4)
+            item.add_argument(
+                "--max-changes",
+                type=int,
+                default=50,
+                help="maximum catalog changes per run; use 0 for unlimited",
+            )
         item.set_defaults(func=function)
 
     reconcile = subparsers.add_parser("reconcile", help="refresh every catalog entry from osu! API")


### PR DESCRIPTION
## What changed

- cap weekly discovery at 50 meaningful catalog changes
- process verified, then probable, then candidate matches
- defer the remaining search backlog to later weekly runs
- stop `last_checked`-only updates from creating weekly diffs
- document the cap in the workflow PR body and README

## Why

The first complete discovery batch changed hundreds of entries and produced an 8,000-line PR that GitHub could not render usefully for review.

## Validation

- `make check` (23 tests)
- `make build`
- regression coverage verifies the cap, confidence ordering, deferred records, and date-only churn suppression