### PR TITLE
docs: include Touhou-related mashups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ override a manual inclusion or exclusion.
   original and non-Touhou music.
 - Historical collection membership is evidence for discovery, not automatic
   proof.
-- Medleys and mixed-source sets require manual review.
+- Medleys, mashups, and mixed-source sets are in scope and follow the same
+  evidence rules as other sets. The presence of non-Touhou material alone is
+  not a reason to hold or exclude a set.
 
 ## Catalog editing
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 An open, reproducible index of Touhou Project music mapped in osu!. It combines
 historical collections, official beatmap packs, Touhou-only tournament pools,
 and osu! API discovery into one deduplicated catalog keyed by **beatmapset ID**.
+Touhou-related medleys, mashups, and MADs are included when they satisfy the
+same metadata and provenance rules as other sets.
 
 **[Browse the index](https://n0zom1z0.github.io/touhou-osu-index/)** ·
 [Download JSON](https://n0zom1z0.github.io/touhou-osu-index/catalog.json) ·

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -22,6 +22,19 @@ class ClassifierTests(unittest.TestCase):
         self.assertEqual(item.confidence, "verified")
         self.assertIn("osu_source", item.evidence)
 
+    def test_touhou_sourced_cross_franchise_mashup_is_verified(self):
+        item = Entry(
+            20406,
+            artist="Nico Nico Douga",
+            title="Owens",
+            source="Touhou",
+            evidence=["discovery_query:Touhou"],
+            confidence="candidate",
+        )
+        apply_classification(item, tags="dj yoshitaka evans jubeat u.n. owen was her")
+        self.assertEqual(item.confidence, "verified")
+        self.assertIn("osu_source", item.evidence)
+
     def test_unrelated_romanized_touhou_source_stays_candidate(self):
         item = Entry(
             1,


### PR DESCRIPTION
## Summary
- define Touhou-related medleys, mashups, and MADs as in scope
- apply the existing metadata and provenance rules uniformly to mixed-source sets
- add a regression test for a Touhou-sourced cross-franchise mashup

## Safety
- does not treat arbitrary `touhou` substrings as sufficient evidence
- existing Hakkenden false-positive regressions remain intact

## Checks
- `make check`
- `make build`
- `git diff --check`