### PR TITLE
feat: complete Touhou source coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ override a manual inclusion or exclusion.
   verified.
 - A Touhou mapper tag plus a known Touhou artist and independent historical
   Touhou collection membership is probable.
+- A link from a curated Touhou-only queue becomes probable after its public
+  osu! artist/title metadata resolves. Deleted or unresolved links stay
+  candidates.
 - A known Touhou circle alone is only a candidate because circles also release
   original and non-Touhou music.
 - Historical collection membership is evidence for discovery, not automatic
@@ -57,7 +60,23 @@ missing evidence, and unsorted data.
 
 Add declarative entries to `config/seeds.json` when the source is supported.
 New source types need a parser plus fixture-based tests. A seed must have a
-stable canonical URL and a clear curation rationale.
+stable canonical URL, a clear curation rationale, and a conservative
+`minimum_entries` floor. Mark a mixed or partially themed tournament
+`"trusted": false`; its pool starts as candidates and only independently
+verified Touhou entries enter the public index.
+
+Use the reusable source commands before committing:
+
+```sh
+make audit-sources  # live URLs, record counts, and unique beatmapsets
+make import-seeds   # merge configured sources
+make hydrate        # fill incomplete records through public osu! pages
+make check
+make build
+```
+
+`python -m touhou_osu audit-sources --json` provides machine-readable output.
+The audit and hydration commands do not require osu! OAuth credentials.
 
 Network calls do not run in the unit test suite. Save a minimal, anonymized
 fixture that exercises the response shape instead of recording credentials or

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check test validate clean
+.PHONY: build check test validate import-seeds audit-sources hydrate clean
 
 build:
 	python3 -m touhou_osu build
@@ -10,6 +10,15 @@ test:
 
 validate:
 	python3 -m touhou_osu validate
+
+import-seeds:
+	python3 -m touhou_osu import-seeds --write
+
+audit-sources:
+	python3 -m touhou_osu audit-sources
+
+hydrate:
+	python3 -m touhou_osu hydrate --write
 
 clean:
 	python3 -m touhou_osu clean

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ files, songs, backgrounds, or other copyrighted assets.
 | State | Meaning |
 | --- | --- |
 | `verified` | Recognized Touhou Project/game source, official Touhou pack, Touhou-only tournament, or manual verification. |
-| `probable` | Multiple independent signals agree: Touhou tags, a known artist, and curated collection membership. |
+| `probable` | Multiple independent signals agree, or a Touhou-only curated queue entry has resolved osu! metadata. |
 | `candidate` | Historical collection membership or one weaker signal; needs review. |
 | `excluded` | Manually confirmed false positive, retained to prevent rediscovery. |
 
@@ -78,7 +78,9 @@ Requires Python 3.11+ and otherwise uses only the standard library.
 ```sh
 make check          # schema validation and tests
 make build          # generate site, JSON, and CSV
-python -m touhou_osu import-seeds --write
+make audit-sources  # query every configured source without changing the catalog
+make import-seeds   # merge every configured source into the catalog
+make hydrate        # resolve incomplete public beatmapset metadata (no OAuth)
 ```
 
 Seed import currently understands:
@@ -87,10 +89,15 @@ Seed import currently understands:
   10S's collection, and `4-Touhou Main`);
 - official osu! Touhou beatmap packs;
 - osu!Collector Touhou tournament pools;
-- osu! wiki tournament pages, including Touhou Project Mania Cup 1st–4th.
+- osu! wiki tournament pages, including Touhou Project Mania Cup 1st–4th;
+- paginated public forum queues, including `sd_touhou`'s BN queue.
 
 The importer deduplicates everything by beatmapset ID and unions its evidence.
-Source definitions live in [`config/seeds.json`](config/seeds.json).
+Source definitions, canonical URLs, safety floors, and trust policy live in
+[`config/seeds.json`](config/seeds.json). Each source has a `minimum_entries`
+floor so an upstream format change or truncated response fails closed instead
+of silently deleting coverage. See [SOURCES.md](SOURCES.md) for the complete
+inventory and current source audit.
 
 ## Automated discovery
 

--- a/SOURCES.md
+++ b/SOURCES.md
@@ -1,0 +1,99 @@
+# Source inventory
+
+The catalog is built from reproducible public sources declared in
+[`config/seeds.json`](config/seeds.json). Run `make audit-sources` to query all
+of them, verify their safety floors, and print their current record counts and
+URLs. Use `python -m touhou_osu audit-sources --json` for automation.
+
+The latest full audit on 2026-08-15 returned **6,397 source records** from
+**27 sources**, representing **2,992 unique beatmapsets** before catalog
+classification and deduplication. Counts below are upstream snapshots, not
+promises that every record is accepted into the public index.
+
+## Historical collections
+
+| Collection | ID | Records | Initial trust |
+| --- | ---: | ---: | --- |
+| CardinalWolf 2hu 0–2.99 star (pt.1) | 1402 | 1,112 | candidate |
+| CardinalWolf 2hu 3–4.49 star (pt.2) | 1405 | 1,240 | candidate |
+| CardinalWolf 2hu 4.5 star plus (pt.3) | 1407 | 1,211 | candidate |
+| 10S Touhou | 6907 | 1,015 | candidate |
+| 4-Touhou Main | 14845 | 11 | probable/original |
+
+These large snapshots are discovery evidence, not blanket verification. The
+importer uses the osu!Collector API endpoint encoded by each collection ID.
+
+## Official osu! packs
+
+| Pack | Canonical tag | Records |
+| --- | --- | ---: |
+| [Touhou Chart](https://osu.ppy.sh/beatmaps/packs/R29) | R29 | 21 |
+| [Touhou Music Pack](https://osu.ppy.sh/beatmaps/packs/T65) | T65 | 20 |
+| [Touhou Pack](https://osu.ppy.sh/beatmaps/packs/T106) | T106 | 8 |
+| [Stan Touhou Music Pack](https://osu.ppy.sh/beatmaps/packs/FQ55) | FQ55 | 7 |
+| [UNDEAD CORPORATION Touhou pack](https://osu.ppy.sh/beatmaps/packs/FQ35) | FQ35 | 8 |
+
+Official pack membership is verified evidence. `R29` is the current canonical
+tag for the historical Touhou Chart pack.
+
+## Tournament pools
+
+| Tournament source | osu!Collector ID | Records | Policy |
+| --- | ---: | ---: | --- |
+| [Touhou Project Mania Cup 1st](https://osu.ppy.sh/community/forums/topics/1143215) | 466 | 84 | verified |
+| [Touhou Project Mania Cup 2nd](https://osu.ppy.sh/community/forums/topics/1481811) | 467 | 68 | verified |
+| [Touhou Project Mania Cup 3rd](https://osu.ppy.sh/community/forums/topics/1751979) | 748 | 69 | verified |
+| [Touhou Project Mania Cup 4th](https://osu.ppy.sh/community/forums/topics/2015815) | 1661 | 103 | verified |
+| [Touhou Tournament 2](https://osu.ppy.sh/community/forums/topics/1024816) | 1432 | 98 | verified |
+| [Touhou Tournament 3](https://osu.ppy.sh/community/forums/topics/1740437) | 828 | 113 | verified |
+| [Austrian Touhou Cup](https://osu.ppy.sh/community/forums/topics/1907498) | 1865 | 88 | verified |
+| [5 Digit Touhou Cup 2](https://osu.ppy.sh/community/forums/topics/1976975) | 1793 | 102 | verified |
+| [5 Digit Touhou Cup 3](https://osu.ppy.sh/community/forums/topics/2162098) | 2163 | 102 | verified |
+| [Scarlet's Touhou Tournament](https://osu.ppy.sh/community/forums/topics/1323843) | 526 | 131 | candidate-first |
+| [Scarlet's Touhou Tournament Season 2](https://osu.ppy.sh/community/forums/topics/1407029) | 829 | 140 | candidate-first |
+| [Scarlet's Touhou Tournament 3rd Season](https://osu.ppy.sh/community/forums/topics/1759334) | 731 | 111 | candidate-first |
+
+Touhou Project Mania Cup 1st–4th are also imported from their authoritative
+osu! wiki pages (86, 72, 74, and 109 records respectively). The independent
+wiki and osu!Collector paths preserve redundant provenance and make upstream
+drift visible.
+
+Scarlet's tournament description explicitly permits some non-Touhou maps, so
+those three complete pools are intentionally imported as candidates. Entries
+are promoted only when their own osu! metadata or other independent evidence
+satisfies the classifier.
+
+## Community queue and API discovery
+
+The [`sd_touhou` BN queue](https://osu.ppy.sh/community/forums/topics/1881813)
+is followed across every public forum page using the last post ID as the next
+cursor. The 2026-08-15 audit found 194 unique beatmapsets. A queue link is kept
+as a candidate until `make hydrate` or the monthly API reconciliation resolves
+its artist/title metadata; unresolved and deleted links never enter the public
+index.
+
+Weekly osu! API discovery searches the configured source aliases, Japanese and
+English Touhou terms, Team Shanghai Alice, ZUN, and related metadata. It uses
+cursor pagination and limits each automated PR to 50 meaningful catalog
+changes. Search results remain candidates unless the classifier finds explicit
+Touhou source metadata or sufficient independent signals.
+
+## Reproduction and safety
+
+```sh
+make audit-sources
+make import-seeds
+make hydrate
+make check
+make build
+```
+
+- `audit-sources` performs a read-only live query and enforces every configured
+  `minimum_entries` floor.
+- `import-seeds` deduplicates by numeric beatmapset ID and unions provenance.
+- `hydrate` resolves partial forum/tournament records from public beatmapset
+  pages without OAuth. Its intentionally low concurrency avoids rate limits.
+- `discover` and `reconcile` use osu! API v2 OAuth credentials; CI supplies
+  those only through GitHub Actions secrets.
+- No command downloads or stores `.osz`, audio, backgrounds, or other map
+  assets.

--- a/config/seeds.json
+++ b/config/seeds.json
@@ -1,72 +1,169 @@
 {
   "discovery_queries": [
+    "source=東方",
     "source=東方Project",
     "source=Touhou Project",
     "source=Touhou",
     "Touhou",
     "東方Project",
     "東方",
+    "Team Shanghai Alice",
+    "上海アリス幻樂団",
     "ZUN"
   ],
   "osu_collector_collections": [
     {
       "id": 1402,
       "name": "CardinalWolf 2hu 0-2.99 star",
-      "confidence": "candidate"
+      "confidence": "candidate",
+      "minimum_entries": 1000
     },
     {
       "id": 1405,
       "name": "CardinalWolf 2hu 3-4.49 star",
-      "confidence": "candidate"
+      "confidence": "candidate",
+      "minimum_entries": 1100
     },
     {
       "id": 1407,
       "name": "CardinalWolf 2hu 4.5 star plus",
-      "confidence": "candidate"
+      "confidence": "candidate",
+      "minimum_entries": 1100
     },
     {
       "id": 6907,
       "name": "10S Touhou",
-      "confidence": "candidate"
+      "confidence": "candidate",
+      "minimum_entries": 900
     },
     {
       "id": 14845,
       "name": "4-Touhou Main",
       "confidence": "probable",
-      "touhou_kind": "original"
+      "touhou_kind": "original",
+      "minimum_entries": 10
     }
   ],
   "official_packs": [
-    {"tag": "468", "name": "Official Touhou Chart"},
-    {"tag": "T65", "name": "Touhou Music Pack"},
-    {"tag": "T106", "name": "Mappers Guild Touhou Pack"},
-    {"tag": "FQ55", "name": "Stan Touhou Music Pack"},
-    {"tag": "FQ35", "name": "UNDEAD CORPORATION Touhou pack"}
+    {"tag": "R29", "name": "Touhou Chart", "minimum_entries": 20},
+    {"tag": "T65", "name": "Touhou Music Pack", "minimum_entries": 20},
+    {"tag": "T106", "name": "Touhou Pack", "minimum_entries": 8},
+    {"tag": "FQ55", "name": "Stan Touhou Music Pack", "minimum_entries": 7},
+    {"tag": "FQ35", "name": "UNDEAD CORPORATION Touhou pack", "minimum_entries": 8}
   ],
   "osu_collector_tournaments": [
-    {"id": 1865, "name": "Austrian Touhou Cup"},
-    {"id": 1793, "name": "5 Digit Touhou Cup 2"}
+    {
+      "id": 466,
+      "name": "Touhou Project Mania Cup 1st",
+      "url": "https://osu.ppy.sh/community/forums/topics/1143215",
+      "minimum_entries": 80
+    },
+    {
+      "id": 467,
+      "name": "Touhou Project Mania Cup 2nd",
+      "url": "https://osu.ppy.sh/community/forums/topics/1481811",
+      "minimum_entries": 65
+    },
+    {
+      "id": 526,
+      "name": "Scarlet's Touhou Tournament",
+      "url": "https://osu.ppy.sh/community/forums/topics/1323843",
+      "trusted": false,
+      "confidence": "candidate",
+      "minimum_entries": 120
+    },
+    {
+      "id": 731,
+      "name": "Scarlet's Touhou Tournament 3rd Season",
+      "url": "https://osu.ppy.sh/community/forums/topics/1759334",
+      "trusted": false,
+      "confidence": "candidate",
+      "minimum_entries": 100
+    },
+    {
+      "id": 748,
+      "name": "Touhou Project Mania Cup 3rd",
+      "url": "https://osu.ppy.sh/community/forums/topics/1751979",
+      "minimum_entries": 65
+    },
+    {
+      "id": 828,
+      "name": "Touhou Tournament 3",
+      "url": "https://osu.ppy.sh/community/forums/topics/1740437",
+      "minimum_entries": 100
+    },
+    {
+      "id": 829,
+      "name": "Scarlet's Touhou Tournament Season 2",
+      "url": "https://osu.ppy.sh/community/forums/topics/1407029",
+      "trusted": false,
+      "confidence": "candidate",
+      "minimum_entries": 130
+    },
+    {
+      "id": 1432,
+      "name": "Touhou Tournament 2",
+      "url": "https://osu.ppy.sh/community/forums/topics/1024816",
+      "minimum_entries": 90
+    },
+    {
+      "id": 1661,
+      "name": "Touhou Project Mania Cup 4th",
+      "url": "https://osu.ppy.sh/community/forums/topics/2015815",
+      "minimum_entries": 95
+    },
+    {
+      "id": 1793,
+      "name": "5 Digit Touhou Cup 2",
+      "url": "https://osu.ppy.sh/community/forums/topics/1976975",
+      "minimum_entries": 95
+    },
+    {
+      "id": 1865,
+      "name": "Austrian Touhou Cup",
+      "url": "https://osu.ppy.sh/community/forums/topics/1907498",
+      "minimum_entries": 80
+    },
+    {
+      "id": 2163,
+      "name": "5 Digit Touhou Cup 3",
+      "url": "https://osu.ppy.sh/community/forums/topics/2162098",
+      "minimum_entries": 95
+    }
   ],
   "wiki_tournaments": [
     {
       "edition": "1st",
       "name": "Touhou Project Mania Cup 1st",
-      "url": "https://osu.ppy.sh/wiki/en/Tournaments/TMC/1st"
+      "url": "https://osu.ppy.sh/wiki/en/Tournaments/TMC/1st",
+      "minimum_entries": 80
     },
     {
       "edition": "2nd",
       "name": "Touhou Project Mania Cup 2nd",
-      "url": "https://osu.ppy.sh/wiki/en/Tournaments/TMC/2nd"
+      "url": "https://osu.ppy.sh/wiki/en/Tournaments/TMC/2nd",
+      "minimum_entries": 65
     },
     {
       "edition": "3rd",
       "name": "Touhou Project Mania Cup 3rd",
-      "url": "https://osu.ppy.sh/wiki/en/Tournaments/TMC/3rd"
+      "url": "https://osu.ppy.sh/wiki/en/Tournaments/TMC/3rd",
+      "minimum_entries": 70
     },
     {
       "edition": "4th",
       "name": "Touhou Project Mania Cup 4th",
-      "url": "https://osu.ppy.sh/wiki/en/Tournaments/TMC/4th"
+      "url": "https://osu.ppy.sh/wiki/en/Tournaments/TMC/4th",
+      "minimum_entries": 100
+    }
+  ],
+  "forum_queues": [
+    {
+      "slug": "sd_touhou",
+      "name": "sd_touhou BN queue",
+      "url": "https://osu.ppy.sh/community/forums/topics/1881813",
+      "minimum_entries": 100,
+      "max_pages": 10
     }
   ]
 }

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -155,6 +155,7 @@
       "evidence": [
         "discovery_query:Touhou",
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -492,6 +493,7 @@
       "evidence": [
         "discovery_query:Touhou",
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407"
@@ -543,7 +545,8 @@
         "osu_source",
         "osucollector:1402",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -986,7 +989,7 @@
       "artist": "Yuu",
       "title": "U.N. Owen was Her?",
       "creator": "ignorethis",
-      "source": "",
+      "source": "Sound Sepher",
       "status": "ranked",
       "modes": [
         "osu",
@@ -996,9 +999,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "mapper_tags",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:526",
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -1045,6 +1051,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-01-20T16:49:37Z"
+    },
+    {
+      "beatmapset_id": 7184,
+      "artist": "709sec",
+      "title": "Night Bird",
+      "creator": "Daiyousei",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "mapper_tags",
+        "tournament_candidate:526"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2010-04-26T13:06:53Z"
     },
     {
       "beatmapset_id": 7224,
@@ -1162,7 +1189,7 @@
       "artist": "IOSYS",
       "title": "Kyuukyoku Yakiniku Restaurant! Orin no Jigokutei!",
       "creator": "DJPop",
-      "source": "",
+      "source": "Touhou Chouto Maten",
       "status": "ranked",
       "modes": [
         "osu"
@@ -1175,7 +1202,8 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -1197,9 +1225,11 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2009-07-07T22:55:40Z"
     },
@@ -1564,9 +1594,10 @@
         "known_touhou_artist",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2009-09-26T16:30:12Z"
     },
@@ -1586,9 +1617,10 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2009-09-08T14:53:23Z"
     },
@@ -1607,6 +1639,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
@@ -1705,7 +1738,8 @@
         "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -1725,9 +1759,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2009-12-20T07:09:10Z"
     },
@@ -1821,7 +1856,7 @@
       "artist": "Sound skt",
       "title": "History of the Moon",
       "creator": "happy30",
-      "source": "",
+      "source": "Dearly",
       "status": "ranked",
       "modes": [
         "osu"
@@ -1830,8 +1865,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "mapper_tags",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:731"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -1907,7 +1944,7 @@
       "artist": "ZUN",
       "title": "Captain Murasa",
       "creator": "Cyclone",
-      "source": "",
+      "source": "Touhou",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -1917,10 +1954,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2009-11-13T05:03:24Z"
     },
@@ -1993,7 +2032,7 @@
       "artist": "Silver Forest",
       "title": "The Doll Maker of Bucuresti",
       "creator": "Yes",
-      "source": "",
+      "source": "Graze",
       "status": "ranked",
       "modes": [
         "osu"
@@ -2002,9 +2041,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "mapper_tags",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -2049,7 +2090,8 @@
         "discovery_query:Touhou",
         "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -2126,7 +2168,7 @@
       "artist": "SOUND HOLIC",
       "title": "Ooeyama Nonbee Ondo",
       "creator": "Gabi",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -2136,8 +2178,10 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -2290,6 +2334,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:6907"
@@ -2536,7 +2581,8 @@
         "known_touhou_artist",
         "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -2658,7 +2704,7 @@
       "artist": "Golden City Factory",
       "title": "Stirring an Autumn Moon",
       "creator": "Tonoko",
-      "source": "",
+      "source": "Last Celebration",
       "status": "ranked",
       "modes": [
         "osu"
@@ -2667,8 +2713,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "mapper_tags",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -2823,6 +2871,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:6907"
@@ -3148,7 +3197,8 @@
         "discovery_query:Touhou",
         "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -3170,6 +3220,7 @@
       "evidence": [
         "discovery_query:Touhou",
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -3215,6 +3266,7 @@
         "discovery_query:ZUN",
         "known_touhou_artist",
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -3551,6 +3603,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -3586,7 +3639,7 @@
       "artist": "KEDAMA",
       "title": "Hajimari no Sakamichi",
       "creator": "Zekira",
-      "source": "",
+      "source": "OHK",
       "status": "ranked",
       "modes": [
         "osu"
@@ -3595,7 +3648,9 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1402"
+        "mapper_tags",
+        "osucollector:1402",
+        "tournament_candidate:526"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -3855,6 +3910,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -3877,6 +3933,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -4066,6 +4123,7 @@
         "discovery_query:Touhou",
         "known_touhou_artist",
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
@@ -4157,7 +4215,8 @@
         "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -4267,6 +4326,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -4289,6 +4349,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -4382,7 +4443,8 @@
         "discovery_query:Touhou",
         "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -4441,7 +4503,7 @@
       "artist": "Liz Triangle",
       "title": "Heart of Glass",
       "creator": "S i R i R u",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -4450,10 +4512,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-03-14T21:49:57Z"
     },
@@ -4484,7 +4548,7 @@
       "artist": "Kucchy vs Akky",
       "title": "Satori ~3rd eyes~",
       "creator": "DJPop",
-      "source": "",
+      "source": "Otona no Raku ga Kichou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -4493,9 +4557,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "mapper_tags",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -4716,9 +4782,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-01-03T16:38:48Z"
     },
@@ -4879,7 +4946,7 @@
       "artist": "sun3",
       "title": "Higan Retour",
       "creator": "saymun",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -4889,8 +4956,10 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -5305,7 +5374,7 @@
       "artist": "Silver Forest",
       "title": "Phantasm Brigade -another side-",
       "creator": "S i R i R u",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -5314,10 +5383,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-05-12T16:43:35Z"
     },
@@ -5412,7 +5483,7 @@
       "artist": "Conagusuri",
       "title": "Hina Choco Dark Matter",
       "creator": "Mafiamaster",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -5421,12 +5492,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-05-23T14:18:24Z"
     },
@@ -5671,9 +5744,10 @@
       "evidence": [
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-05-23T17:27:45Z"
     },
@@ -5717,6 +5791,7 @@
         "discovery_query:source=Touhou Project",
         "discovery_query:東方Project",
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -5754,7 +5829,7 @@
       "artist": "Drop",
       "title": "Orokamono ni Tsukurareta Yami no Musume",
       "creator": "Shinxyn",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -5763,12 +5838,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-06-04T05:40:17Z"
     },
@@ -5977,6 +6054,26 @@
       "osu_last_updated": "2010-06-06T04:10:46Z"
     },
     {
+      "beatmapset_id": 16541,
+      "artist": "Nei Kino",
+      "title": "Usan no Kaori",
+      "creator": "qinche",
+      "source": "Umineko no Naku Koro ni",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:526"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2010-07-04T01:01:15Z"
+    },
+    {
       "beatmapset_id": 16569,
       "artist": "Yellow Zebra",
       "title": "Saisei ~Bird can sing~",
@@ -6047,7 +6144,7 @@
       "artist": "SYNC.ART'S feat. Misato",
       "title": "The Deep Flame of Autumn Sky",
       "creator": "Frill",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -6056,11 +6153,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-07-04T06:18:33Z"
     },
@@ -6144,6 +6243,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -6177,7 +6277,7 @@
       "artist": "MUZIK SERVANT feat. TAM",
       "title": "Chain of Scarlet Moon - ver.TAM -",
       "creator": "tieff",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -6186,10 +6286,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-06-11T21:59:06Z"
     },
@@ -6253,7 +6355,8 @@
         "known_touhou_artist",
         "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament:1432"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -6371,6 +6474,27 @@
       "osu_last_updated": "2011-04-09T02:10:47Z"
     },
     {
+      "beatmapset_id": 17073,
+      "artist": "Jun.A",
+      "title": "Reach for the Moon, Immortal Smoke(Taketori Extend)",
+      "creator": "Reimu Tea",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2010-06-18T04:37:29Z"
+    },
+    {
       "beatmapset_id": 17103,
       "artist": "Aizawa",
       "title": "Flutter Girl",
@@ -6450,6 +6574,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -6515,6 +6640,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405"
       ],
@@ -6548,7 +6674,7 @@
       "artist": "EastNewSound",
       "title": "Lucid Dream",
       "creator": "Leorda",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -6558,12 +6684,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-11-17T17:50:32Z"
     },
@@ -6694,6 +6822,7 @@
       "evidence": [
         "known_touhou_artist",
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407"
@@ -6813,7 +6942,7 @@
       "artist": "dBu",
       "title": "Shinkou Fuuka Kyoku ~ Native Faith",
       "creator": "saymun",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -6823,12 +6952,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-07-18T07:48:34Z"
     },
@@ -7043,7 +7174,7 @@
       "artist": "Yuma Mizonokuchi",
       "title": "Requiem ~Sekai wa Owari, Soshite Hajimaru~",
       "creator": "Shinxyn",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -7052,10 +7183,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-08-12T01:22:45Z"
     },
@@ -7282,7 +7415,8 @@
         "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -7531,7 +7665,7 @@
       "artist": "IOSYS",
       "title": "Miracle-Hinacle",
       "creator": "vincerio",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -7542,10 +7676,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-10-25T14:32:50Z"
     },
@@ -7590,7 +7726,8 @@
         "discovery_query:Touhou",
         "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -7735,7 +7872,7 @@
       "artist": "Masayoshi Minoshima",
       "title": "Fire",
       "creator": "Shinxyn",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -7744,11 +7881,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-12-05T05:55:00Z"
     },
@@ -7838,7 +7977,9 @@
         "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -7932,7 +8073,7 @@
       "artist": "Xi",
       "title": "Black Apple",
       "creator": "Kite",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -7941,11 +8082,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-01-08T13:30:22Z"
     },
@@ -8052,6 +8195,29 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-11-15T20:16:02Z"
+    },
+    {
+      "beatmapset_id": 21235,
+      "artist": "ZUN",
+      "title": "Fires of Hokkai",
+      "creator": "Evil_Twilight",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2011-03-21T16:33:58Z"
     },
     {
       "beatmapset_id": 21390,
@@ -8218,6 +8384,7 @@
       "original_themes": [],
       "evidence": [
         "official_pack:468",
+        "official_pack:R29",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407"
@@ -8356,7 +8523,8 @@
         "discovery_query:Touhou",
         "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -8449,9 +8617,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-07-08T14:03:41Z"
     },
@@ -8482,7 +8651,7 @@
       "artist": "ALiCE'S EMOTiON",
       "title": "under the black, over the shine",
       "creator": "Saten ruiko",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -8491,11 +8660,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-01-15T01:15:26Z"
     },
@@ -8539,7 +8710,8 @@
         "discovery_query:Touhou",
         "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -8575,7 +8747,7 @@
       "artist": "Riverside",
       "title": "Ouka Sange",
       "creator": "Pokie",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -8584,10 +8756,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-01-03T09:19:12Z"
     },
@@ -8791,7 +8965,7 @@
       "artist": "Sasha Asuka",
       "title": "Meguri Meguru",
       "creator": "loveFantasy",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -8800,10 +8974,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-08-12T06:08:33Z"
     },
@@ -9169,7 +9345,7 @@
       "artist": "Silver Forest",
       "title": "Tsundere Arisu no Yuuutsu",
       "creator": "Komeiji Yuki",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -9179,10 +9355,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-12-26T04:27:18Z"
     },
@@ -9574,19 +9752,22 @@
       "artist": "Seventh Heaven MAXION",
       "title": "affection and hatred",
       "creator": "Licnect",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
-        "osu"
+        "osu",
+        "taiko"
       ],
       "touhou_kind": "unknown",
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-09-06T14:15:14Z"
     },
@@ -9697,7 +9878,8 @@
         "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:14845"
+        "osucollector:14845",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -10378,7 +10560,7 @@
       "artist": "3L",
       "title": "Spring of Dreams",
       "creator": "impossiblexu",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -10388,11 +10570,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-07-29T11:02:29Z"
     },
@@ -10423,7 +10607,7 @@
       "artist": "SYNC.ART'S",
       "title": "Splendid Encount -one more encore-",
       "creator": "KanaRin",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -10433,10 +10617,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-05-05T10:24:09Z"
     },
@@ -10445,7 +10632,7 @@
       "artist": "Midnight Project",
       "title": "Crystal Cinderella",
       "creator": "C R E A M",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -10454,10 +10641,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-07-27T03:38:20Z"
     },
@@ -10477,9 +10666,10 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-08-16T18:28:20Z"
     },
@@ -10627,9 +10817,10 @@
       "evidence": [
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-08-06T20:27:36Z"
     },
@@ -10747,7 +10938,7 @@
       "artist": "ALiCE'S EMOTiON",
       "title": "Tag (Hardbeat Remix)",
       "creator": "Takos",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -10759,9 +10950,11 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-06-13T10:14:23Z"
     },
@@ -10953,19 +11146,22 @@
       "artist": "Mitsuki Nakae",
       "title": "Disappearing Queen",
       "creator": "KuraiPettan",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
-        "osu"
+        "osu",
+        "taiko"
       ],
       "touhou_kind": "unknown",
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-01-12T18:58:46Z"
     },
@@ -11208,6 +11404,27 @@
       "osu_last_updated": "2012-01-13T15:07:43Z"
     },
     {
+      "beatmapset_id": 31480,
+      "artist": "Yuma Mizonokuchi",
+      "title": "akasha-simulater",
+      "creator": "Shinxyn",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2011-07-24T08:56:26Z"
+    },
+    {
       "beatmapset_id": 31710,
       "artist": "O-Life Japan",
       "title": "Greenwich in the Sky",
@@ -11232,7 +11449,7 @@
       "artist": "ALiCE'S EMOTiON",
       "title": "Voice",
       "creator": "banvi",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -11245,7 +11462,8 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -11299,7 +11517,7 @@
       "artist": "ZUN",
       "title": "Bloom Nobly, Cherry Blossoms of Sumizome ~ Border of Life",
       "creator": "lufi10",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -11310,10 +11528,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-09-04T11:09:45Z"
     },
@@ -11739,20 +11959,23 @@
       "artist": "ZUN",
       "title": "Shoutoku Legend ~ True Administrator",
       "creator": "Lybydose",
-      "source": "",
+      "source": "Touhou",
       "status": "graveyard",
       "modes": [
-        "osu"
+        "osu",
+        "taiko"
       ],
       "touhou_kind": "unknown",
       "origin_games": [],
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-11-02T06:01:22Z"
     },
@@ -11774,9 +11997,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-10-19T17:44:49Z"
     },
@@ -11891,6 +12115,27 @@
       "osu_last_updated": "2012-04-03T21:28:19Z"
     },
     {
+      "beatmapset_id": 36138,
+      "artist": "Silver Forest",
+      "title": "Harukaze (8-bit Mix)",
+      "creator": "GiNa",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2012-08-11T01:55:06Z"
+    },
+    {
       "beatmapset_id": 36743,
       "artist": "Masayoshi Minoshima feat. nomico",
       "title": "Dreaming",
@@ -11983,7 +12228,7 @@
       "artist": "Mitani Nana",
       "title": "Sakura Forever Friendship",
       "creator": "Pereira006",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -11992,10 +12237,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-11-06T01:10:22Z"
     },
@@ -12087,6 +12334,28 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2011-12-20T21:30:45Z"
+    },
+    {
+      "beatmapset_id": 38693,
+      "artist": "ZUN",
+      "title": "Haigoku Lullaby",
+      "creator": "latias380",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2012-09-08T15:50:45Z"
     },
     {
       "beatmapset_id": 38747,
@@ -12246,7 +12515,7 @@
       "artist": "EastNewSound",
       "title": "Yuune Zekka, Ryouran no Sai",
       "creator": "goodbye",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -12255,12 +12524,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-01-22T13:24:53Z"
     },
@@ -12736,9 +13007,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-11-30T08:29:21Z"
     },
@@ -12747,7 +13019,7 @@
       "artist": "IRON ATTACK!",
       "title": "Remotely Combat",
       "creator": "C R E A M",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -12756,10 +13028,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-12-16T11:55:54Z"
     },
@@ -12858,7 +13132,7 @@
       "artist": "Xi",
       "title": "Majotachi no Butoukai ~ Magus",
       "creator": "Kite",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -12868,12 +13142,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-10-01T23:19:58Z"
     },
@@ -12905,7 +13181,7 @@
       "artist": "mineko",
       "title": "Honpou Tora ^ Honsou Nezumi",
       "creator": "Sallad4ever",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -12914,10 +13190,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-05-26T00:43:30Z"
     },
@@ -13085,19 +13363,22 @@
       "artist": "Yellow Zebra",
       "title": "Melody!",
       "creator": "wcx19911123",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
-        "osu"
+        "osu",
+        "taiko"
       ],
       "touhou_kind": "unknown",
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-04-28T06:17:22Z"
     },
@@ -13366,20 +13647,23 @@
       "artist": "Jun.A",
       "title": "Ghost Lead",
       "creator": "Scorpiour",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
-        "osu"
+        "osu",
+        "taiko"
       ],
       "touhou_kind": "unknown",
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-05-15T02:42:35Z"
     },
@@ -13662,9 +13946,10 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-11-01T11:46:20Z"
     },
@@ -13982,7 +14267,7 @@
       "artist": "zts",
       "title": "Captain Murasa",
       "creator": "Reiji-RJ",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -13991,9 +14276,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1405"
+        "osu_source",
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-02-18T18:37:20Z"
     },
@@ -14199,7 +14486,7 @@
       "artist": "Sakaue Nachi",
       "title": "Crazy Hot",
       "creator": "Mythol",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -14208,11 +14495,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-08-31T16:52:52Z"
     },
@@ -14328,7 +14617,7 @@
       "artist": "Hatsuki Yura",
       "title": "Intense Desire",
       "creator": "Frostmourne",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -14337,10 +14626,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-04-25T13:51:40Z"
     },
@@ -14753,9 +15044,10 @@
         "known_touhou_artist",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-01-28T14:51:58Z"
     },
@@ -14907,6 +15199,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-03-14T23:05:19Z"
+    },
+    {
+      "beatmapset_id": 62530,
+      "artist": "Tsukasa",
+      "title": "Accelerator",
+      "creator": "Tshemmp",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2012-10-25T09:14:35Z"
     },
     {
       "beatmapset_id": 62764,
@@ -15120,9 +15433,10 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2012-12-22T19:27:00Z"
     },
@@ -15270,6 +15584,28 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-03-20T07:59:13Z"
+    },
+    {
+      "beatmapset_id": 69783,
+      "artist": "maritumix",
+      "title": "Sakura Spirit -Reiou-",
+      "creator": "Dai",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-05-29T08:11:45Z"
     },
     {
       "beatmapset_id": 70137,
@@ -15471,7 +15807,7 @@
       "artist": "Syrufit & Poplica* ft. Mei Ayakura",
       "title": "Threat of rain",
       "creator": "Jenny",
-      "source": "",
+      "source": "Touhou",
       "status": "approved",
       "modes": [
         "osu"
@@ -15480,9 +15816,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1405"
+        "osu_source",
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-06-12T15:02:56Z"
     },
@@ -15555,7 +15893,7 @@
       "artist": "Draw the Emotional",
       "title": "Just follow time",
       "creator": "emmy",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -15564,11 +15902,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-02-21T02:56:58Z"
     },
@@ -15800,9 +16140,11 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-02-18T02:59:10Z"
     },
@@ -16082,6 +16424,49 @@
       "osu_last_updated": "2013-03-17T12:28:20Z"
     },
     {
+      "beatmapset_id": 84856,
+      "artist": "ALiCE'S EMOTiON",
+      "title": "Mami Mami Zone",
+      "creator": "Kodora",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2014-11-04T16:56:31Z"
+    },
+    {
+      "beatmapset_id": 85328,
+      "artist": "_yoc. feat. Matsumoto Sara",
+      "title": "Crescendo",
+      "creator": "Snepif",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-11T14:59:30Z"
+    },
+    {
       "beatmapset_id": 85512,
       "artist": "Matsumoto Sara",
       "title": "Ito Hakanaki Hikari no Gotoku",
@@ -16123,6 +16508,28 @@
       "osu_last_updated": "2013-05-25T06:57:33Z"
     },
     {
+      "beatmapset_id": 85754,
+      "artist": "ZUN",
+      "title": "The Venerable Ancient Battlefield ~ Suwa Foughten Field",
+      "creator": "Parachute",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2014-04-04T13:24:29Z"
+    },
+    {
       "beatmapset_id": 86003,
       "artist": "Demetori ft. Red Parka",
       "title": "Emotional Skyscraper ~ World's End (Extended Broken Wear Remix)",
@@ -16147,7 +16554,7 @@
       "artist": "senya",
       "title": "Higanbana",
       "creator": "Satellite",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -16156,10 +16563,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-05-16T12:38:25Z"
     },
@@ -16211,7 +16620,7 @@
       "artist": "ZUN",
       "title": "Crimson in the Black Sea ~ Legendary Fish",
       "creator": "Leader",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -16222,10 +16631,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-12-07T19:48:55Z"
     },
@@ -16470,9 +16881,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-08-22T12:29:09Z"
     },
@@ -16543,7 +16955,7 @@
       "artist": "Dee! feat. Nomiya Ayumi",
       "title": "Hito Ayumishi Unmei ni Yosete",
       "creator": "Mixagji",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -16552,12 +16964,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-11-13T05:51:49Z"
     },
@@ -16602,7 +17016,8 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -16858,9 +17273,10 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-05-20T18:04:01Z"
     },
@@ -16914,7 +17330,7 @@
       "artist": "EastNewSound",
       "title": "Sadistic Paranoia",
       "creator": "TicClick",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -16923,11 +17339,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-04-01T11:53:15Z"
     },
@@ -17105,6 +17523,30 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-01-14T11:49:40Z"
+    },
+    {
+      "beatmapset_id": 106212,
+      "artist": "LeaF",
+      "title": "MEPHISTO",
+      "creator": "Alumetorz",
+      "source": "BMS",
+      "status": "ranked",
+      "modes": [
+        "catch",
+        "mania",
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "tournament_candidate:526"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2013-11-07T16:22:24Z"
     },
     {
       "beatmapset_id": 106318,
@@ -17304,7 +17746,7 @@
       "artist": "ZUN",
       "title": "Kobito of the Shining Needle ~ Little Princess",
       "creator": "sjoy",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -17317,9 +17759,12 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:526",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-11-02T08:24:36Z"
     },
@@ -17404,9 +17849,10 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-08-09T05:29:25Z"
     },
@@ -17415,7 +17861,7 @@
       "artist": "ttbt",
       "title": "Makkuro Flandre S Shuuseiban",
       "creator": "moonlightleaf",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -17424,12 +17870,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-08-26T12:22:35Z"
     },
@@ -17609,7 +18057,7 @@
       "artist": "Eru",
       "title": "Heian no Alien",
       "creator": "Vass_Bass",
-      "source": "",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -17618,11 +18066,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-10-27T18:48:18Z"
     },
@@ -17693,7 +18143,7 @@
       "artist": "Rin",
       "title": "Spring of Dreams",
       "creator": "jyc-Binggan",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -17702,10 +18152,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-04-02T03:38:04Z"
     },
@@ -17782,7 +18235,7 @@
       "artist": "ZUN",
       "title": "Onbashira no Hakaba ~ Grave of Being",
       "creator": "Totoro le Pacha",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -17793,10 +18246,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-11-24T08:25:22Z"
     },
@@ -17805,7 +18260,7 @@
       "artist": "Matsumoto Sara",
       "title": "Ito Hakanaki Hikari no Gotoku",
       "creator": "Mixagji",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -17814,11 +18269,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-12-29T15:48:22Z"
     },
@@ -17867,7 +18324,7 @@
       "artist": "Amane",
       "title": "Purity Red",
       "creator": "TicClick",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -17879,7 +18336,8 @@
       "evidence": [
         "official_pack:T65",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -17902,9 +18360,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-06-05T15:47:24Z"
     },
@@ -17997,7 +18456,7 @@
       "artist": "Akiyama Uni",
       "title": "The Grimoire of Alice",
       "creator": "Hollow Wings",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -18009,9 +18468,12 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828",
+        "tournament_candidate:526",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-09-21T11:01:49Z"
     },
@@ -18126,6 +18588,27 @@
       "osu_last_updated": "2013-12-24T11:10:32Z"
     },
     {
+      "beatmapset_id": 128128,
+      "artist": "38BEETS",
+      "title": "Dear rest",
+      "creator": "KokoroStudiox3",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-03-08T21:35:09Z"
+    },
+    {
       "beatmapset_id": 128432,
       "artist": "Aki",
       "title": "Wanna Be My Dream",
@@ -18196,7 +18679,7 @@
       "artist": "FELT",
       "title": "Sky Gate",
       "creator": "Frostmourne",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -18205,10 +18688,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2013-12-31T16:08:25Z"
     },
@@ -18298,6 +18783,46 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-02-18T18:40:50Z"
+    },
+    {
+      "beatmapset_id": 130624,
+      "artist": "UNDEAD CORPORATION",
+      "title": "The silent world",
+      "creator": "Lortus",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 131354,
+      "artist": "Hachimitsu-Lemon",
+      "title": "Last Remote~Blaze Mix",
+      "creator": "Meramin",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 131628,
@@ -18728,7 +19253,7 @@
       "artist": "TatshMusicCircle",
       "title": "Raikou -3rd Desire-",
       "creator": "Kite",
-      "source": "",
+      "source": "東方神霊廟　～ Ten Desires.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -18737,12 +19262,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-12-13T13:20:55Z"
     },
     {
       "beatmapset_id": 143584,
@@ -18769,7 +19296,7 @@
       "artist": "Chata",
       "title": "Wan",
       "creator": "Vhy",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -18778,10 +19305,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-03-15T18:04:35Z"
     },
@@ -18806,6 +19335,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-01-04T20:24:11Z"
+    },
+    {
+      "beatmapset_id": 144421,
+      "artist": "FELT",
+      "title": "Runway Drive",
+      "creator": "kxRete",
+      "source": "touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2014-01-29T10:53:09Z"
     },
     {
       "beatmapset_id": 145885,
@@ -18873,7 +19423,7 @@
       "artist": "Draw the Emotional",
       "title": "Morning glow",
       "creator": "UnitedWeSin",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -18882,12 +19432,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-10-09T09:43:37Z"
     },
@@ -18896,7 +19448,7 @@
       "artist": "Foreground Eclipse",
       "title": "I Bet You'll Forget That Even If You Noticed That",
       "creator": "rEdo",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -18905,12 +19457,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-04-22T15:57:24Z"
     },
@@ -18982,7 +19536,7 @@
       "artist": "Autobahn",
       "title": "Aki no Kaze",
       "creator": "Leorda",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -18991,10 +19545,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-08-09T05:38:38Z"
     },
@@ -19003,7 +19560,7 @@
       "artist": "Akiyama Uni",
       "title": "Odoru Mizushibuki",
       "creator": "Hollow Wings",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -19012,12 +19569,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-12-07T19:07:48Z"
     },
@@ -19123,7 +19682,8 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -19221,7 +19781,7 @@
       "artist": "FELT",
       "title": "Closed Wings",
       "creator": "Sylith",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -19230,11 +19790,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-08-06T01:32:09Z"
     },
@@ -19243,7 +19805,7 @@
       "artist": "SYNC.ART'S",
       "title": "Road to Departure",
       "creator": "sjoy",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -19252,12 +19814,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-08-26T14:59:49Z"
     },
@@ -19342,6 +19906,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-05-19T10:09:07Z"
+    },
+    {
+      "beatmapset_id": 166339,
+      "artist": "Liz Triangle",
+      "title": "Shizuka",
+      "creator": "Irie Miyuki",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2014-10-08T00:38:02Z"
     },
     {
       "beatmapset_id": 168099,
@@ -19613,6 +20198,27 @@
       "osu_last_updated": "2014-06-20T11:03:47Z"
     },
     {
+      "beatmapset_id": 177429,
+      "artist": "Foreground Eclipse",
+      "title": "Last Liar Standing",
+      "creator": "rEdo",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2014-07-23T18:32:46Z"
+    },
+    {
       "beatmapset_id": 177890,
       "artist": "UNDEAD CORPORATION",
       "title": "The Empress",
@@ -19724,7 +20330,7 @@
       "title": "Necro Fantasia -An remix-",
       "creator": "captin1",
       "source": "",
-      "status": "ranked",
+      "status": "graveyard",
       "modes": [
         "osu"
       ],
@@ -19734,9 +20340,10 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -19756,9 +20363,10 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-08-11T21:28:00Z"
     },
@@ -19874,7 +20482,7 @@
       "artist": "nmk",
       "title": "sola",
       "creator": "sjoy",
-      "source": "",
+      "source": "BMS",
       "status": "ranked",
       "modes": [
         "osu"
@@ -19883,10 +20491,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "mapper_tags",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -19953,7 +20563,8 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -20235,7 +20846,7 @@
       "artist": "Comp",
       "title": "Touchuu Aika",
       "creator": "Mao",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu",
@@ -20248,9 +20859,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2014-09-21T19:12:45Z"
     },
@@ -20494,7 +21107,7 @@
       "artist": "Chiyoko",
       "title": "Alice's Mad Tea Party",
       "creator": "neonat",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "mania",
@@ -20504,14 +21117,37 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-01-11T06:22:30Z"
+    },
+    {
+      "beatmapset_id": 215899,
+      "artist": "FELT",
+      "title": "Sign",
+      "creator": "Pho",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-03-17T16:59:38Z"
     },
     {
       "beatmapset_id": 217190,
@@ -20529,9 +21165,10 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-01-01T08:33:03Z"
     },
@@ -20623,7 +21260,7 @@
       "artist": "O-LIFE.JP",
       "title": "Koukishin Yuusen",
       "creator": "sjoy",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -20632,9 +21269,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source",
         "osucollector:1407"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-06-01T01:01:22Z"
     },
@@ -20676,9 +21315,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-01-21T17:40:03Z"
     },
@@ -20687,7 +21327,7 @@
       "artist": "senya",
       "title": "Sakuretsu Irony",
       "creator": "Sellenite",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
@@ -20696,10 +21336,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-01-17T03:39:17Z"
     },
@@ -20772,7 +21414,7 @@
       "artist": "Kiryu",
       "title": "Disguise",
       "creator": "Seikatu",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -20781,10 +21423,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-09-29T23:31:10Z"
     },
@@ -21067,6 +21711,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-07-26T04:52:48Z"
+    },
+    {
+      "beatmapset_id": 235366,
+      "artist": "Dark PHOENiX",
+      "title": "Taketori Hishou",
+      "creator": "sodarose",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2014-11-29T02:41:55Z"
     },
     {
       "beatmapset_id": 236396,
@@ -21421,7 +22086,7 @@
       "artist": "Amane",
       "title": "TWEEKER",
       "creator": "TicClick",
-      "source": "",
+      "source": "東方文花帖　～ Shoot the Bullet.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -21430,12 +22095,15 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-09-10T13:23:14Z"
     },
@@ -21570,7 +22238,7 @@
       "artist": "ALiCE'S EMOTiON",
       "title": "Evening Steps",
       "creator": "TicClick",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -21582,9 +22250,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-03-02T17:48:42Z"
     },
@@ -21820,7 +22490,7 @@
     {
       "beatmapset_id": 286262,
       "artist": "Camellia",
-      "title": "Lunatic Rough Party!! (Long Ver.) (Ichigaki) [Lunatic]",
+      "title": "Lunatic Rough Party!! (Long Ver.)",
       "creator": "Ichigaki",
       "source": "",
       "status": "ranked",
@@ -21833,7 +22503,8 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -21930,7 +22601,7 @@
       "artist": "Demetori",
       "title": "Shoujo Satori ~ Innumerable Eyes",
       "creator": "A Mystery",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -21939,12 +22610,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-01-19T22:35:14Z"
     },
@@ -22091,9 +22764,10 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-11-07T12:57:33Z"
     },
@@ -22275,7 +22949,7 @@
       "artist": "FELT",
       "title": "Story",
       "creator": "Yohanes",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -22288,7 +22962,8 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -22423,9 +23098,9 @@
       "beatmapset_id": 300934,
       "artist": "loz",
       "title": "Cinderella Cage -Trancecore Mix- (drunkenstein) [Insane]",
-      "creator": "",
+      "creator": "drunkenstein",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -22433,7 +23108,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -22544,9 +23220,9 @@
       "beatmapset_id": 302911,
       "artist": "The Ghost of 3.13",
       "title": "Last Star In The Universe (Shoegazer) [Serenade]",
-      "creator": "",
+      "creator": "Shoegazer",
       "source": "",
-      "status": "unknown",
+      "status": "loved",
       "modes": [
         "mania"
       ],
@@ -22554,7 +23230,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -22750,6 +23427,27 @@
       "osu_last_updated": "2016-01-23T21:34:26Z"
     },
     {
+      "beatmapset_id": 310687,
+      "artist": "Dark PHOENiX",
+      "title": "Locked Girl - Shoujo Misshitsu",
+      "creator": "sjoy",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-06-24T02:13:49Z"
+    },
+    {
       "beatmapset_id": 311328,
       "artist": "Foreground Eclipse",
       "title": "Storytellers",
@@ -22942,7 +23640,7 @@
     {
       "beatmapset_id": 315435,
       "artist": "UNDEAD CORPORATION",
-      "title": "The Empress scream off ver (TheZiemniax) [SC]",
+      "title": "The Empress scream off ver",
       "creator": "TheZiemniax",
       "source": "",
       "status": "ranked",
@@ -22956,7 +23654,8 @@
         "known_touhou_artist",
         "osucollector:1402",
         "osucollector:1405",
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -22967,7 +23666,7 @@
       "artist": "FELT",
       "title": "Crumbling",
       "creator": "happy30",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -22976,9 +23675,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "osu_source",
+        "osucollector:1407",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-08-05T17:26:56Z"
     },
@@ -22998,9 +23699,10 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-07-25T04:55:07Z"
     },
@@ -23074,9 +23776,9 @@
       "beatmapset_id": 316932,
       "artist": "F-777",
       "title": "Dark Angel ([ Mee ]) [MEE]",
-      "creator": "",
+      "creator": "[ Mee ]",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -23084,7 +23786,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -23131,6 +23834,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-03-01T23:10:50Z"
+    },
+    {
+      "beatmapset_id": 319063,
+      "artist": "nomico",
+      "title": "Lost Emotion",
+      "creator": "Krauv",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2015-06-02T17:20:46Z"
     },
     {
       "beatmapset_id": 319217,
@@ -23401,9 +24125,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-07-11T02:03:25Z"
     },
@@ -23713,7 +24438,7 @@
       "artist": "UNDEAD CORPORATION",
       "title": "Everything will freeze",
       "creator": "sjoy",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -23726,9 +24451,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-08-01T09:52:41Z"
     },
@@ -23780,7 +24507,7 @@
       "artist": "Halozy",
       "title": "Kanshou no Matenrou",
       "creator": "sodarose",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -23790,9 +24517,11 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:1407"
+        "osu_source",
+        "osucollector:1407",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-01-24T06:51:35Z"
     },
@@ -23912,9 +24641,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-11-20T13:11:47Z"
     },
@@ -23987,7 +24717,7 @@
       "artist": "Glunwald",
       "title": "Bloody Scarlet Nightmare",
       "creator": "RikiH_",
-      "source": "",
+      "source": "BMS",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -23996,7 +24726,9 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "mapper_tags",
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -24017,9 +24749,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-01-16T20:24:22Z"
     },
@@ -24039,6 +24772,7 @@
       "evidence": [
         "osucollector:1407",
         "osucollector:6907",
+        "tournament:1432",
         "tournament:1865"
       ],
       "confidence": "verified",
@@ -24110,6 +24844,28 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-09-11T11:09:41Z"
+    },
+    {
+      "beatmapset_id": 348411,
+      "artist": "Halozy",
+      "title": "GO 4 IT",
+      "creator": "HatsuMin",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2015-08-23T04:33:12Z"
     },
     {
       "beatmapset_id": 348711,
@@ -24438,9 +25194,9 @@
       "beatmapset_id": 361936,
       "artist": "ZUN arr.Myon",
       "title": "Plastic Mind(8bit) (Kuo Kyoka) [snover\\'s Phantasm]",
-      "creator": "",
+      "creator": "Kuo Kyoka",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -24448,7 +25204,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -24542,7 +25299,7 @@
       "artist": "SOUND HOLIC",
       "title": "Detarame Yousei Daisensou",
       "creator": "mjozog3",
-      "source": "",
+      "source": "東方Project",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -24551,10 +25308,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-02-24T17:56:29Z"
     },
@@ -24581,7 +25340,7 @@
     {
       "beatmapset_id": 365790,
       "artist": "senya",
-      "title": "Nihil Kagura (Raediaufar) [Lunatic]",
+      "title": "Nihil Kagura",
       "creator": "Raediaufar",
       "source": "",
       "status": "ranked",
@@ -24594,7 +25353,8 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -24647,7 +25407,7 @@
       "artist": "ALiCE'S EMOTiON",
       "title": "Foughten Field",
       "creator": "Natsu",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -24656,12 +25416,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-11-19T15:10:18Z"
     },
@@ -24796,7 +25558,7 @@
       "artist": "Halozy",
       "title": "Genryuu Kaiko",
       "creator": "Baraatje123",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -24806,9 +25568,11 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:1405"
+        "osu_source",
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-11-20T12:28:08Z"
     },
@@ -24858,7 +25622,7 @@
       "artist": "IOSYS",
       "title": "Tanoshii Yoru no Ochakai - Ringo's Tea Party",
       "creator": "Frey",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -24868,12 +25632,14 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-01-02T16:28:23Z"
     },
@@ -24904,9 +25670,9 @@
       "beatmapset_id": 376703,
       "artist": "Akiyama Uni",
       "title": "Odoru Mizushibuki (Shoegazer) [Macabre]",
-      "creator": "",
+      "creator": "Shoegazer",
       "source": "",
-      "status": "unknown",
+      "status": "loved",
       "modes": [
         "mania"
       ],
@@ -24914,7 +25680,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -24925,7 +25692,7 @@
       "artist": "Demetori",
       "title": "Genshi no Yoru ~ Ghostly Eyes",
       "creator": "Alheak",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -24934,10 +25701,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2015-11-25T01:27:59Z"
     },
@@ -25126,9 +25895,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-02-10T13:08:46Z"
     },
@@ -25199,7 +25969,7 @@
       "artist": "Akiyama Uni",
       "title": "Kanpan Tasogare Shinbun",
       "creator": "09kami",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -25208,12 +25978,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-03-02T17:35:36Z"
     },
@@ -25325,7 +26097,7 @@
       "artist": "IOSYS",
       "title": "Cirno no Perfect Sansuu Kyoushitsu",
       "creator": "alacat",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -25339,7 +26111,8 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -25393,7 +26166,7 @@
       "artist": "UNDEAD CORPORATION",
       "title": "Flowering Night Fever",
       "creator": "Alheak",
-      "source": "",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -25406,9 +26179,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-06-08T19:24:05Z"
     },
@@ -25459,7 +26234,7 @@
       "artist": "Nakashinoda Mugi",
       "title": "Senjou no Aria",
       "creator": "Okorin",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu",
@@ -25469,12 +26244,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-09-22T19:43:16Z"
     },
@@ -25679,7 +26456,7 @@
       "artist": "FELT",
       "title": "OUR SHIP",
       "creator": "MokouSmoke",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -25688,10 +26465,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-07-01T14:09:31Z"
     },
@@ -26181,7 +26960,7 @@
       "artist": "U2",
       "title": "Ningyou Saiban",
       "creator": "Hollow Wings",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -26190,12 +26969,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-12-12T18:32:28Z"
     },
@@ -26302,7 +27083,8 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -26397,7 +27179,7 @@
     {
       "beatmapset_id": 430151,
       "artist": "MUZIK SERVANT feat.CHERICa",
-      "title": "Over the Starlit sky (Feerum) [Hard]",
+      "title": "Over the Starlit sky",
       "creator": "Feerum",
       "source": "",
       "status": "ranked",
@@ -26410,7 +27192,8 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -26524,6 +27307,26 @@
       "osu_last_updated": "2017-05-26T14:13:11Z"
     },
     {
+      "beatmapset_id": 433476,
+      "artist": "SAVE THE QUEEN",
+      "title": "EX-Termination",
+      "creator": "ShiraKai",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 433821,
       "artist": "nachi",
       "title": "Tobidase! Bankikki (Casual Killer remix)",
@@ -26564,6 +27367,7 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
+        "tournament:1432",
         "tournament:1865"
       ],
       "confidence": "verified",
@@ -26574,9 +27378,9 @@
       "beatmapset_id": 435450,
       "artist": "LeaF",
       "title": "Calamity Fortune (Shoegazer) [Euphoria]",
-      "creator": "",
+      "creator": "Shoegazer",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -26584,7 +27388,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -26799,9 +27604,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-06-27T06:32:54Z"
     },
@@ -26976,6 +27782,27 @@
       "osu_last_updated": "2016-10-27T02:23:23Z"
     },
     {
+      "beatmapset_id": 447943,
+      "artist": "LiLA'c Records",
+      "title": "Other Place",
+      "creator": "AdveNt",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2016-05-01T13:04:50Z"
+    },
+    {
       "beatmapset_id": 448399,
       "artist": "Shindehai",
       "title": "KUMIKYOKU EPIC ROCK VERSION",
@@ -27060,9 +27887,9 @@
       "beatmapset_id": 454219,
       "artist": "Demetori",
       "title": "U.N. Owen wa kanojo nano ka? (puxtu) [Lunatic]",
-      "creator": "",
+      "creator": "puxtu",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -27070,7 +27897,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -27139,9 +27967,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-06-19T23:39:54Z"
     },
@@ -27485,7 +28314,7 @@
       "artist": "Shoujo Fractal",
       "title": "Hatenaki Kaze no Kiseki sae",
       "creator": "-Mo-",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -27494,12 +28323,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-10-13T23:23:52Z"
     },
@@ -27551,9 +28382,9 @@
       "beatmapset_id": 464898,
       "artist": "ZUN (arr. sun3)",
       "title": "Higan Retour -idling mix- (Shoegazer) [Sequencer]",
-      "creator": "",
+      "creator": "Shoegazer",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -27561,7 +28392,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -27646,9 +28478,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-07-30T17:55:42Z"
     },
@@ -27702,7 +28535,7 @@
       "artist": "Yonder Voice",
       "title": "Setsugen Tir na nOg off vocal",
       "creator": "Akareh",
-      "source": "",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -27711,10 +28544,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-05-20T20:52:03Z"
     },
@@ -27737,6 +28572,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-06-28T15:09:39Z"
+    },
+    {
+      "beatmapset_id": 474280,
+      "artist": "FELT",
+      "title": "crescent moon",
+      "creator": "Kinshara",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2018-09-01T05:05:56Z"
     },
     {
       "beatmapset_id": 474417,
@@ -27804,9 +28660,9 @@
       "beatmapset_id": 475615,
       "artist": "NAGI",
       "title": "inside (Jinjin) [Longing]",
-      "creator": "",
+      "creator": "Jinjin",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -27814,7 +28670,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -27844,7 +28701,7 @@
     {
       "beatmapset_id": 476565,
       "artist": "Camellia",
-      "title": "Ultimate Ascension (Fresh Chicken) [advanced]",
+      "title": "Ultimate Ascension",
       "creator": "Fresh Chicken",
       "source": "",
       "status": "ranked",
@@ -27857,7 +28714,8 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -27879,9 +28737,10 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-08-30T04:01:02Z"
     },
@@ -27924,6 +28783,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-06-24T21:30:11Z"
+    },
+    {
+      "beatmapset_id": 476871,
+      "artist": "cosMo@Bousou-P",
+      "title": "Sadistic.Music Factory",
+      "creator": "Chaoslitz",
+      "source": "初音ミク -Project DIVA- f",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2016-08-09T07:33:35Z"
     },
     {
       "beatmapset_id": 477351,
@@ -28175,7 +29054,8 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -28560,7 +29440,7 @@
       "artist": "nachi",
       "title": "bellow",
       "creator": "TicClick",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -28569,10 +29449,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-04-25T10:46:39Z"
     },
@@ -28621,9 +29503,9 @@
       "beatmapset_id": 505330,
       "artist": "Pizuya's Cell",
       "title": "Particle Observer (AutotelicBrown) [Ayumu's Answer]",
-      "creator": "",
+      "creator": "AutotelicBrown",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -28631,7 +29513,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -28714,9 +29597,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-11-03T14:51:23Z"
     },
@@ -28843,11 +29727,32 @@
       "osu_last_updated": "2017-11-21T20:33:44Z"
     },
     {
+      "beatmapset_id": 514965,
+      "artist": "A-One feat. Aki",
+      "title": "Darkish",
+      "creator": "Lortus",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "loved",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2017-08-05T19:14:10Z"
+    },
+    {
       "beatmapset_id": 514980,
       "artist": "Kanpyohgo",
       "title": "Unmei no Dark Side -Rolling Gothic mix",
       "creator": "My Angel Azusa",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -28856,12 +29761,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-03-16T08:21:21Z"
     },
@@ -28882,9 +29789,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-12-31T13:55:50Z"
     },
@@ -29033,11 +29941,11 @@
       "osu_last_updated": "2017-03-17T02:07:27Z"
     },
     {
-      "beatmapset_id": 525444,
-      "artist": "Akiyama Uni",
-      "title": "Yuuga ni Sakase, Sumizome no Sakura ~ Border of Life",
-      "creator": "Axarious",
-      "source": "",
+      "beatmapset_id": 524264,
+      "artist": "Shinigiwa Satellite",
+      "title": "Eigou Labyrinth",
+      "creator": "daiyouseii-",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -29046,9 +29954,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2018-04-24T00:37:07Z"
+    },
+    {
+      "beatmapset_id": 525444,
+      "artist": "Akiyama Uni",
+      "title": "Yuuga ni Sakase, Sumizome no Sakura ~ Border of Life",
+      "creator": "Axarious",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "osucollector:1407",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-10-28T21:45:31Z"
     },
@@ -29107,9 +30039,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-04-18T16:02:19Z"
     },
@@ -29128,9 +30061,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-11-23T21:54:37Z"
     },
@@ -29138,9 +30072,9 @@
       "beatmapset_id": 531514,
       "artist": "ZUN remix by 44teru-k",
       "title": "Harutoman no Youkai Shoujo~VirusV (Wh1teh) [k]",
-      "creator": "",
+      "creator": "Wh1teh",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -29148,7 +30082,28 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 537952,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Seven Colors",
+      "creator": "Realazy",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -29178,9 +30133,9 @@
       "beatmapset_id": 541278,
       "artist": "A4paper",
       "title": "Hypernova (Spy) [Mashiro's 4K Hyper]",
-      "creator": "",
+      "creator": "Spy",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -29188,7 +30143,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -29255,6 +30211,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-12-12T19:34:41Z"
+    },
+    {
+      "beatmapset_id": 544039,
+      "artist": "FELT",
+      "title": "Free to Believe",
+      "creator": "Konge",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2019-03-16T23:41:43Z"
     },
     {
       "beatmapset_id": 545150,
@@ -29479,6 +30456,7 @@
       "evidence": [
         "osucollector:1407",
         "osucollector:6907",
+        "tournament:1432",
         "tournament:1865"
       ],
       "confidence": "verified",
@@ -29590,6 +30568,29 @@
       "osu_last_updated": "2017-06-21T13:39:29Z"
     },
     {
+      "beatmapset_id": 560696,
+      "artist": "lol",
+      "title": "sync",
+      "creator": "tuandi",
+      "source": "双星の陰陽師",
+      "status": "graveyard",
+      "modes": [
+        "catch",
+        "mania",
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-03-09T10:01:10Z"
+    },
+    {
       "beatmapset_id": 561556,
       "artist": "IRON-CHINO",
       "title": "Killing Under A Scarlet Moon",
@@ -29672,6 +30673,26 @@
       "osu_last_updated": "2017-02-14T17:48:22Z"
     },
     {
+      "beatmapset_id": 567189,
+      "artist": "FELT",
+      "title": "New World",
+      "creator": "felys",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 567410,
       "artist": "Camellia",
       "title": "Lunatic Rough Party!!",
@@ -29727,9 +30748,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-05-28T06:29:21Z"
     },
@@ -29782,7 +30804,7 @@
       "artist": "a*ru",
       "title": "Kizuato",
       "creator": "Halfslashed",
-      "source": "",
+      "source": "東方妖々夢 ～ Perfect Cherry Blossom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -29791,12 +30813,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-06-05T16:48:02Z"
     },
@@ -30009,9 +31033,9 @@
       "beatmapset_id": 582016,
       "artist": "UNDEAD CORPORATION",
       "title": "Magus night fever inst. (puxtu) [pxt]",
-      "creator": "",
+      "creator": "puxtu",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -30019,7 +31043,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -30044,6 +31069,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-03-08T13:15:36Z"
+    },
+    {
+      "beatmapset_id": 582274,
+      "artist": "Xe vs. cYsmix",
+      "title": "Youkai Festival Shrine Road",
+      "creator": "Mirash",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 582625,
@@ -30174,6 +31219,26 @@
       "osu_last_updated": "2017-10-05T02:16:35Z"
     },
     {
+      "beatmapset_id": 589304,
+      "artist": "t+pazolite",
+      "title": "CENSORED!!",
+      "creator": "PandaHero",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 593107,
       "artist": "Sasara Yuuna",
       "title": "dnabgib kaerB",
@@ -30295,6 +31360,7 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
+        "tournament:1432",
         "tournament:1865"
       ],
       "confidence": "verified",
@@ -30323,6 +31389,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-07-24T04:33:30Z"
+    },
+    {
+      "beatmapset_id": 600443,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Murasa",
+      "creator": "tokiko",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 600882,
@@ -30373,7 +31459,7 @@
       "artist": "GET IN THE RING",
       "title": "Rebirth",
       "creator": "Metaku",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -30383,11 +31469,33 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-09-25T14:26:12Z"
+    },
+    {
+      "beatmapset_id": 605290,
+      "artist": "senya",
+      "title": "Zetsubou no Fuchi",
+      "creator": "-Mo-",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 605383,
@@ -30414,9 +31522,9 @@
       "beatmapset_id": 606334,
       "artist": "Dark PHOENiX",
       "title": "Taketori Hishou (Madoka2574) [Lunatic]",
-      "creator": "",
+      "creator": "Madoka2574",
       "source": "",
-      "status": "unknown",
+      "status": "ranked",
       "modes": [
         "mania"
       ],
@@ -30424,7 +31532,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -30517,9 +31626,9 @@
       "beatmapset_id": 611200,
       "artist": "Gekidan Hitotose",
       "title": "Curtain Call!!!!! (Tofu1222) [Hard]",
-      "creator": "",
+      "creator": "Tofu1222",
       "source": "",
-      "status": "unknown",
+      "status": "ranked",
       "modes": [
         "mania"
       ],
@@ -30527,7 +31636,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -30852,7 +31962,7 @@
       "artist": "UNDEAD CORPORATION",
       "title": "Hafuri",
       "creator": "tokiko",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -30866,7 +31976,8 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -30942,7 +32053,7 @@
       "artist": "BUTAOTOME",
       "title": "Makkuro na Yuki",
       "creator": "Mirash",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -30952,12 +32063,14 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-01-15T14:37:52Z"
     },
@@ -30976,9 +32089,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-11-12T21:04:55Z"
     },
@@ -30986,9 +32100,9 @@
       "beatmapset_id": 632689,
       "artist": "ZUN Arranged by er",
       "title": "Gogo No Koishi-chan (Elementaires) [Tea Time]",
-      "creator": "",
+      "creator": "Elementaires",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -30996,7 +32110,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -31172,9 +32287,9 @@
       "beatmapset_id": 638838,
       "artist": "IOSYS",
       "title": "Ringo's Tea Party (TheToaphster) [Spooked]",
-      "creator": "",
+      "creator": "TheToaphster",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -31182,18 +32297,19 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
-      "beatmapset_id": 639050,
-      "artist": "Dark PHOENiX",
-      "title": "Love-coloured Master Spark",
-      "creator": "Meftly",
-      "source": "",
+      "beatmapset_id": 639026,
+      "artist": "EastNewSound",
+      "title": "Hana wa Gensou no Hate Ni",
+      "creator": "DT-sama",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -31202,9 +32318,32 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "forum_queue:sd_touhou",
+        "osu_source"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-01-17T15:33:22Z"
+    },
+    {
+      "beatmapset_id": 639050,
+      "artist": "Dark PHOENiX",
+      "title": "Love-coloured Master Spark",
+      "creator": "Meftly",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "osucollector:1407",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-01-27T22:42:02Z"
     },
@@ -31254,9 +32393,9 @@
       "beatmapset_id": 639692,
       "artist": "Shinigiwa Satellite",
       "title": "The Life and Times of Dino Spumoni (Rudalek) [Insane]",
-      "creator": "",
+      "creator": "Rudalek",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -31264,7 +32403,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -31295,9 +32435,9 @@
       "beatmapset_id": 640512,
       "artist": "FELT",
       "title": "Crescent Moon (MintApril\\_) [Hopeless Masquerade]",
-      "creator": "",
+      "creator": "MintApril_",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -31305,11 +32445,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 641319,
+      "artist": "Camellia",
+      "title": "Lunatic Rough Party!!",
+      "creator": "Kawashiro",
+      "source": "東方紅魔郷～the Embodiment of Scarlet Devil",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:526"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2017-12-14T20:29:13Z"
     },
     {
       "beatmapset_id": 642547,
@@ -31337,7 +32499,7 @@
       "artist": "Draw the Emotional",
       "title": "Endless cycle of rebirth & We cannot get out of here forever",
       "creator": "Nepuri",
-      "source": "",
+      "source": "東方神霊廟　～ Ten Desires.",
       "status": "ranked",
       "modes": [
         "osu",
@@ -31347,10 +32509,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-10-08T13:09:11Z"
     },
@@ -31391,9 +32555,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-11-12T11:57:40Z"
     },
@@ -31402,7 +32567,7 @@
       "artist": "Diao ye zong",
       "title": "Lost",
       "creator": "Suissie",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -31413,9 +32578,11 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-10-22T21:03:32Z"
     },
@@ -31488,7 +32655,7 @@
       "artist": "Nekomata Master",
       "title": "Sennen no Kotowari",
       "creator": "celerih",
-      "source": "",
+      "source": "SOUND VOLTEX III GRAVITY WARS",
       "status": "ranked",
       "modes": [
         "osu"
@@ -31497,10 +32664,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "mapper_tags",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -31595,7 +32764,7 @@
       "artist": "senya",
       "title": "Shunkan Everlasting",
       "creator": "Naotoshi",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -31604,12 +32773,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-09-23T16:12:13Z"
     },
@@ -31701,7 +32872,7 @@
       "artist": "Liz Triangle",
       "title": "Ryokugan no Kemono",
       "creator": "Mirash",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -31713,7 +32884,8 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -31740,6 +32912,28 @@
       "osu_last_updated": "2018-06-19T09:58:45Z"
     },
     {
+      "beatmapset_id": 662578,
+      "artist": "senya",
+      "title": "Wasurerareta Kiseki -Sciencefiction-",
+      "creator": "Satellite",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-05-24T03:09:51Z"
+    },
+    {
       "beatmapset_id": 664196,
       "artist": "Halozy",
       "title": "Cornelia",
@@ -31755,9 +32949,10 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-12-23T11:39:28Z"
     },
@@ -31786,9 +32981,9 @@
       "beatmapset_id": 665005,
       "artist": "M2U",
       "title": "Nightmare (Shoegazer) [Desolation]",
-      "creator": "",
+      "creator": "Shoegazer",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -31796,7 +32991,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -32014,7 +33210,7 @@
       "artist": "Rin",
       "title": "Mythic set ~ Heart-Stirring Urban Legends",
       "creator": "yaspo",
-      "source": "",
+      "source": "東方深秘録　～ Urban Legend in Limbo.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -32023,12 +33219,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-10-27T13:29:43Z"
     },
@@ -32037,7 +33235,7 @@
       "artist": "Masayoshi Minoshima feat.nomico",
       "title": "Lost Emotion (Amane UK Hardcore Remix)",
       "creator": "Zer0-",
-      "source": "",
+      "source": "東方心綺楼　～ Hopeless Masquerade.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -32046,10 +33244,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-05-03T20:15:58Z"
     },
@@ -32153,9 +33353,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-04-06T01:44:54Z"
     },
@@ -32198,6 +33399,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-12-21T20:28:12Z"
+    },
+    {
+      "beatmapset_id": 687513,
+      "artist": "Hatsuki Yura",
+      "title": "vanish out of one's sight -LAZ Remix-",
+      "creator": "-Tochi",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2017-12-14T09:23:24Z"
     },
     {
       "beatmapset_id": 688877,
@@ -32323,9 +33544,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-06-15T02:02:47Z"
     },
@@ -32344,9 +33566,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-12-13T17:40:14Z"
     },
@@ -32397,7 +33620,7 @@
       "artist": "Chata",
       "title": "con",
       "creator": "Hailie",
-      "source": "",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -32406,9 +33629,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1405"
+        "osu_source",
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-02-01T06:27:14Z"
     },
@@ -32502,7 +33727,7 @@
       "artist": "senya",
       "title": "Utakata, Ai no Mahoroba",
       "creator": "Satellite",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -32511,12 +33736,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-03-23T16:48:50Z"
     },
@@ -32669,6 +33896,29 @@
       "osu_last_updated": "2018-02-02T15:34:41Z"
     },
     {
+      "beatmapset_id": 710729,
+      "artist": "ZUN",
+      "title": "Sleepless Night of the Eastern Country",
+      "creator": "Champs de ble",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2018-10-27T20:53:53Z"
+    },
+    {
       "beatmapset_id": 711897,
       "artist": "Rin",
       "title": "Eientewi set 12 B ~ Flight in the Bamboo Cutter",
@@ -32736,9 +33986,9 @@
       "beatmapset_id": 712241,
       "artist": "Senya Arr. Iceon",
       "title": "Replica no Koi (Kroly-) [LuNatic]",
-      "creator": "",
+      "creator": "Kroly-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -32746,7 +33996,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -32757,7 +34008,7 @@
       "artist": "SYNC.ART'S",
       "title": "Graveyard in lake",
       "creator": "Halfslashed",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -32766,11 +34017,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-03-25T00:03:06Z"
     },
@@ -32779,7 +34032,7 @@
       "artist": "FELT",
       "title": "Time and again",
       "creator": "MokouSmoke",
-      "source": "",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -32788,12 +34041,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-05-04T16:12:52Z"
     },
@@ -32817,6 +34072,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-01-19T01:36:22Z"
+    },
+    {
+      "beatmapset_id": 715955,
+      "artist": "Serina Akesaka (CV: Emi Nitta)",
+      "title": "Heart Beat",
+      "creator": "Moa",
+      "source": "CHUNITHM PLUS",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-08-19T12:00:18Z"
     },
     {
       "beatmapset_id": 719447,
@@ -32853,7 +34128,9 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "mapper_tags",
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -32899,9 +34176,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-08-11T16:21:55Z"
     },
@@ -32930,7 +34209,7 @@
       "artist": "SYNC.ART'S",
       "title": "Mienai kara, Mieru Mono.",
       "creator": "pyrowar56",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -32942,9 +34221,12 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:526",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-05-24T22:16:11Z"
     },
@@ -33035,9 +34317,9 @@
       "beatmapset_id": 728496,
       "artist": "Shoegazer",
       "title": "Everything Will Freeze (Shoegazer) [Calamity]",
-      "creator": "",
+      "creator": "Shoegazer",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -33045,7 +34327,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -33120,7 +34403,7 @@
       "artist": "Rin",
       "title": "Mythic set ~ Heart-Stirring Urban Legends",
       "creator": "Hailie",
-      "source": "",
+      "source": "東方深秘録　～ Urban Legend in Limbo.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -33129,11 +34412,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-03-10T05:31:12Z"
     },
@@ -33162,9 +34447,9 @@
       "beatmapset_id": 732983,
       "artist": "Dark PHOENiX",
       "title": "The Primal Scene of Japan the Girl Saw (juankristal) [Stage 3: Release]",
-      "creator": "",
+      "creator": "juankristal",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -33172,11 +34457,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 733107,
+      "artist": "NewEastSound",
+      "title": "Seisou Rinne ~Repeat~",
+      "creator": "Duftende Pizza",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2018-02-11T11:39:51Z"
     },
     {
       "beatmapset_id": 733288,
@@ -33326,9 +34633,9 @@
       "beatmapset_id": 738235,
       "artist": "UNDEAD CORPORATION",
       "title": "Necrophilia (Gekido-) [Desire]",
-      "creator": "",
+      "creator": "Gekido-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -33336,7 +34643,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -33389,9 +34697,9 @@
       "beatmapset_id": 741280,
       "artist": "Milky",
       "title": "LAST REMOTE (MintApril) [sleet]",
-      "creator": "",
+      "creator": "MintApril",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -33399,7 +34707,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -33467,9 +34776,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-06-17T16:21:13Z"
     },
@@ -33478,7 +34788,7 @@
       "artist": "Shinra-bansho",
       "title": "Itazura Sensation",
       "creator": "Hailie",
-      "source": "",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -33491,9 +34801,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-05-30T18:02:23Z"
     },
@@ -33553,9 +34865,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-06-29T23:25:41Z"
     },
@@ -33666,6 +34979,27 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 751434,
+      "artist": "Foreground Eclipse",
+      "title": "Wandering, Never Wondering (There Exists A Shade)",
+      "creator": "Seni",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-10-23T09:19:44Z"
+    },
+    {
       "beatmapset_id": 751755,
       "artist": "IOSYS",
       "title": "Club Ibuki in Break All",
@@ -33726,9 +35060,10 @@
       "evidence": [
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-05-04T01:43:44Z"
     },
@@ -33747,9 +35082,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-04-02T00:49:12Z"
     },
@@ -33779,7 +35115,7 @@
       "artist": "Akatsuki Records",
       "title": "WARNING x WARNING x WARNING",
       "creator": "Hailie",
-      "source": "",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -33788,12 +35124,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-09-26T19:36:26Z"
     },
@@ -33862,9 +35200,9 @@
       "beatmapset_id": 759362,
       "artist": "Feint",
       "title": "Reprise (Original Mix) (ExNeko) [HD]",
-      "creator": "",
+      "creator": "ExNeko",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -33872,7 +35210,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -34008,7 +35347,7 @@
       "artist": "ESQUARIA feat. Meramipop",
       "title": "Echoes -ziki_7 Remix-",
       "creator": "-Tochi",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -34017,10 +35356,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-05-31T12:24:07Z"
     },
@@ -34069,9 +35410,9 @@
       "beatmapset_id": 772168,
       "artist": "Mili",
       "title": "Lemonade (-Hyme) [Hard]",
-      "creator": "",
+      "creator": "-Hyme",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -34079,7 +35420,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -34239,7 +35581,7 @@
       "artist": "UNDEAD CORPORATION",
       "title": "Embraced by the Flame",
       "creator": "PoNo",
-      "source": "",
+      "source": "東方地霊殿 ～ Subterranean Animism.",
       "status": "loved",
       "modes": [
         "osu"
@@ -34253,7 +35595,8 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -34300,6 +35643,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-10-19T12:57:46Z"
+    },
+    {
+      "beatmapset_id": 784476,
+      "artist": "zetoban",
+      "title": "Romantic Children",
+      "creator": "BarkingMadDog",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 785589,
@@ -34464,9 +35827,10 @@
       "evidence": [
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-07-04T19:52:40Z"
     },
@@ -34475,7 +35839,7 @@
       "artist": "Shibayan feat. 3L",
       "title": "Getsurei 11.3 no Candle Magic",
       "creator": "RLC",
-      "source": "",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -34484,10 +35848,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-03-21T02:30:00Z"
     },
@@ -34581,7 +35947,7 @@
       "artist": "LiLA'c Records",
       "title": "Jue",
       "creator": "eiri-",
-      "source": "",
+      "source": "東方心綺楼　～ Hopeless Masquerade.",
       "status": "ranked",
       "modes": [
         "osu",
@@ -34594,9 +35960,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-11-09T00:13:41Z"
     },
@@ -34605,7 +35973,7 @@
       "artist": "Akatsuki Records",
       "title": "Kamisama Stories -INNOCENT-",
       "creator": "Hailie",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -34614,10 +35982,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-09-20T16:15:52Z"
     },
@@ -34647,7 +36017,7 @@
       "artist": "Meramipop",
       "title": "Unknown x known - DYES IWASAKI Remix -",
       "creator": "Lasse",
-      "source": "",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -34656,12 +36026,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-07-09T13:20:56Z"
     },
@@ -34670,7 +36042,7 @@
       "artist": "Hatsuki Yura",
       "title": "Lunicode",
       "creator": "GreenHue",
-      "source": "",
+      "source": "東方輝針城　～ Double Dealing Character.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -34679,12 +36051,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-09-27T05:42:57Z"
     },
@@ -34775,11 +36149,51 @@
       "osu_last_updated": "2018-08-30T16:34:16Z"
     },
     {
+      "beatmapset_id": 807555,
+      "artist": "xi-on",
+      "title": "Mysterious Mountain",
+      "creator": "Dada",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 807673,
+      "artist": "Xenogen",
+      "title": "Native Faith - Suwako's Theme",
+      "creator": "Val",
+      "source": "",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 807855,
       "artist": "3L",
       "title": "Tiny Little Adiantum",
       "creator": "MaridiuS",
-      "source": "",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -34788,10 +36202,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-07-20T20:49:41Z"
     },
@@ -34884,7 +36300,7 @@
       "artist": "FELT",
       "title": "Oblivion",
       "creator": "MaridiuS",
-      "source": "",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -34896,9 +36312,13 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament:2163",
+        "tournament_candidate:526",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-10-04T22:30:04Z"
     },
@@ -34969,7 +36389,7 @@
       "artist": "Halozy",
       "title": "Masshiro na Yuki",
       "creator": "Heilia",
-      "source": "",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -34979,10 +36399,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-08-19T09:21:45Z"
     },
@@ -35049,11 +36471,11 @@
       "osu_last_updated": "2018-08-26T06:37:45Z"
     },
     {
-      "beatmapset_id": 827677,
-      "artist": "ShinRa-Bansho",
-      "title": "Traveller of the Aurora",
-      "creator": "Asagi",
-      "source": "",
+      "beatmapset_id": 826767,
+      "artist": "t+pazolite",
+      "title": "CENSORED!!",
+      "creator": "Shmiklak",
+      "source": "SOUND VOLTEX III GRAVITY WARS",
       "status": "ranked",
       "modes": [
         "osu"
@@ -35062,18 +36484,41 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "mapper_tags",
+        "tournament_candidate:731"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-02-06T14:59:48Z"
+    },
+    {
+      "beatmapset_id": 827677,
+      "artist": "ShinRa-Bansho",
+      "title": "Kyokkou no Tabibito",
+      "creator": "Asagi",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "tournament:1793",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2024-06-07T21:23:59Z"
     },
     {
       "beatmapset_id": 828302,
       "artist": "Raven's Jig",
       "title": "Un Jour Joueur",
       "creator": "Maardhen",
-      "source": "",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -35082,9 +36527,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1405"
+        "osu_source",
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-03-12T21:21:57Z"
     },
@@ -35149,11 +36596,32 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-11-10T23:11:58Z"
+    },
+    {
+      "beatmapset_id": 829950,
+      "artist": "ALiCE'S EMOTiON",
+      "title": "Lorelei",
+      "creator": "Dada",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 831385,
@@ -35190,6 +36658,7 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "tournament:1432",
         "tournament:1865"
       ],
       "confidence": "verified",
@@ -35231,9 +36700,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-10-18T10:04:06Z"
     },
@@ -35241,9 +36711,9 @@
       "beatmapset_id": 836072,
       "artist": "Alstroemeria Records",
       "title": "SACRIFICE feat. ayame (ATing) [MAXIMUM]",
-      "creator": "",
+      "creator": "ATing",
       "source": "",
-      "status": "unknown",
+      "status": "ranked",
       "modes": [
         "mania"
       ],
@@ -35251,7 +36721,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -35285,9 +36756,9 @@
       "beatmapset_id": 836634,
       "artist": "ZYTOKINE",
       "title": "DESIRE DREAM feat. itori - FELT Remix (\\_underjoy) [Melancholia]",
-      "creator": "",
+      "creator": "_underjoy",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -35295,7 +36766,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -35327,7 +36799,7 @@
       "artist": "Masayoshi Minoshima",
       "title": "Bad Apple!! feat. nomico",
       "creator": "Cheri",
-      "source": "",
+      "source": "東方幻想郷　～ Lotus Land Story",
       "status": "ranked",
       "modes": [
         "osu"
@@ -35336,10 +36808,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-12-13T08:32:21Z"
     },
@@ -35348,7 +36822,7 @@
       "artist": "Shinra-bansho",
       "title": "Kaiten",
       "creator": "DJ Lucky",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -35358,11 +36832,13 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-08-17T16:28:59Z"
     },
@@ -35382,9 +36858,10 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-03-28T03:36:39Z"
     },
@@ -35408,6 +36885,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-01-07T11:33:47Z"
+    },
+    {
+      "beatmapset_id": 846639,
+      "artist": "Black Sun Empire",
+      "title": "All Is Lost (Memtrix Remix)",
+      "creator": "Ksardas",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2018-09-09T20:22:38Z"
     },
     {
       "beatmapset_id": 847073,
@@ -35455,9 +36952,9 @@
       "beatmapset_id": 853700,
       "artist": "senya",
       "title": "Kowareta Unmei wo Tsumuide (souzirou1000) [LN]",
-      "creator": "",
+      "creator": "souzirou1000",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -35465,7 +36962,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -35541,7 +37039,7 @@
       "artist": "Dark PHOENiX",
       "title": "Koiiro Master Spark",
       "creator": "MaridiuS",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -35550,12 +37048,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-03-26T20:41:29Z"
     },
@@ -35626,7 +37126,7 @@
       "artist": "Akatsuki Records",
       "title": "Sci-Fi ROMANCE TRAVELER",
       "creator": "Hailie",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -35635,13 +37135,36 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-11-23T17:28:16Z"
+    },
+    {
+      "beatmapset_id": 857734,
+      "artist": "IOSYS",
+      "title": "Re: Usatei (Short Ver.)",
+      "creator": "YokesPai",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-14T19:31:44Z"
     },
     {
       "beatmapset_id": 857816,
@@ -35692,7 +37215,7 @@
       "artist": "Akatsuki Records",
       "title": "WARNING x WARNING x WARNING",
       "creator": "Xenon-",
-      "source": "",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -35701,10 +37224,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-01-25T01:36:09Z"
     },
@@ -35765,9 +37290,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-10-21T23:49:05Z"
     },
@@ -35809,6 +37335,7 @@
         "known_touhou_artist",
         "osucollector:1407",
         "osucollector:6907",
+        "tournament:1432",
         "tournament:1793"
       ],
       "confidence": "verified",
@@ -35831,7 +37358,8 @@
       "evidence": [
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -35883,7 +37411,7 @@
       "artist": "BUTAOTOME",
       "title": "Utakata",
       "creator": "DJ Lucky",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -35893,10 +37421,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-06-05T05:14:18Z"
     },
@@ -35946,9 +37476,9 @@
       "beatmapset_id": 871668,
       "artist": "Pegboard Nerds",
       "title": "Try This (Ciel) [your size]",
-      "creator": "",
+      "creator": "Ciel",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -35956,7 +37486,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -36012,9 +37543,9 @@
       "beatmapset_id": 874723,
       "artist": "Silentroom",
       "title": "NULCTRL (Janko) [ SILENT]",
-      "creator": "",
+      "creator": "Janko",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -36022,7 +37553,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -36094,9 +37626,9 @@
       "beatmapset_id": 876910,
       "artist": "Xceon ft. Mayumi Morinaga",
       "title": "Genei No Shoshitsu (araragigun) [Yukizakura]",
-      "creator": "",
+      "creator": "araragigun",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -36104,7 +37636,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -36130,6 +37663,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-04-03T17:34:25Z"
+    },
+    {
+      "beatmapset_id": 879051,
+      "artist": "Gekidan Record feat. Nekomata Master",
+      "title": "Houkou Orpheus",
+      "creator": "celerih",
+      "source": "REFLEC BEAT 悠久のリフレシア",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2018-12-08T16:55:33Z"
     },
     {
       "beatmapset_id": 882828,
@@ -36348,7 +37901,7 @@
       "artist": "Sally",
       "title": "did -Less Extra- Ranko ver.",
       "creator": "celerih",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -36357,10 +37910,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-01-01T17:51:04Z"
     },
@@ -36379,9 +37934,10 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2018-12-20T23:04:24Z"
     },
@@ -36390,7 +37946,7 @@
       "artist": "Demetori",
       "title": "Retrospective Kyoto ~ Japanese Beautiful Barrage",
       "creator": "Crissa",
-      "source": "",
+      "source": "東方文花帖　～ Shoot the Bullet.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -36400,11 +37956,33 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2019-02-17T20:45:34Z"
+    },
+    {
+      "beatmapset_id": 898791,
+      "artist": "M2U feat. NICODE",
+      "title": "Breach",
+      "creator": "Hailie",
+      "source": "RIDE ZERO",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
-      "osu_last_updated": "2019-02-17T20:45:34Z"
+      "osu_last_updated": "2019-04-07T19:46:32Z"
     },
     {
       "beatmapset_id": 898849,
@@ -36500,7 +38078,7 @@
       "artist": "Akatsuki Records",
       "title": "Treasure Cirno",
       "creator": "Apo11o",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -36509,11 +38087,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-07-05T17:19:37Z"
     },
@@ -36579,6 +38159,26 @@
       "osu_last_updated": "2019-05-07T23:11:19Z"
     },
     {
+      "beatmapset_id": 904935,
+      "artist": "Sonic Hybrid Orchestra",
+      "title": "Eyes Of Insanity ~ Invisible Full Moon",
+      "creator": "xept",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 904962,
       "artist": "Shinra-Bansho",
       "title": "Kyoukyou no Fortunate Polka",
@@ -36594,9 +38194,10 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-04-09T07:30:49Z"
     },
@@ -36731,11 +38332,32 @@
       "osu_last_updated": "2019-06-11T14:28:03Z"
     },
     {
+      "beatmapset_id": 907792,
+      "artist": "ESQUARIA",
+      "title": "Butterfly Delusion - Nhato remix -",
+      "creator": "MaridiuS",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2019-01-24T16:46:18Z"
+    },
+    {
       "beatmapset_id": 907820,
       "artist": "Hatsuki Yura",
       "title": "Lunicode",
       "creator": "Jabba",
-      "source": "",
+      "source": "東方輝針城　～ Double Dealing Character.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -36744,12 +38366,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-10-06T15:39:00Z"
     },
@@ -36881,9 +38505,9 @@
       "beatmapset_id": 914391,
       "artist": "Camellia feat. Nanahira",
       "title": "Seashore on the moon (cut ver.) (Bentai Bosmic) [Tsuki]",
-      "creator": "",
+      "creator": "Bentai Bosmic",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -36891,7 +38515,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -36923,6 +38548,27 @@
       "osu_last_updated": "2019-05-13T18:48:10Z"
     },
     {
+      "beatmapset_id": 915070,
+      "artist": "RD-Sounds feat. Meramipop/nayuta",
+      "title": "Shiten",
+      "creator": "MaddaFakka-sama",
+      "source": "東方天空璋 ～ Hidden Star in Four Seasons.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-02-24T20:08:42Z"
+    },
+    {
       "beatmapset_id": 915299,
       "artist": "Diao Ye Zong feat. nayuta",
       "title": "Tori yo",
@@ -36942,6 +38588,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-03-21T10:22:55Z"
+    },
+    {
+      "beatmapset_id": 917915,
+      "artist": "Silentroom",
+      "title": "Nhelv",
+      "creator": "Nyxa",
+      "source": "Arcaea",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:526"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2019-11-28T23:55:44Z"
     },
     {
       "beatmapset_id": 918509,
@@ -37046,11 +38712,32 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-24T18:05:54Z"
+    },
+    {
+      "beatmapset_id": 920634,
+      "artist": "UI-70",
+      "title": "Mou Uta Shika Kikoenai",
+      "creator": "xept",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
-      "osu_last_updated": "2024-11-24T18:05:54Z"
+      "osu_last_updated": "2020-02-21T12:52:26Z"
     },
     {
       "beatmapset_id": 922004,
@@ -37174,9 +38861,11 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-06-14T17:35:35Z"
     },
@@ -37205,9 +38894,9 @@
       "beatmapset_id": 925063,
       "artist": "loz",
       "title": "Cinderella Cage -Trancecore Mix- (Kamikaze) [Tails' vs Kami's Lunatic]",
-      "creator": "",
+      "creator": "Kamikaze",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -37215,7 +38904,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -37242,6 +38932,26 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-05-16T16:38:51Z"
+    },
+    {
+      "beatmapset_id": 926885,
+      "artist": "Yunomi & nicamoq",
+      "title": "Indoor Kei Nara Trackmaker (curryrice Remix)",
+      "creator": "toybot",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:526"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2019-04-03T21:35:44Z"
     },
     {
       "beatmapset_id": 928244,
@@ -37341,9 +39051,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-02-21T11:27:30Z"
     },
@@ -37371,9 +39083,9 @@
       "beatmapset_id": 930473,
       "artist": "Camellia",
       "title": "Tojita Sekai (MyZterioN-) [Last Defiance]",
-      "creator": "",
+      "creator": "MyZterioN-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -37381,7 +39093,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -37413,7 +39126,7 @@
       "artist": "Liz Triangle",
       "title": "Yoru no Circus",
       "creator": "Entry",
-      "source": "",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -37422,9 +39135,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osu_source",
+        "osucollector:6907",
+        "tournament_candidate:526",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2022-02-25T11:30:24Z"
     },
@@ -37528,9 +39244,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -37559,9 +39276,9 @@
       "beatmapset_id": 936831,
       "artist": "FELT",
       "title": "Day After (arcwinolivirus) [Blossoming Flower 1.1x]",
-      "creator": "",
+      "creator": "arcwinolivirus",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -37569,7 +39286,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -37603,7 +39321,7 @@
       "artist": "Akatsuki Records",
       "title": "BLOODSHED",
       "creator": "Zelq",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -37616,7 +39334,10 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1432",
+        "tournament:1865",
+        "tournament:828",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -37669,7 +39390,7 @@
       "artist": "Liz Triangle",
       "title": "Immortal Philosophy",
       "creator": "Jounzan",
-      "source": "",
+      "source": "東方深秘録　～ Urban Legend in Limbo.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -37678,9 +39399,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "osu_source",
+        "osucollector:1407",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-03-23T20:08:06Z"
     },
@@ -37725,9 +39448,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-10-20T14:56:25Z"
     },
@@ -37735,9 +39459,9 @@
       "beatmapset_id": 943788,
       "artist": "FELT",
       "title": "Life [Eris's \"a Fate Encounter\" mix] ([OSC]Amagai) [4k // Lunatic]",
-      "creator": "",
+      "creator": "[OSC]Amagai",
       "source": "",
-      "status": "unknown",
+      "status": "ranked",
       "modes": [
         "mania"
       ],
@@ -37745,7 +39469,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -37860,9 +39585,9 @@
       "beatmapset_id": 948789,
       "artist": "cYsmix",
       "title": "Abandoned Shrine Party (juankristal) [Stage 3: Outliers]",
-      "creator": "",
+      "creator": "juankristal",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -37870,7 +39595,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -37985,9 +39711,9 @@
       "beatmapset_id": 956232,
       "artist": "3L",
       "title": "Endless Night (Gekido-) [Eternal]",
-      "creator": "",
+      "creator": "Gekido-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -37995,7 +39721,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -38063,11 +39790,32 @@
       "osu_last_updated": "2019-05-01T13:41:58Z"
     },
     {
+      "beatmapset_id": 961846,
+      "artist": "tamaonsen",
+      "title": "Hoshi no Utsuwa feat. Rappubito",
+      "creator": "dennischan",
+      "source": "東方幻想郷　～ Lotus Land Story",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2019-07-25T08:11:15Z"
+    },
+    {
       "beatmapset_id": 962568,
       "artist": "BUTAOTOME",
       "title": "Futari Dake no Kotoba",
       "creator": "celerih",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38080,9 +39828,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-06-01T00:18:45Z"
     },
@@ -38090,9 +39840,9 @@
       "beatmapset_id": 963806,
       "artist": "Hotaru",
       "title": "Indomitable Spirit [Hommarju Remix] ([Crz]Auraah) [[L]u[N]atic]",
-      "creator": "",
+      "creator": "Auraah",
       "source": "",
-      "status": "unknown",
+      "status": "loved",
       "modes": [
         "mania"
       ],
@@ -38100,11 +39850,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 963884,
+      "artist": "Spacelectro",
+      "title": "EAT!EAT!EAT! feat. Momokami (PSYQUI Remix)",
+      "creator": "Typ4",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2019-08-14T14:14:35Z"
     },
     {
       "beatmapset_id": 967550,
@@ -38149,11 +39921,31 @@
       "osu_last_updated": "2019-05-14T18:30:59Z"
     },
     {
+      "beatmapset_id": 968961,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Kasha no Sakebu Yori ni",
+      "creator": "enryotoki",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 969563,
       "artist": "senya",
       "title": "Iro wa Nioedo Chirinuru o",
       "creator": "Entry",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38162,11 +39954,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-07-15T18:43:07Z"
     },
@@ -38174,9 +39968,9 @@
       "beatmapset_id": 969976,
       "artist": "Akiyama Uni",
       "title": "Kanpan Tasogare Shinbun (Larc) [Lunatic]",
-      "creator": "",
+      "creator": "Larc",
       "source": "",
-      "status": "unknown",
+      "status": "ranked",
       "modes": [
         "mania"
       ],
@@ -38184,7 +39978,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -38205,9 +40000,11 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-09-01T09:41:53Z"
     },
@@ -38303,7 +40100,7 @@
       "artist": "Rin",
       "title": "Amanojaku set 02 ~ Midnight Spell Card",
       "creator": "Aeril",
-      "source": "",
+      "source": "弾幕アマノジャク　～ Impossible Spell Card.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38314,9 +40111,11 @@
       "evidence": [
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-08-22T23:22:11Z"
     },
@@ -38325,7 +40124,7 @@
       "artist": "ShinRa-Bansho",
       "title": "Mugen Shitto Gekijou \"666\"",
       "creator": "Hey lululu",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38335,10 +40134,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-10-05T12:41:42Z"
     },
@@ -38389,7 +40190,7 @@
       "artist": "ShinRa-Bansho",
       "title": "Mother Right Heron",
       "creator": "Loneight",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38399,9 +40200,11 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:1405"
+        "osu_source",
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-08-23T12:56:40Z"
     },
@@ -38465,9 +40268,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-07-18T19:27:18Z"
     },
@@ -38653,7 +40457,7 @@
       "artist": "Draw the Emotional feat. Meramipop",
       "title": "Vanished truth",
       "creator": "IsomirDiAngelo",
-      "source": "",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38662,12 +40466,15 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-12-23T00:51:18Z"
     },
@@ -38676,7 +40483,7 @@
       "artist": "FELT",
       "title": "Lost in the Abyss",
       "creator": "Nowaie",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38685,18 +40492,41 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament:828",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2022-05-13T18:11:08Z"
+    },
+    {
+      "beatmapset_id": 985131,
+      "artist": "Shibayan feat. yana",
+      "title": "Kare to Kanojo to Watashi no Hanashi",
+      "creator": "Elcheer",
+      "source": "",
+      "status": "loved",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 985141,
       "artist": "Shinigiwa Satellite feat. Meramipop",
       "title": "Tensei Redemption",
       "creator": "Crissa",
-      "source": "",
+      "source": "東方求聞史紀　～ Perfect Memento in Strict Sense.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38705,9 +40535,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "mapper_tags",
         "osucollector:1402",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -38803,7 +40635,7 @@
       "artist": "ShinRa-Bansho",
       "title": "Zenryoku Happy Life",
       "creator": "Kirylln",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38813,10 +40645,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-05-02T23:38:23Z"
     },
@@ -38845,9 +40679,9 @@
       "beatmapset_id": 988816,
       "artist": "Shoujo Fractal",
       "title": "Hatenaki Kaze no Kiseki sae (AuraahDono) [Even the Endless Wind's Wall]",
-      "creator": "",
+      "creator": "AuraahDono",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -38855,7 +40689,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -38866,7 +40701,7 @@
       "artist": "Rin",
       "title": "Koumakan set 02 ~ Apparitions Stalk the Night",
       "creator": "eiri-",
-      "source": "",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38875,13 +40710,35 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-07-25T22:47:06Z"
+    },
+    {
+      "beatmapset_id": 992579,
+      "artist": "BUTAOTOME",
+      "title": "Kiiroi Hana",
+      "creator": "Kirylln",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 993059,
@@ -38917,9 +40774,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-08-09T21:36:17Z"
     },
@@ -38928,7 +40786,7 @@
       "artist": "Rin",
       "title": "Eientewi set 06 ~ Plain Asia",
       "creator": "yaspo",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38937,12 +40795,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-08-11T20:50:45Z"
     },
@@ -38971,7 +40831,7 @@
       "artist": "Draw the Emotional",
       "title": "Sad spring",
       "creator": "Resurreccion",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -38980,14 +40840,37 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-01-29T12:48:49Z"
+    },
+    {
+      "beatmapset_id": 994914,
+      "artist": "Demetori",
+      "title": "Pure Furies ~ Vengeance is Mine",
+      "creator": "genericiface",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-03T14:00:18Z"
     },
     {
       "beatmapset_id": 996256,
@@ -39053,11 +40936,32 @@
       "osu_last_updated": "2019-07-15T10:10:05Z"
     },
     {
+      "beatmapset_id": 997836,
+      "artist": "Demetori",
+      "title": "Inchlings of the Shining Needle ~ Counter-Attack of the Weak",
+      "creator": "rockstarrzz",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2019-07-07T03:22:31Z"
+    },
+    {
       "beatmapset_id": 999421,
       "artist": "Chata",
       "title": "Aru Korai kara Nozoku Tensen",
       "creator": "Senseabel",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -39066,10 +40970,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-07-15T22:21:16Z"
     },
@@ -39078,7 +40984,7 @@
       "artist": "ZUN",
       "title": "Ryokugan no Jealousy",
       "creator": "Net0",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -39088,13 +40994,15 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:14845",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "probable",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-08-11T13:55:14Z"
     },
@@ -39167,7 +41075,7 @@
       "artist": "Pizuya's Cell",
       "title": "Inchlings of the Shining Needle ~ Little Princess",
       "creator": "Shurelia",
-      "source": "",
+      "source": "東方憑依華　～ Antinomy of Common Flowers.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -39179,9 +41087,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-08-18T20:04:40Z"
     },
@@ -39382,9 +41292,9 @@
       "beatmapset_id": 1008419,
       "artist": "BilliumMoto",
       "title": "Four Veiled Stars (- Aries -) [FAMoss' Hard]",
-      "creator": "",
+      "creator": "- Aries -",
       "source": "",
-      "status": "unknown",
+      "status": "ranked",
       "modes": [
         "mania"
       ],
@@ -39392,7 +41302,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -39472,7 +41383,7 @@
       "artist": "ShinRa-Bansho",
       "title": "Corpse Dance",
       "creator": "Qnio",
-      "source": "",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -39482,9 +41393,11 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:6907"
+        "osu_source",
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2022-04-02T20:57:51Z"
     },
@@ -39589,9 +41502,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-08-23T02:20:05Z"
     },
@@ -39644,7 +41559,7 @@
       "artist": "UNDEAD CORPORATION",
       "title": "Adore Your Pain",
       "creator": "Zelq",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -39654,11 +41569,13 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-04-14T22:24:00Z"
     },
@@ -39752,7 +41669,7 @@
       "artist": "Rin",
       "title": "Amanojaku set 03 ~ Romantic Escape Flight",
       "creator": "Halfslashed",
-      "source": "",
+      "source": "弾幕アマノジャク　～ Impossible Spell Card.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -39764,9 +41681,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-08-27T22:37:38Z"
     },
@@ -39775,7 +41694,7 @@
       "artist": "ShinRa-Bansho",
       "title": "Marisa wa Taihen na Mono o Nusunde Ikimashita ShinRa-Bansho Ver",
       "creator": "Len",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -39785,11 +41704,14 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-10-10T13:42:09Z"
     },
@@ -39808,9 +41730,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-09-23T05:58:51Z"
     },
@@ -39874,9 +41797,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-04-20T15:37:25Z"
     },
@@ -39989,7 +41913,7 @@
       "artist": "TAMAONSEN",
       "title": "Witches' Night (ShinRa-Bansho Ver.)",
       "creator": "Dafiely",
-      "source": "",
+      "source": "妖精大戦争　～ 東方三月精",
       "status": "ranked",
       "modes": [
         "osu"
@@ -39998,11 +41922,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-10-29T18:10:51Z"
     },
@@ -40077,7 +42003,7 @@
       "artist": "BUTAOTOME",
       "title": "Kurukuru Tsukai",
       "creator": "Entry",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -40090,9 +42016,12 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament:2163",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-10-19T16:48:25Z"
     },
@@ -40145,7 +42074,7 @@
       "artist": "Demetori",
       "title": "Warabe Matsuri ~ Innocent Treasures",
       "creator": "Remapper",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -40154,10 +42083,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-02-18T00:32:56Z"
     },
@@ -40166,7 +42097,7 @@
       "artist": "Demetori",
       "title": "Yuuga ni Sakase, Sumizome no Sakura ~ The Harm of Coming into Existence",
       "creator": "jonathanlfj",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -40176,9 +42107,11 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-03-29T21:05:42Z"
     },
@@ -40197,9 +42130,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-10-23T23:19:05Z"
     },
@@ -40228,9 +42162,9 @@
       "beatmapset_id": 1037582,
       "artist": "uma feat. mashiro",
       "title": "Brave My Soul -Full Version- (Tamaki Iroha) [Hard(Edit)]",
-      "creator": "",
+      "creator": "Tamaki Iroha",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -40238,7 +42172,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -40331,9 +42266,9 @@
       "beatmapset_id": 1042429,
       "artist": "Halozy",
       "title": "Serenade of Love (Hydria) [Hard]",
-      "creator": "",
+      "creator": "Hydria",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -40341,7 +42276,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -40351,9 +42287,9 @@
       "beatmapset_id": 1042644,
       "artist": "Tokyo Machine",
       "title": "FIGHT (Zytosy) [ FIGHTO !]",
-      "creator": "",
+      "creator": "Zytosy",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -40361,7 +42297,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -40392,7 +42329,7 @@
       "artist": "Akatsuki Records",
       "title": "Bhavacakra",
       "creator": "SMOKELIND",
-      "source": "",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -40402,9 +42339,11 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-07-15T22:01:00Z"
     },
@@ -40478,9 +42417,9 @@
       "beatmapset_id": 1055109,
       "artist": "nomico, ayame & Masayoshi Minoshima",
       "title": "Bad Apple!! (ARM x Kitsune Musou Remix) (\\_underjoy) [ EIRIN!!!! [1,1x Rate]]",
-      "creator": "",
+      "creator": "_underjoy",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -40488,7 +42427,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -40499,7 +42439,7 @@
       "artist": "Akatsuki Records",
       "title": "Trance Dance Anarchy",
       "creator": "papapa213",
-      "source": "",
+      "source": "東方天空璋　～ Hidden Star in Four Seasons.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -40508,11 +42448,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-04-02T18:10:03Z"
     },
@@ -40584,9 +42526,9 @@
       "beatmapset_id": 1060785,
       "artist": "Rabpit",
       "title": "Saika (Jinjin) [LN Master]",
-      "creator": "",
+      "creator": "ATing",
       "source": "",
-      "status": "unknown",
+      "status": "loved",
       "modes": [
         "mania"
       ],
@@ -40594,7 +42536,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -40623,6 +42566,26 @@
       "osu_last_updated": "2021-02-19T11:06:09Z"
     },
     {
+      "beatmapset_id": 1062030,
+      "artist": "Akatsuki Records",
+      "title": "KOISHI ~ Koishi Infinity ~",
+      "creator": "Villdjack",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1063655,
       "artist": "ShinRa-Bansho",
       "title": "Junjou Armeria",
@@ -40649,7 +42612,7 @@
       "artist": "Adust Rain",
       "title": "TRAUMATIC SYNDROME -Lenboxx Remix-",
       "creator": "eiri-",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -40662,9 +42625,11 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-12-05T06:21:23Z"
     },
@@ -40673,7 +42638,7 @@
       "artist": "UNDEAD CORPORATION",
       "title": "Tengai",
       "creator": "Lafayla",
-      "source": "",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -40684,7 +42649,8 @@
       "evidence": [
         "known_touhou_artist",
         "official_pack:FQ35",
-        "osucollector:1405"
+        "osucollector:1405",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -40695,7 +42661,7 @@
       "artist": "UNDEAD CORPORATION",
       "title": "Tokoyo Omohikane no Kami",
       "creator": "Mirash",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -40709,7 +42675,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -40754,9 +42723,12 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:1432",
+        "tournament:2163",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-01-05T14:09:53Z"
     },
@@ -40824,6 +42796,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-12-16T14:53:56Z"
+    },
+    {
+      "beatmapset_id": 1071549,
+      "artist": "Foreground Eclipse",
+      "title": "Destruction",
+      "creator": "Kojio",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-05-24T11:08:28Z"
     },
     {
       "beatmapset_id": 1073159,
@@ -40904,9 +42897,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-05-17T10:54:08Z"
     },
@@ -40924,11 +42918,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament:1432"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2019-12-06T16:44:54Z"
+    },
+    {
+      "beatmapset_id": 1075959,
+      "artist": "SYNC.ART'S",
+      "title": "sympacy dolls",
+      "creator": "Frostmourne",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2019-12-15T06:07:03Z"
     },
     {
       "beatmapset_id": 1076644,
@@ -40955,9 +42971,9 @@
       "beatmapset_id": 1076900,
       "artist": "Cory Williams",
       "title": "The Mean Kitty Song (SaltedFISSH) [cat]",
-      "creator": "",
+      "creator": "SaltedFISSH",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -40965,7 +42981,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -41019,7 +43036,7 @@
       "artist": "Akatsuki Records",
       "title": "HANIPAGANDA",
       "creator": "Night Mare",
-      "source": "",
+      "source": "東方鬼形獣　～ Wily Beast and Weakest Creature.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -41032,11 +43049,34 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-06-10T20:18:11Z"
+    },
+    {
+      "beatmapset_id": 1084045,
+      "artist": "Foreground Eclipse",
+      "title": "Fall Of Tears",
+      "creator": "synderes",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:526"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 1084144,
@@ -41215,6 +43255,27 @@
       "osu_last_updated": "2020-03-02T22:21:52Z"
     },
     {
+      "beatmapset_id": 1089633,
+      "artist": "ALiCE'S EMOTiON",
+      "title": "blood sacrifice",
+      "creator": "Qnio",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-30T10:24:48Z"
+    },
+    {
       "beatmapset_id": 1091216,
       "artist": "Diao Ye Zong feat. Meramipop",
       "title": "Hocus Pocus",
@@ -41371,7 +43432,7 @@
       "artist": "Kishida Kyoudan & THE Akeboshi Rockets",
       "title": "Necrofantasia",
       "creator": "skytuna",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -41381,7 +43442,9 @@
       "original_themes": [],
       "evidence": [
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1432",
+        "tournament:1793",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -41542,9 +43605,9 @@
       "beatmapset_id": 1109484,
       "artist": "senya",
       "title": "Sasayaku Kiekaketa Kouishou ga (souzirou1000) [LN]",
-      "creator": "",
+      "creator": "souzirou1000",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -41552,7 +43615,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -41586,7 +43650,7 @@
       "artist": "Jerico",
       "title": "Do you believe a Dullahan?",
       "creator": "greenhue",
-      "source": "",
+      "source": "東方輝針城　～ Double Dealing Character.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -41595,10 +43659,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
-        "osucollector:1407"
+        "osucollector:1407",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-04-10T12:59:23Z"
     },
@@ -41607,7 +43674,7 @@
       "artist": "Rin",
       "title": "Daishibyo set 08 ~ Furuki Yuanxian",
       "creator": "Lasse",
-      "source": "",
+      "source": "東方神霊廟　～ Ten Desires.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -41619,7 +43686,9 @@
         "official_pack:T106",
         "osucollector:1402",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -41630,7 +43699,7 @@
       "artist": "Jerico",
       "title": "Catadioptric",
       "creator": "SaltyLucario",
-      "source": "",
+      "source": "SOUND VOLTEX II -infinite infection-",
       "status": "ranked",
       "modes": [
         "osu"
@@ -41639,10 +43708,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "mapper_tags",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
@@ -41652,9 +43723,9 @@
       "beatmapset_id": 1113922,
       "artist": "Various Artists",
       "title": "Xingyue's 4K > JackMonster < EP.2 (Xingyue-) [Halozy / 143 (extended mix)]",
-      "creator": "",
+      "creator": "Xingyue-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -41662,7 +43733,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -41672,9 +43744,9 @@
       "beatmapset_id": 1116132,
       "artist": "ARForest",
       "title": "It's alright (riunosk) [8.]",
-      "creator": "",
+      "creator": "riunosk",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -41682,7 +43754,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -41705,18 +43778,40 @@
         "known_touhou_artist",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-11-29T12:49:57Z"
     },
     {
+      "beatmapset_id": 1118286,
+      "artist": "katikatiyama",
+      "title": "Aki no Uta",
+      "creator": "Seni",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163",
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1118538,
       "artist": "Diao Ye Zong feat. Meramipop",
       "title": "Kyougen 'Hane Gyokuto'",
       "creator": "Irin",
-      "source": "",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -41725,10 +43820,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-07-27T04:57:41Z"
     },
@@ -41838,9 +43936,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-05-30T16:51:27Z"
     },
@@ -41868,7 +43967,7 @@
     {
       "beatmapset_id": 1125904,
       "artist": "t+pazolite",
-      "title": "Kansabi",
+      "title": "t+pazolite -Kansabi (Zyph) [Desolation]",
       "creator": "Zyph",
       "source": "WACCA",
       "status": "graveyard",
@@ -41879,7 +43978,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -41906,12 +44006,33 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1126812,
+      "artist": "Akatsuki Records",
+      "title": "Alf Layla wa Layla",
+      "creator": "AdveNt",
+      "source": "こちら秘封探偵事務所",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "mapper_tags",
+        "tournament_candidate:731"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2020-05-14T16:00:09Z"
+    },
+    {
       "beatmapset_id": 1128020,
       "artist": "uno(IOSYS)",
       "title": "#Fairy_dancing_in_lake (notapplicable) [#Fairy_dancing_in_the_world]",
-      "creator": "",
+      "creator": "notapplicable",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -41919,7 +44040,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -41951,7 +44073,7 @@
       "artist": "IOSYS",
       "title": "Marisa wa Taihen na Mono wo Nusunde Ikimashita",
       "creator": "eiri-",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -41961,12 +44083,14 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-12-10T03:10:28Z"
     },
@@ -42086,7 +44210,7 @@
       "artist": "Shibayan feat. 3L",
       "title": "Maigo no Echo",
       "creator": "kelinimo",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -42095,9 +44219,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2023-01-12T19:44:09Z"
     },
@@ -42123,12 +44249,34 @@
       "osu_last_updated": "2020-06-08T17:30:57Z"
     },
     {
+      "beatmapset_id": 1146136,
+      "artist": "ShinRa-Bansho",
+      "title": "Uchouten Dreamers",
+      "creator": "Kurashina Asuka",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-03-19T18:03:36Z"
+    },
+    {
       "beatmapset_id": 1146384,
       "artist": "Zekk",
       "title": "Let Me Hear (Dubstek) [Let Me Play]",
-      "creator": "",
+      "creator": "Dubstek",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -42136,7 +44284,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42147,7 +44296,7 @@
       "artist": "Chata",
       "title": "min",
       "creator": "Melwoine",
-      "source": "",
+      "source": "東方神霊廟　～ Ten Desires.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -42160,7 +44309,9 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:2163",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42209,6 +44360,67 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1152458,
+      "artist": "ZUN",
+      "title": "Osanagokorochi no Uchouten",
+      "creator": "-Tynamo",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1152559,
+      "artist": "D.watt(OTAKU-ELITE Recordings)",
+      "title": "Opium and Purple Haze",
+      "creator": "Nines",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1152650,
+      "artist": "IOSYS feat. Nanahira",
+      "title": "Judgment Day Has Come",
+      "creator": "-Tynamo",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-04-23T21:30:07Z"
+    },
+    {
       "beatmapset_id": 1153755,
       "artist": "Kishida Kyoudan & The Akeboshi Rockets",
       "title": "Shinkou wa Hakanaki Ningen no Tame ni",
@@ -42222,9 +44434,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -42233,7 +44446,7 @@
       "artist": "FELT",
       "title": "Midnight Boogie",
       "creator": "[Mad]",
-      "source": "",
+      "source": "東方輝針城　～ Double Dealing Character.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -42245,7 +44458,9 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42256,7 +44471,7 @@
       "artist": "LeaF",
       "title": "Arianrhod",
       "creator": "greenhue",
-      "source": "",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -42270,11 +44485,93 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-05-27T02:21:37Z"
+    },
+    {
+      "beatmapset_id": 1157967,
+      "artist": "Nhato",
+      "title": "Hell's Sun",
+      "creator": "Mun",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1158069,
+      "artist": "Ciel",
+      "title": "If you're my destiny, end this fated determination.",
+      "creator": "Xen",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1158806,
+      "artist": "Jerico",
+      "title": "Shattered Aya",
+      "creator": "- Heatwave -",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1159171,
+      "artist": "SOUND HOLIC",
+      "title": "Idola Deus Ex Flamma",
+      "creator": "Yukiyo",
+      "source": "東方鬼形獣　～ Wily Beast and Weakest Creature.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2020-07-14T12:54:24Z"
     },
     {
       "beatmapset_id": 1160488,
@@ -42299,6 +44596,27 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-10-16T03:29:26Z"
+    },
+    {
+      "beatmapset_id": 1160681,
+      "artist": "Amane",
+      "title": "Kiyurougetsu ~ Eternal Fullmoon",
+      "creator": "Mao",
+      "source": "東方夢時空　～ Pantasmagria of Dim.Dream",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-06-18T20:51:33Z"
     },
     {
       "beatmapset_id": 1161067,
@@ -42348,7 +44666,7 @@
       "artist": "Alstroemeria Records feat. ayame",
       "title": "SACRIFICE (Original Mix)",
       "creator": "Nuvolina",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -42357,12 +44675,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-05-06T18:20:35Z"
     },
@@ -42380,7 +44700,29 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1163051,
+      "artist": "Masayoshi Minoshima",
+      "title": "Bad Apple!! feat.nomico (Camellia's \"Bad Psy!!\" Remix)",
+      "creator": "Nines",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1432",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42426,7 +44768,8 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42436,9 +44779,9 @@
       "beatmapset_id": 1164662,
       "artist": "Paul Bazooka",
       "title": "Drunken Stein (Sillyp) [KUNNAN BIANSU]",
-      "creator": "",
+      "creator": "Sillyp",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -42446,7 +44789,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42456,9 +44800,9 @@
       "beatmapset_id": 1165415,
       "artist": "Chroma",
       "title": "Genyo Ressha no Tabi (Zestiri9) [Journey]",
-      "creator": "",
+      "creator": "Zestiri9",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -42466,7 +44810,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42542,9 +44887,9 @@
       "beatmapset_id": 1170710,
       "artist": "Camellia ft. Hatsune Miku",
       "title": "Looking for Edge of Ground (MyZterioN-) [Flawless World]",
-      "creator": "",
+      "creator": "MyZterioN-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -42552,7 +44897,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42604,9 +44950,9 @@
       "beatmapset_id": 1173144,
       "artist": "beatMARIO",
       "title": "Night of Knights (Cranky Remix) (FAMoss) [Hard]",
-      "creator": "",
+      "creator": "FAMoss",
       "source": "",
-      "status": "unknown",
+      "status": "ranked",
       "modes": [
         "mania"
       ],
@@ -42614,7 +44960,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42635,9 +44982,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-06-10T21:48:15Z"
     },
@@ -42691,7 +45039,7 @@
       "artist": "BLANKFIELD",
       "title": "Guilty People, Innocent Doll",
       "creator": "eiri-",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -42700,12 +45048,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-01-23T03:58:32Z"
     },
@@ -42816,9 +45166,9 @@
       "beatmapset_id": 1180540,
       "artist": "AQUAELIE",
       "title": "Broken the Moon ([Crz]hinako1804) [Yue x1.05_P]",
-      "creator": "",
+      "creator": "[Crz]hinako1804",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -42826,7 +45176,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42903,9 +45254,9 @@
       "beatmapset_id": 1181310,
       "artist": "DOT96",
       "title": "MAKE IT FUNKY NOW (RuleBlazing) [Funny]",
-      "creator": "",
+      "creator": "RuleBlazing",
       "source": "",
-      "status": "unknown",
+      "status": "wip",
       "modes": [
         "mania"
       ],
@@ -42913,7 +45264,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -42923,9 +45275,9 @@
       "beatmapset_id": 1182593,
       "artist": "Nhato",
       "title": "Gekka (Short Version) ([Crz]hinako1804) [Halation]",
-      "creator": "",
+      "creator": "[Crz]hinako1804",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -42933,7 +45285,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43001,9 +45354,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-08-16T05:55:05Z"
     },
@@ -43031,9 +45385,9 @@
       "beatmapset_id": 1188944,
       "artist": "FELT",
       "title": "OUR SHIP (Evening) [ Enchanted Love]",
-      "creator": "",
+      "creator": "Evening",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43041,7 +45395,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43052,7 +45407,7 @@
       "artist": "SEPHID",
       "title": "Critical Cannonball (Extended ver.)",
       "creator": "DeviousPanda",
-      "source": "",
+      "source": "東方輝針城　～ Double Dealing Character.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -43065,19 +45420,20 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-07-01T01:05:14Z"
     },
     {
       "beatmapset_id": 1190312,
       "artist": "StarX",
       "title": "The little devil dance (Tamaki Iroha) [Lunatic]",
-      "creator": "",
+      "creator": "Tamaki Iroha",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43085,7 +45441,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43118,9 +45475,9 @@
       "beatmapset_id": 1195487,
       "artist": "Various Artists",
       "title": "Jack Complexes Vol1.A (deceleration) [ZOU+ [Sumika]]",
-      "creator": "",
+      "creator": "deceleration",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43128,7 +45485,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43159,9 +45517,9 @@
       "beatmapset_id": 1199190,
       "artist": "ccy",
       "title": "Fallen (cherrychou) [Stage 2: Acc]",
-      "creator": "",
+      "creator": "cherrychou",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43169,7 +45527,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43223,7 +45582,7 @@
       "artist": "Houshou Marine with Holoism Fantasy",
       "title": "Hoihoi*Gensou Holoism",
       "creator": "Amateurre",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -43232,10 +45591,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-10-28T04:59:26Z"
     },
@@ -43263,9 +45625,9 @@
       "beatmapset_id": 1212220,
       "artist": "Masayoshi Minoshima",
       "title": "Struggle (Fe_Sanae_C) [Forever Blossom]",
-      "creator": "",
+      "creator": "Fe_Sanae_C",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43273,7 +45635,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43305,7 +45668,7 @@
       "artist": "Diao Ye Zong feat. Meramipop",
       "title": "Moumoku no Egao",
       "creator": "Jelljel",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -43314,10 +45677,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-12-14T10:45:55Z"
     },
@@ -43411,9 +45776,9 @@
       "beatmapset_id": 1224030,
       "artist": "UNDEAD CORPORATION",
       "title": "Yoru Naku Usagi wa Yume wo Miru (Antori) [Invisible Full Moon]",
-      "creator": "",
+      "creator": "Antori",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43421,7 +45786,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43442,11 +45808,32 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-11-14T17:49:05Z"
+    },
+    {
+      "beatmapset_id": 1229597,
+      "artist": "ZUN",
+      "title": "Flowering Night",
+      "creator": "FailureAtOsu",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 1231746,
@@ -43521,7 +45908,7 @@
       "artist": "IOSYS",
       "title": "Madoite Kitare, Yuuda na Kamikakushi ~ Border of Death",
       "creator": "Luscent",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -43531,11 +45918,13 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-02-06T01:46:23Z"
     },
@@ -43543,9 +45932,9 @@
       "beatmapset_id": 1235559,
       "artist": "Camellia",
       "title": "Routing (Couil) [Drifting]",
-      "creator": "",
+      "creator": "Couil",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43553,7 +45942,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43563,9 +45953,9 @@
       "beatmapset_id": 1235944,
       "artist": "Rin",
       "title": "Ayakashi set 12 Another ~ Border of Life (LaoXiao-) [Jack of Life]",
-      "creator": "",
+      "creator": "LaoXiao-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43573,7 +45963,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43604,9 +45995,9 @@
       "beatmapset_id": 1237160,
       "artist": "Ryu-5150",
       "title": "Louder than steel (Ryu-5150 - Louder than steel) [1x]",
-      "creator": "",
+      "creator": "Ska",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43614,7 +46005,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43666,7 +46058,7 @@
       "artist": "ShinRa-Bansho",
       "title": "MY Heart Rate",
       "creator": "UberFazz",
-      "source": "",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -43676,11 +46068,14 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-01-22T23:31:46Z"
     },
@@ -43689,7 +46084,7 @@
       "artist": "Amane",
       "title": "BOOZEHOUND",
       "creator": "Luscent",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -43698,12 +46093,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-12-08T13:49:20Z"
     },
@@ -43711,9 +46108,9 @@
       "beatmapset_id": 1242775,
       "artist": "XXXTENTACION",
       "title": "SAD! (Couil) [down]",
-      "creator": "",
+      "creator": "Couil",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43721,7 +46118,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43731,9 +46129,9 @@
       "beatmapset_id": 1243225,
       "artist": "Rin",
       "title": "Mythic set ~ Heart-Stirring Urban Legends (UnluckyCroco) [Tales of the Occult]",
-      "creator": "",
+      "creator": "UnluckyCroco",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43741,7 +46139,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43751,9 +46150,9 @@
       "beatmapset_id": 1243593,
       "artist": "Camellia",
       "title": "KillerBeast (Noa Himesaka) [SV]",
-      "creator": "",
+      "creator": "Noa Himesaka",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43761,7 +46160,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43772,7 +46172,7 @@
       "artist": "Sorane",
       "title": "Love song with heart",
       "creator": "Adinda",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -43781,13 +46181,35 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2020-10-12T04:11:54Z"
+    },
+    {
+      "beatmapset_id": 1245436,
+      "artist": "Michiru Kagemori (CV: Morohoshi Sumire)",
+      "title": "Ready to (Mokelmbe Bootleg)",
+      "creator": "Mir",
+      "source": "BNA ビー・エヌ・エー",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
-      "osu_last_updated": "2020-10-12T04:11:54Z"
+      "osu_last_updated": "2021-08-15T22:11:48Z"
     },
     {
       "beatmapset_id": 1247472,
@@ -43853,12 +46275,34 @@
       "osu_last_updated": "2022-01-25T06:51:37Z"
     },
     {
+      "beatmapset_id": 1249382,
+      "artist": "ZUN",
+      "title": "Guuzou ni Sekai wo Yudanete ~ Idoratrize World",
+      "creator": "kaiku",
+      "source": "東方鬼形獣　～ Wily Beast and Weakest Creature.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-01-31T21:20:19Z"
+    },
+    {
       "beatmapset_id": 1251545,
       "artist": "goreshit",
       "title": "satori de pon! (SaltedFISSH) [~pon~]",
-      "creator": "",
+      "creator": "SaltedFISSH",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -43866,7 +46310,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43907,7 +46352,8 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -43941,7 +46387,7 @@
       "artist": "ShinRa-Bansho x Yuuhei Satellite & Shoujo Fractal",
       "title": "Genso Connect",
       "creator": "Wither",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -43950,10 +46396,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-12-12T14:51:54Z"
     },
@@ -43972,9 +46420,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-11-09T04:51:49Z"
     },
@@ -43983,7 +46432,7 @@
       "artist": "Masayoshi Minoshima",
       "title": "Bad Apple!! feat. nomico (Camellia's \"Bad Psy!!\" Remix)",
       "creator": "fusionnqn",
-      "source": "",
+      "source": "東方幻想郷　～ Lotus Land Story",
       "status": "ranked",
       "modes": [
         "osu"
@@ -43995,7 +46444,10 @@
         "osucollector:1407",
         "osucollector:6907",
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament_candidate:526",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44069,9 +46521,9 @@
       "beatmapset_id": 1258005,
       "artist": "Nanahira",
       "title": "Monosugoi ikioide keine ga monosugoi uta (SaltedFISSH) [Revolution!!!]",
-      "creator": "",
+      "creator": "SaltedFISSH",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44079,7 +46531,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44110,9 +46563,9 @@
       "beatmapset_id": 1260461,
       "artist": "Wakeshima Kanon",
       "title": "Foul Play ni Kurari (datoujia) [SV Beginner]",
-      "creator": "",
+      "creator": "datoujia",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44120,7 +46573,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44130,9 +46584,9 @@
       "beatmapset_id": 1261327,
       "artist": "Super Psychic Fujy",
       "title": "Dark Avatara Beam (Le Dos-on Remix) (Blue_Potion) [Edit]",
-      "creator": "",
+      "creator": "Blue_Potion",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44140,7 +46594,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44150,9 +46605,9 @@
       "beatmapset_id": 1261406,
       "artist": "ZUN",
       "title": "Youma Yakou (Zestiri9) [Stage 4: Hybrid]",
-      "creator": "",
+      "creator": "Zestiri9",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44160,7 +46615,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44171,7 +46627,7 @@
       "artist": "Rin",
       "title": "Eientewi set 13 ~ Extend Ash",
       "creator": "Halfslashed",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -44180,12 +46636,15 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-01-27T02:08:33Z"
     },
@@ -44194,7 +46653,7 @@
       "artist": "cYsmix",
       "title": "Abandoned Shrine Party",
       "creator": "Halfslashed",
-      "source": "",
+      "source": "東方神霊廟　～ Ten Desires.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -44208,11 +46667,14 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:526",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-09-29T17:36:35Z"
     },
     {
       "beatmapset_id": 1267260,
@@ -44260,7 +46722,7 @@
       "artist": "FELT",
       "title": "OUR SHIP",
       "creator": "Halfslashed",
-      "source": "",
+      "source": "東方夢時空　～ Phantasmagoria of Dim.Dream",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -44269,11 +46731,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2020-09-27T20:54:03Z"
     },
     {
       "beatmapset_id": 1267353,
@@ -44289,9 +46752,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -44345,9 +46810,9 @@
       "beatmapset_id": 1268988,
       "artist": "Aya ponzu*/a yo/Marcia/Amamiya Miya",
       "title": "Genso konekuto (cherrychou) [Gensokyo]",
-      "creator": "",
+      "creator": "cherrychou",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44355,7 +46820,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44409,7 +46875,7 @@
       "artist": "senya",
       "title": "Shinra-Banshou ni Furete",
       "creator": "Satellite",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -44418,22 +46884,24 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-08-03T10:06:20Z"
     },
     {
       "beatmapset_id": 1271347,
       "artist": "Poppin'Party",
       "title": "STAR BEAT!~Hoshi no Kodou~ (Raveille) [Stage 3: LN]",
-      "creator": "",
+      "creator": "Raveille",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44441,7 +46909,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44451,9 +46920,9 @@
       "beatmapset_id": 1271396,
       "artist": "LeaF",
       "title": "Armageddon (Sillyp) [Stage 1: SV]",
-      "creator": "",
+      "creator": "Sillyp",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44461,7 +46930,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44489,12 +46959,32 @@
       "osu_last_updated": "2020-11-26T17:47:29Z"
     },
     {
+      "beatmapset_id": 1271996,
+      "artist": "BEMANI Sound Team \"Nekomata Master\"",
+      "title": "Life is beautiful",
+      "creator": "anna apple",
+      "source": "GITADORA Matixx",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-12-04T00:34:24Z"
+    },
+    {
       "beatmapset_id": 1275896,
       "artist": "Foreground Eclipse",
       "title": "(I Don't Need Any Titles To This Song!) (YuEast 2018) [ [] ]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44502,7 +46992,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44534,7 +47025,7 @@
       "artist": "ZUN",
       "title": "Desire Drive",
       "creator": "Halfslashed",
-      "source": "",
+      "source": "東方神霊廟　～ Ten Desires.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -44548,7 +47039,9 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44559,7 +47052,7 @@
       "artist": "ShinRa-Bansho",
       "title": "Itazura Sensation",
       "creator": "UberFazz",
-      "source": "",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -44569,11 +47062,13 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-12-02T19:35:26Z"
     },
@@ -44581,9 +47076,9 @@
       "beatmapset_id": 1278431,
       "artist": "Camallia",
       "title": "Tera's Collection ([Crz]Noire) [ Perfect Cherry Storm]",
-      "creator": "",
+      "creator": "[Crz]Noire",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44591,17 +47086,18 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
-      "beatmapset_id": 1280750,
-      "artist": "FELT",
-      "title": "COLORS",
-      "creator": "cocona",
+      "beatmapset_id": 1280194,
+      "artist": "seatrus",
+      "title": "MONONOKE",
+      "creator": "Realazy",
       "source": "",
       "status": "ranked",
       "modes": [
@@ -44611,11 +47107,74 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-07-30T18:14:10Z"
+    },
+    {
+      "beatmapset_id": 1280488,
+      "artist": "Silver Forest",
+      "title": "Todokanai Eien no Kyori",
+      "creator": "ConsumerOfBean",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-02-18T16:46:24Z"
+    },
+    {
+      "beatmapset_id": 1280750,
+      "artist": "FELT",
+      "title": "COLORS",
+      "creator": "cocona",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "osucollector:6907",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
       "osu_last_updated": "2021-12-23T21:53:03Z"
+    },
+    {
+      "beatmapset_id": 1281400,
+      "artist": "AVTechNO!",
+      "title": "boku-boku SuketchP Remix",
+      "creator": "-Tynamo",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2020-11-01T21:06:07Z"
     },
     {
       "beatmapset_id": 1281563,
@@ -44643,7 +47202,7 @@
       "artist": "Akatsuki Records",
       "title": "KARMANATIONS",
       "creator": "-Rik-",
-      "source": "",
+      "source": "東方夢時空　～ Pantasmagria of Dim.Dream",
       "status": "ranked",
       "modes": [
         "osu"
@@ -44656,7 +47215,8 @@
         "osucollector:1407",
         "osucollector:6907",
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44687,7 +47247,7 @@
       "artist": "KISIDA KYODAN & THE AKEBOSI ROCKETS",
       "title": "secret philosophy (Cut Ver.)",
       "creator": "Serafeim",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -44696,12 +47256,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-02-20T23:59:47Z"
     },
@@ -44730,7 +47292,7 @@
       "artist": "Xi",
       "title": "Shoujo Kisoukyoku ~ Speed Battle",
       "creator": "Leader",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -44743,7 +47305,9 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44753,9 +47317,9 @@
       "beatmapset_id": 1287937,
       "artist": "nomico",
       "title": "Boku no owari o kazaru hana (lgzzz) [Owaru Hana]",
-      "creator": "",
+      "creator": "lgzzz",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44763,7 +47327,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44815,6 +47380,27 @@
       "osu_last_updated": "2020-12-26T23:32:33Z"
     },
     {
+      "beatmapset_id": 1289097,
+      "artist": "Kanpyohgo",
+      "title": "Unmei no Dark Side -Rolling Gothic mix",
+      "creator": "Suicune3",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-12-16T06:30:43Z"
+    },
+    {
       "beatmapset_id": 1289851,
       "artist": "UNDEAD CORPORATION",
       "title": "Kasha no Sakebu Yoru ni",
@@ -44832,11 +47418,72 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2020-10-31T02:34:42Z"
+    },
+    {
+      "beatmapset_id": 1291267,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "Eiya 'Imperishable Challengers'",
+      "creator": "captin1",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1291579,
+      "artist": "FROZEN QUALIA",
+      "title": "Aisubeki Hibi e",
+      "creator": "Beomsan",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
       ],
       "confidence": "candidate",
       "last_checked": "2026-08-15",
-      "osu_last_updated": "2020-10-31T02:34:42Z"
+      "osu_last_updated": "2020-12-25T16:30:44Z"
+    },
+    {
+      "beatmapset_id": 1291888,
+      "artist": "PHOENIX Project",
+      "title": "Apparitions Stalk the Night",
+      "creator": "dectopia",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
     },
     {
       "beatmapset_id": 1292214,
@@ -44852,7 +47499,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44862,9 +47510,9 @@
       "beatmapset_id": 1295013,
       "artist": "LeaF",
       "title": "Wizdomiot (Zestiri9) [ Jealousy]",
-      "creator": "",
+      "creator": "Zestiri9",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44872,7 +47520,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44882,9 +47531,9 @@
       "beatmapset_id": 1295068,
       "artist": "tasofro",
       "title": "Cosmic Mind ([Crz]hinako1804) [Da Bei Zhou x1.05_P]",
-      "creator": "",
+      "creator": "[Crz]hinako1804",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44892,7 +47541,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44903,7 +47553,7 @@
       "artist": "ShinRa-Bansho",
       "title": "Paragraph 14",
       "creator": "Lugu",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -44913,11 +47563,14 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-01-19T21:10:35Z"
     },
@@ -44935,7 +47588,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44967,9 +47621,9 @@
       "beatmapset_id": 1298744,
       "artist": "REDALiCE & aran",
       "title": "Sweet Requiem (Irone OSU) [Luscious Chant]",
-      "creator": "",
+      "creator": "Irone OSU",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44977,7 +47631,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -44987,9 +47642,9 @@
       "beatmapset_id": 1298827,
       "artist": "3L",
       "title": "Miracle Hinacle (Zestiri9) [Misfortune Dispelln]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -44997,7 +47652,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45020,7 +47676,9 @@
         "known_touhou_artist",
         "osucollector:6907",
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45030,9 +47688,9 @@
       "beatmapset_id": 1303204,
       "artist": "Camellia",
       "title": "werewolf howls. ['Growling' Long ver.] (Zestiri9) [Star Fang]",
-      "creator": "",
+      "creator": "Zestiri9",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45040,7 +47698,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45050,9 +47709,9 @@
       "beatmapset_id": 1304805,
       "artist": "Kobaryo",
       "title": "CU73-D3V1L (Tamaki Iroha) [wyyyyw's LUN47IC]",
-      "creator": "",
+      "creator": "Tamaki Iroha",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45060,7 +47719,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45070,9 +47730,9 @@
       "beatmapset_id": 1306263,
       "artist": "Various",
       "title": "YSOF#2 -Fairy- (YuEast 2018) [Morimori Atsushi - Tits or get the fuck out!!]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45080,7 +47740,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45091,7 +47752,7 @@
       "artist": "Frozen Starfall",
       "title": "Farewell (feat. Sasi)",
       "creator": "eiri-",
-      "source": "",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -45100,12 +47761,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-01-13T21:33:05Z"
     },
@@ -45113,9 +47776,9 @@
       "beatmapset_id": 1306399,
       "artist": "Nanahira",
       "title": "STAND UP! ([Crz]hinako1804) [Full]",
-      "creator": "",
+      "creator": "[Crz]hinako1804",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45123,7 +47786,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45133,9 +47797,9 @@
       "beatmapset_id": 1306401,
       "artist": "ShinRa-Bansho",
       "title": "Pink Kurage to, Sotto, Kiss o Shita. (Irone OSU) [Affable Affection]",
-      "creator": "",
+      "creator": "Irone OSU",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45143,7 +47807,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45173,9 +47838,9 @@
       "beatmapset_id": 1306448,
       "artist": "SOUND HOLIC",
       "title": "Touhou Hakureisou (Tamaki Iroha) [Amagai's Extra Stage(Edit)]",
-      "creator": "",
+      "creator": "Tamaki Iroha",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45183,7 +47848,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45205,7 +47871,8 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45276,9 +47943,9 @@
       "beatmapset_id": 1309375,
       "artist": "BUTAOTOME",
       "title": "Towa no Maigo (Irone OSU) [Foolish Fright 1.2x (216bpm)]",
-      "creator": "",
+      "creator": "Irone OSU",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45286,7 +47953,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45316,9 +47984,9 @@
       "beatmapset_id": 1310043,
       "artist": "Morimori Atsushi",
       "title": "Toono Gensou Monogatari (MRM REMIX) (Irone OSU) [Surreal Fantasy]",
-      "creator": "",
+      "creator": "Irone OSU",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45326,7 +47994,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45336,9 +48005,9 @@
       "beatmapset_id": 1311414,
       "artist": "Xe",
       "title": "Satori Maiden ~ 3rd Eye (Zestiri9) [Satire Deity 0.95x]",
-      "creator": "",
+      "creator": "Zestiri9",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45346,18 +48015,63 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:1st"
+        "tmc:1st",
+        "tournament:466"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1316298,
+      "artist": "ShibayanRecords feat. 3L",
+      "title": "Maigo no Echo",
+      "creator": "Chai the Tea",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-06-09T18:00:38Z"
+    },
+    {
+      "beatmapset_id": 1316401,
+      "artist": "ShinRa-Bansho",
+      "title": "lunatic love baby you",
+      "creator": "Wither",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-01-14T03:31:05Z"
+    },
+    {
       "beatmapset_id": 1316489,
       "artist": "ShinRa-Bansho",
       "title": "Ningen ga Daisuki na Kowareta Youkai no Uta ShinRa-Bansho Ver",
       "creator": "CebollaVladimir",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -45367,10 +48081,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-05-09T21:16:18Z"
     },
@@ -45378,9 +48094,9 @@
       "beatmapset_id": 1317026,
       "artist": "Dat File Records, kju:8",
       "title": "Greenwich burned down III (GetDatGreen) [Trapped]",
-      "creator": "",
+      "creator": "GetDatGreen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45388,7 +48104,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45399,7 +48116,7 @@
       "artist": "Tatsh feat. Sariyajin",
       "title": "FOUR SEASONS OF LONELINESS",
       "creator": "Bellicose",
-      "source": "",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -45408,12 +48125,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-01-15T18:30:50Z"
     },
@@ -45433,7 +48152,8 @@
       "evidence": [
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45567,6 +48287,28 @@
       "osu_last_updated": "2021-01-02T22:15:46Z"
     },
     {
+      "beatmapset_id": 1330649,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Kasokeshi Mono e",
+      "creator": "Sytex",
+      "source": "osu!",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "mapper_tags",
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-20T21:20:18Z"
+    },
+    {
       "beatmapset_id": 1331153,
       "artist": "ShinRa-Bansho",
       "title": "Kakumei no bullet",
@@ -45610,6 +48352,26 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1335353,
+      "artist": "Metrik",
+      "title": "We Got It (feat. Rothwell)",
+      "creator": "evth",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-11-10T19:14:00Z"
     },
     {
       "beatmapset_id": 1335452,
@@ -45704,7 +48466,7 @@
       "artist": "Akatsuki Records",
       "title": "PANDORA66",
       "creator": "Lugu",
-      "source": "",
+      "source": "東方心綺楼　～ Hopeless Masquerade.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -45713,21 +48475,23 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-07-08T19:12:32Z"
     },
     {
       "beatmapset_id": 1346056,
       "artist": "Diao Ye Zong feat. Meramipop",
       "title": "Sekaijuu no Dare yori mo",
       "creator": "Nao Tomori",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -45736,12 +48500,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-02-16T00:29:13Z"
     },
@@ -45767,6 +48533,27 @@
       "osu_last_updated": "2021-02-01T20:09:00Z"
     },
     {
+      "beatmapset_id": 1347587,
+      "artist": "ALiCE'S EMOTiON",
+      "title": "Ghostly Parapara Ship (Hardcore Edit)",
+      "creator": "-Rik-",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-09-08T19:12:23Z"
+    },
+    {
       "beatmapset_id": 1347987,
       "artist": "Water Color Melody.",
       "title": "MotherGoose o Kikinagara",
@@ -45789,7 +48576,7 @@
     {
       "beatmapset_id": 1349559,
       "artist": "C.H.S",
-      "title": "Luv*Lab*Poison 22ate! (Cut Ver.)",
+      "title": "C.H.S- Luv\\*Lab\\*Poison 22ate! (Cut Ver.) (Hytex) [Insane]",
       "creator": "Hytex",
       "source": "東方花映塚 ～ Phantasmagoria of Flower View.",
       "status": "graveyard",
@@ -45848,6 +48635,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-03-14T18:10:06Z"
+    },
+    {
+      "beatmapset_id": 1357813,
+      "artist": "Akatsuki Records feat. ayaponzu*",
+      "title": "Daikirai Scarlet",
+      "creator": "moonlightleaf",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-06-13T05:34:33Z"
     },
     {
       "beatmapset_id": 1359291,
@@ -45928,9 +48736,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-06-06T11:48:30Z"
     },
@@ -45938,9 +48747,9 @@
       "beatmapset_id": 1366426,
       "artist": "Camellia",
       "title": "CLOUDY WITH INTERMITTENT RAIN (Cut Ver.) (Salty Mermaid) [Flowing Skies]",
-      "creator": "",
+      "creator": "Salty Mermaid",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -45948,7 +48757,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -45975,6 +48785,26 @@
       "osu_last_updated": "2021-04-09T19:43:54Z"
     },
     {
+      "beatmapset_id": 1368017,
+      "artist": "ZUN",
+      "title": "Tsukidokei ~ Luna Dial",
+      "creator": "ConsumerOfBean",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1368836,
       "artist": "BLANKFIELD",
       "title": "Witching Dream",
@@ -45999,7 +48829,7 @@
       "artist": "Rin",
       "title": "Moriya set 04 ReEdit ~ Unmei no Dark Side",
       "creator": "Halfslashed",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -46008,11 +48838,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2023-08-11T17:17:21Z"
     },
     {
       "beatmapset_id": 1376085,
@@ -46075,9 +48907,10 @@
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -46086,7 +48919,7 @@
       "artist": "ZUN",
       "title": "Toragara no Bishamonten",
       "creator": "Halfslashed",
-      "source": "",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -46097,11 +48930,13 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-10-28T16:29:45Z"
     },
     {
       "beatmapset_id": 1381715,
@@ -46122,6 +48957,67 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1381824,
+      "artist": "ISOMERZ (DJ Raisei + seatrus)",
+      "title": "Symmetric",
+      "creator": "Realazy",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-10-02T12:38:21Z"
+    },
+    {
+      "beatmapset_id": 1388780,
+      "artist": "Rin",
+      "title": "Kishinjou set 01 ~ Mist Lake",
+      "creator": "Luminiscental",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "mapper_tags",
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-02-28T23:20:42Z"
+    },
+    {
+      "beatmapset_id": 1388906,
+      "artist": "Raphlesia & BilliumMoto",
+      "title": "My Love",
+      "creator": "Mao",
+      "source": "A Labour of Love",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-09-28T17:04:08Z"
     },
     {
       "beatmapset_id": 1391331,
@@ -46191,9 +49087,9 @@
       "beatmapset_id": 1396066,
       "artist": "FELT",
       "title": "Puppet in the Dark (Part2 : Buried Away) ([Crz]hinako1804) [INTER]",
-      "creator": "",
+      "creator": "[Crz]hinako1804",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46201,7 +49097,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -46211,9 +49108,9 @@
       "beatmapset_id": 1397860,
       "artist": "t+pazolite",
       "title": "World End's Yama Xanadu (Shoegazer) [Parousia 1.2x (228bpm)]",
-      "creator": "",
+      "creator": "Shoegazer",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46221,11 +49118,34 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1397998,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Necromanticism",
+      "creator": "Nerujikan",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-02-17T20:29:05Z"
     },
     {
       "beatmapset_id": 1404277,
@@ -46252,12 +49172,34 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1408216,
+      "artist": "narco & capo",
+      "title": "Fragments",
+      "creator": "Ambrew",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "catch",
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-19T23:32:42Z"
+    },
+    {
       "beatmapset_id": 1409056,
       "artist": "Kohmi Hirose",
       "title": "Promise (Kamikaze) [GET DOWN]",
-      "creator": "",
+      "creator": "Kamikaze",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46265,7 +49207,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -46276,7 +49219,7 @@
       "artist": "Suwawa Records",
       "title": "Lunatic Re:DriVe",
       "creator": "Doomsdaddy",
-      "source": "",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -46285,11 +49228,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-03-25T15:32:07Z"
     },
     {
       "beatmapset_id": 1414107,
@@ -46319,9 +49263,9 @@
       "beatmapset_id": 1415108,
       "artist": "REDALiCE",
       "title": "Kizuato (Xingyue) [ANEGL]",
-      "creator": "",
+      "creator": "Xingyue",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46329,7 +49273,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -46340,7 +49285,7 @@
       "artist": "TatshMusicCircle",
       "title": "Yoiyami no Tsuki ni Dakarete feat. Ayane",
       "creator": "Raijodo",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -46349,20 +49294,22 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:829"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-04-22T17:55:39Z"
     },
     {
       "beatmapset_id": 1415963,
       "artist": "mocchie",
       "title": "Nyan Nyan Drive (D: (Penguinosity) [mrow >:3 ~ 1.25]",
-      "creator": "",
+      "creator": "Penguinosity",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46370,11 +49317,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1417304,
+      "artist": "Rin",
+      "title": "Eientewi set 17 ~ Eastern Youkai Beauty",
+      "creator": "_Chroma",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-03-30T10:18:10Z"
     },
     {
       "beatmapset_id": 1420652,
@@ -46460,9 +49429,9 @@
       "beatmapset_id": 1434343,
       "artist": "Demetori",
       "title": "Higan no dorei \\~ One Conclusion (Tidek) [Old Rain]",
-      "creator": "",
+      "creator": "Tidek",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46470,7 +49439,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -46480,9 +49450,9 @@
       "beatmapset_id": 1435835,
       "artist": "Camellia",
       "title": "werewolf howls. (lemonguy) [LNFINITE.]",
-      "creator": "",
+      "creator": "lemonguy",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46491,19 +49461,42 @@
       "original_themes": [],
       "evidence": [
         "tmc:3rd",
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1437179,
+      "artist": "U2 Akiyama",
+      "title": "Flowering Night (Cut Ver.)",
+      "creator": "Ryaldin",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-07T10:45:45Z"
+    },
+    {
       "beatmapset_id": 1438522,
       "artist": "DJKurara",
       "title": "White Hair Little Swords Girl (guden) [Massacre]",
-      "creator": "",
+      "creator": "guden",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46511,7 +49504,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -46539,11 +49533,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1441555,
+      "artist": "sound sepher",
+      "title": "Lunate Elf",
+      "creator": "Pumice",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1441911,
       "artist": "NIWASHI",
       "title": "Kemuri",
       "creator": "Down",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -46556,11 +49570,13 @@
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-09-01T04:16:08Z"
     },
     {
       "beatmapset_id": 1442363,
@@ -46598,7 +49614,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -46626,11 +49643,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1457127,
+      "artist": "Akatsuki Records",
+      "title": "VENTEN",
+      "creator": "TVRemote",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:731"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1461660,
       "artist": "senya",
       "title": "Sanzen Sekai",
       "creator": "Serafeim",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -46641,11 +49678,12 @@
       "evidence": [
         "osucollector:1405",
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:526"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-06-18T07:36:39Z"
     },
     {
       "beatmapset_id": 1464714,
@@ -46668,6 +49706,26 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1468307,
+      "artist": "Tatsh feat. Tsukiko",
+      "title": "Floating Darkness",
+      "creator": "Cheri",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1469689,
       "artist": "Foreground Eclipse",
       "title": "You Can't Explain Anything Without The Word 'Destruction' / Destruction",
@@ -46684,6 +49742,89 @@
         "osucollector:6907"
       ],
       "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1469780,
+      "artist": "t+pazolite",
+      "title": "Kamsabi",
+      "creator": "404_N0tF0und",
+      "source": "WACCA",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "mapper_tags",
+        "tournament_candidate:526"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-06-01T06:34:54Z"
+    },
+    {
+      "beatmapset_id": 1470413,
+      "artist": "Akatsuki Records",
+      "title": "KARMANATIONS",
+      "creator": "-Kirigiri",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1471439,
+      "artist": "Yuuhei Satellite feat. Marcia",
+      "title": "Heikousen no Koiwazurai",
+      "creator": "Serafeim",
+      "source": "東方虹龍洞　～ Unconnected Marketeers.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:526",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-04-22T09:09:57Z"
+    },
+    {
+      "beatmapset_id": 1471755,
+      "artist": "FELT",
+      "title": "Lost My Way",
+      "creator": "Lunicia",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -46713,7 +49854,7 @@
       "artist": "Touhou LostWord x RichaadEB",
       "title": "Lost Word Chronicle",
       "creator": "sahuang",
-      "source": "",
+      "source": "東方LostWord",
       "status": "ranked",
       "modes": [
         "osu"
@@ -46724,11 +49865,13 @@
       "evidence": [
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-08-10T18:35:42Z"
     },
     {
       "beatmapset_id": 1483410,
@@ -46752,12 +49895,32 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1485352,
+      "artist": "ZUN",
+      "title": "Crazy Backup Dancers",
+      "creator": "ConsumerOfBean",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1490202,
       "artist": "Masayoshi Minoshima feat. nomico",
       "title": "Bad Apple (Camellia's \"Bad Psy!!\" Remix) (guden) [Another 1.2x (192bpm)]",
-      "creator": "",
+      "creator": "guden",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46765,11 +49928,72 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1491009,
+      "artist": "ShinRa-Bansho",
+      "title": "Pink Kurage to, Sotto, Kiss o Shita.",
+      "creator": "Skydiver",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1491216,
+      "artist": "TUMENECO VS. GET IN THE RING",
+      "title": "Yumeuta - Tokubetsu na Futari no Uta",
+      "creator": "Asagi",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1492550,
+      "artist": "onoken",
+      "title": "ZADAMGA",
+      "creator": "Down",
+      "source": "pop'n music ラピストリア",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-10-28T15:08:23Z"
     },
     {
       "beatmapset_id": 1495860,
@@ -46797,9 +50021,9 @@
       "beatmapset_id": 1496109,
       "artist": "er",
       "title": "Super Izanagi Object (Evening) [Da [1.3x Rate]]",
-      "creator": "",
+      "creator": "Evening",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -46807,7 +50031,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -46899,7 +50124,7 @@
       "artist": "ESQUARIA (ruon) feat. Meramipop",
       "title": "Unknown x known",
       "creator": "AYE1337",
-      "source": "",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -46908,18 +50133,20 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-06-27T17:23:29Z"
     },
     {
       "beatmapset_id": 1504033,
       "artist": "Foreground Eclipse",
       "title": "Vermillion Halo",
       "creator": "attendant",
-      "source": "",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -46928,14 +50155,16 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:526"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-07-19T18:55:57Z"
     },
     {
       "beatmapset_id": 1504348,
@@ -46978,6 +50207,51 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1512410,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Everything Will Freeze II",
+      "creator": "Camo",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-12-06T01:48:26Z"
+    },
+    {
+      "beatmapset_id": 1513531,
+      "artist": "Unlucky Morpheus",
+      "title": "Le Cirque de Sept Couleurs",
+      "creator": "PixelGlory",
+      "source": "東方怪綺談　～ Mystic Square.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-08-07T21:28:33Z"
+    },
+    {
       "beatmapset_id": 1513750,
       "artist": "A-One feat. ayaponzu*",
       "title": "Justice Monster",
@@ -46995,7 +50269,8 @@
         "osucollector:1407",
         "osucollector:6907",
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -47006,7 +50281,7 @@
       "artist": "RD-Sounds feat. Meramipop/nayuta",
       "title": "Shiten",
       "creator": "tokiko",
-      "source": "",
+      "source": "東方天空璋　～ Hidden Star in Four Seasons.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -47015,12 +50290,14 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "osu_source",
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2021-08-10T20:16:17Z"
     },
     {
       "beatmapset_id": 1523919,
@@ -47041,6 +50318,29 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1525635,
+      "artist": "IOSYS",
+      "title": "Danzai Yamaxanadu!",
+      "creator": "Annabel",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-02-05T04:45:23Z"
     },
     {
       "beatmapset_id": 1530517,
@@ -47079,9 +50379,10 @@
       "original_themes": [],
       "evidence": [
         "osucollector:1407",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -47109,9 +50410,9 @@
       "beatmapset_id": 1532787,
       "artist": "FELT",
       "title": "FELT LN Collection (-[Ulazis]-) [Uta kata no to zenu]",
-      "creator": "",
+      "creator": "-[Ulazis]-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -47119,7 +50420,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -47188,6 +50490,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1542974,
+      "artist": "SOUND HOLIC",
+      "title": "Optical Cellophane",
+      "creator": "rollpan",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-08-08T04:01:58Z"
     },
     {
       "beatmapset_id": 1543394,
@@ -47269,6 +50592,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-09-15T23:31:48Z"
+    },
+    {
+      "beatmapset_id": 1550606,
+      "artist": "SOUND HOLIC",
+      "title": "Swing and Jive !",
+      "creator": "waefwerf",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:829"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-01-05T17:01:33Z"
     },
     {
       "beatmapset_id": 1550807,
@@ -47374,9 +50718,9 @@
       "beatmapset_id": 1562738,
       "artist": "uma feat. SHACHI",
       "title": "take me to the moon (Ballistic) [Daydream]",
-      "creator": "",
+      "creator": "Ballistic",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -47384,7 +50728,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -47425,9 +50770,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -47456,9 +50802,9 @@
       "beatmapset_id": 1564347,
       "artist": "nmk feat. Kanaeyume",
       "title": "Memoria (Mipha-) [miphather]",
-      "creator": "",
+      "creator": "Mipha-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -47466,7 +50812,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -47533,6 +50880,49 @@
       "osu_last_updated": "2024-08-08T12:09:47Z"
     },
     {
+      "beatmapset_id": 1573851,
+      "artist": "ZUN",
+      "title": "Hellfire Mantle",
+      "creator": "TheBear53",
+      "source": "",
+      "status": "wip",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1574221,
+      "artist": "Frozen Starfall",
+      "title": "Crystal Dream (feat. Selphius)",
+      "creator": "Luminiscental",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "mapper_tags",
+        "tournament_candidate:731",
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-09-21T23:42:18Z"
+    },
+    {
       "beatmapset_id": 1575475,
       "artist": "BUTAOTOME",
       "title": "The fear is oneself",
@@ -47595,11 +50985,32 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1579006,
+      "artist": "LeaF",
+      "title": "Armageddon",
+      "creator": "rip s",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2021-11-09T15:00:21Z"
+    },
+    {
       "beatmapset_id": 1579161,
       "artist": "senya",
       "title": "Iro wa Jou e to Izanau",
       "creator": "Okoratu",
-      "source": "",
+      "source": "東方Project",
       "status": "ranked",
       "modes": [
         "osu"
@@ -47610,11 +51021,33 @@
       "evidence": [
         "osucollector:6907",
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2023-01-07T23:01:58Z"
+    },
+    {
+      "beatmapset_id": 1583787,
+      "artist": "A-One feat. Shihori",
+      "title": "Magic Girl !!",
+      "creator": "Sakurauchi Riko",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-17T19:04:06Z"
     },
     {
       "beatmapset_id": 1588153,
@@ -47650,9 +51083,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -47660,9 +51094,9 @@
       "beatmapset_id": 1589946,
       "artist": "Camellia",
       "title": "Ultimate Ascension (Penguinosity) [Vitality 1.1]",
-      "creator": "",
+      "creator": "Penguinosity",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -47670,7 +51104,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -47740,6 +51175,27 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1597785,
+      "artist": "IRON ATTACK!",
+      "title": "INEXPERIENCE",
+      "creator": "DeviousPanda",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163",
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1597824,
       "artist": "ZUN",
       "title": "Shigen no Beat ~ Pristine Beat",
@@ -47753,7 +51209,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -47778,6 +51235,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1605663,
+      "artist": "ZUN",
+      "title": "Kurayami no Kazaana",
+      "creator": "Teosh",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-04-04T15:13:57Z"
     },
     {
       "beatmapset_id": 1607795,
@@ -47823,9 +51301,9 @@
       "beatmapset_id": 1610573,
       "artist": "Rerun",
       "title": "icicle,icicle (YuEast 2018) [noodle,noodle x1.05]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -47833,7 +51311,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -47843,9 +51322,9 @@
       "beatmapset_id": 1611863,
       "artist": "UNDEAD CORPORATION",
       "title": "Embraced by the Flame (XingRen) [XingRen's 14]",
-      "creator": "",
+      "creator": "Doshowz",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -47853,7 +51332,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -47863,9 +51343,9 @@
       "beatmapset_id": 1612762,
       "artist": "ccy",
       "title": "Another Apple (YuEast 2018) [YuEast's 2025 LN Ver.]",
-      "creator": "",
+      "creator": "cherrychou",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -47873,7 +51353,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -47900,11 +51381,11 @@
       "osu_last_updated": null
     },
     {
-      "beatmapset_id": 1615177,
-      "artist": "Silver Forest",
-      "title": "Tsurupettan (Game Ver.)",
-      "creator": "Bloxi",
-      "source": "",
+      "beatmapset_id": 1614363,
+      "artist": "Akatsuki Records",
+      "title": "KilLove Fireproof!",
+      "creator": "Wither",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -47913,11 +51394,34 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "forum_queue:sd_touhou",
+        "osu_source"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2025-06-07T11:19:25Z"
+    },
+    {
+      "beatmapset_id": 1615177,
+      "artist": "Silver Forest",
+      "title": "Tsurupettan (Game Ver.)",
+      "creator": "Bloxi",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "osucollector:6907",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-08-06T11:17:32Z"
     },
     {
       "beatmapset_id": 1616038,
@@ -47940,12 +51444,32 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1616043,
+      "artist": "REDALiCE",
+      "title": "Taboo tears you up 2017",
+      "creator": "Dada",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1619719,
       "artist": "Naukorin",
       "title": "Luv of Magical Synth (-Deepdive-) [Adoration]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -47953,9 +51477,30 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1621093,
+      "artist": "Foreground Eclipse",
+      "title": "Dear, Are You Getting Sober",
+      "creator": "Ekee",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament_candidate:829"
+      ],
+      "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -48004,9 +51549,9 @@
       "beatmapset_id": 1628191,
       "artist": "Kolaa",
       "title": "Witches Rule (Miscedence) [SV]",
-      "creator": "",
+      "creator": "Miscedence",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48014,7 +51559,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48024,9 +51570,9 @@
       "beatmapset_id": 1628528,
       "artist": "Foreground Eclipse",
       "title": "Last Liar Standing (eZmmR) [Exteeeending Aaaaarm]",
-      "creator": "",
+      "creator": "eZmmR",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48034,7 +51580,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48065,9 +51612,9 @@
       "beatmapset_id": 1631776,
       "artist": "Adust Rain",
       "title": "psychology (FelixSpade) [despondent 1.1x (168bpm)]",
-      "creator": "",
+      "creator": "FelixSpade",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48075,7 +51622,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48095,9 +51643,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -48137,7 +51686,9 @@
       "evidence": [
         "osucollector:6907",
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48268,9 +51819,9 @@
       "beatmapset_id": 1642953,
       "artist": "Shiiki Reku",
       "title": "IDOL (-Deepdive-) [Haniwa]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48278,11 +51829,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1644658,
+      "artist": "Tatsh",
+      "title": "FOUR SEASONS OF LONELINESS",
+      "creator": "LY0N009",
+      "source": "東方星蓮船　～ Undefined Fantastic Object",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-09-25T06:23:20Z"
     },
     {
       "beatmapset_id": 1645394,
@@ -48299,9 +51872,10 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -48329,9 +51903,9 @@
       "beatmapset_id": 1648145,
       "artist": "Shiiki Reku",
       "title": "Rhythmy (-Deepdive-) [Till I'm laid]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48339,7 +51913,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48349,9 +51924,9 @@
       "beatmapset_id": 1650227,
       "artist": "ZYTOKINE",
       "title": "Dancing Dollz feat. cold kiss - REDALiCE Remix ([OSC]Amagai) [1.2x Edit]",
-      "creator": "",
+      "creator": "[OSC]Amagai",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48359,7 +51934,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48369,9 +51945,9 @@
       "beatmapset_id": 1655733,
       "artist": "FELT",
       "title": "Crescent Moon ([Crz]hinako1804]) [Bereft Emotion]",
-      "creator": "",
+      "creator": "[Crz]hinako1804",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48379,7 +51955,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48429,9 +52006,9 @@
       "beatmapset_id": 1660916,
       "artist": "Marcia",
       "title": "Ashita Chiru Unmei Nara (IA daisuki) [LuNatic]",
-      "creator": "",
+      "creator": "IA daisuki",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48439,7 +52016,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48449,9 +52027,9 @@
       "beatmapset_id": 1661860,
       "artist": "Hachimitsu Lemon",
       "title": "far away (YuEast 2018) [Nocturne]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48460,7 +52038,9 @@
       "original_themes": [],
       "evidence": [
         "tmc:2nd",
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48470,9 +52050,9 @@
       "beatmapset_id": 1661988,
       "artist": "Momokami\\/SPACELECTRO",
       "title": "DANCING FOX!!! ([Crz]hinako1804]) [Pure Furies]",
-      "creator": "",
+      "creator": "[Crz]hinako1804",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48480,7 +52060,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48490,9 +52071,9 @@
       "beatmapset_id": 1661989,
       "artist": "SOUND HOLIC",
       "title": "PAIN DIED AGAIN (YuEast 2018) [Himitsu.]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48500,7 +52081,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48531,7 +52113,7 @@
       "artist": "komso",
       "title": "Eien no Shunmu",
       "creator": "Shurelia",
-      "source": "",
+      "source": "東方憑依華　～ Antinomy of Common Flowers.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -48541,7 +52123,8 @@
       "original_themes": [],
       "evidence": [
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48551,9 +52134,9 @@
       "beatmapset_id": 1665834,
       "artist": "t+pazolite feat. Rizna",
       "title": "Ghostly Parapara Ship (Horror struck Edit) (-Deepdive-) [Parapara Night 1.1x (242bpm) OD8]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48561,7 +52144,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48591,9 +52175,9 @@
       "beatmapset_id": 1665954,
       "artist": "Spacelectro feat. Shiiki Reku",
       "title": "Rhythmy [Joulez Remix] (LeiN-) [Equinox // 4K 1.35x (232bpm)]",
-      "creator": "",
+      "creator": "LeiN-",
       "source": "",
-      "status": "unknown",
+      "status": "wip",
       "modes": [
         "mania"
       ],
@@ -48601,7 +52185,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48632,9 +52217,9 @@
       "beatmapset_id": 1670259,
       "artist": "ClumsyRecord",
       "title": "Naughty Kitten (Blue\\_Potion) [Naughty Streams 0.95x]",
-      "creator": "",
+      "creator": "Blue_Potion",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48642,7 +52227,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48652,9 +52238,9 @@
       "beatmapset_id": 1670260,
       "artist": "Akiyama Uni",
       "title": "Touhou Hisouten (Blue\\_Potion) [Streams Rhapsody]",
-      "creator": "",
+      "creator": "Blue_Potion",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48662,7 +52248,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48682,9 +52269,51 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1674037,
+      "artist": "IOSYS feat. Asana",
+      "title": "star river",
+      "creator": "Pache Knowledge",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-25T00:32:47Z"
+    },
+    {
+      "beatmapset_id": 1676028,
+      "artist": "Cle",
+      "title": "Broken Moon (Remix)",
+      "creator": "cocona",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -48692,9 +52321,9 @@
       "beatmapset_id": 1676381,
       "artist": "LeaF",
       "title": "Arianrhod (hi19hi19) [Mabinogi 1.1x (176bpm)]",
-      "creator": "",
+      "creator": "_Kobii",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48702,7 +52331,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48723,7 +52353,8 @@
       "original_themes": [],
       "evidence": [
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48733,9 +52364,9 @@
       "beatmapset_id": 1678453,
       "artist": "TAMAONSEN",
       "title": "Tailin no Soul ([Crz]hinako1804) [The Spirit of Numen x1.1]",
-      "creator": "",
+      "creator": "[Crz]hinako1804",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48743,7 +52374,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48753,9 +52385,9 @@
       "beatmapset_id": 1680643,
       "artist": "Halozy",
       "title": "Starry Presto (arccat) [LN]",
-      "creator": "",
+      "creator": "Arccat",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48763,7 +52395,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48783,9 +52416,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -48793,9 +52427,9 @@
       "beatmapset_id": 1681554,
       "artist": "ZUN",
       "title": "Mou Uta Shika Kikoenai (IA daisuki) [Stage 1: Night Bird]",
-      "creator": "",
+      "creator": "IA daisuki",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48803,7 +52437,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48813,9 +52448,9 @@
       "beatmapset_id": 1681555,
       "artist": "xi",
       "title": "Q.E.D.-Ripples of 495 years- (cherrychou) [Stage 4: Catadioptricl]",
-      "creator": "",
+      "creator": "cherrychou",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48823,7 +52458,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48833,9 +52469,9 @@
       "beatmapset_id": 1681559,
       "artist": "Mican\\*",
       "title": "Sensitive Crisis (zero2snow) [Stage 3: Ichigo]",
-      "creator": "",
+      "creator": "zero2snow",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48843,7 +52479,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48853,9 +52490,9 @@
       "beatmapset_id": 1681566,
       "artist": "Kyou1110",
       "title": "Revavavavava Ideoloololololololo (\\_-Deepdive-) [Stage 5: Reverse Ideology]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48863,7 +52500,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -48873,9 +52511,9 @@
       "beatmapset_id": 1681573,
       "artist": "Amane",
       "title": "Through The Tunnel (eZmmR) [Stage 2: Fox Winder]",
-      "creator": "",
+      "creator": "eZmmR",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48883,11 +52521,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1682269,
+      "artist": "Akatsuki Records",
+      "title": "Necromantic",
+      "creator": "Albert Pama",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "mapper_tags",
+        "tournament_candidate:731"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-01-24T10:21:58Z"
     },
     {
       "beatmapset_id": 1682383,
@@ -48914,7 +52574,7 @@
       "artist": "Down",
       "title": "Ekoro",
       "creator": "Down",
-      "source": "",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -48925,11 +52585,12 @@
       "evidence": [
         "osucollector:6907",
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2022-03-06T02:49:48Z"
     },
     {
       "beatmapset_id": 1684273,
@@ -48956,9 +52617,9 @@
       "beatmapset_id": 1685095,
       "artist": "Mei Ayakura",
       "title": "MANIACAL DEGREE (IA daisuki) [Hard]",
-      "creator": "",
+      "creator": "IA daisuki",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -48966,18 +52627,62 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1685595,
+      "artist": "Konpeki Studio",
+      "title": "Peeping Heart",
+      "creator": "Civafu",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-01-01T09:59:45Z"
+    },
+    {
+      "beatmapset_id": 1685864,
+      "artist": "ShinRa-Bansho",
+      "title": "U r my Nightmare",
+      "creator": "Wither",
+      "source": "東方憑依華　～ Antinomy of Common Flowers.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-01-20T18:18:42Z"
+    },
+    {
       "beatmapset_id": 1686490,
       "artist": "Morimori Atsushi",
       "title": "Txxs or get the fxxk out!!",
       "creator": "Luscent",
-      "source": "",
+      "source": "東方神霊廟　～ Ten Desires.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -48987,19 +52692,22 @@
       "original_themes": [],
       "evidence": [
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163",
+        "tournament:828",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2022-08-20T19:15:58Z"
     },
     {
       "beatmapset_id": 1693521,
       "artist": "FELT",
       "title": "JOURNEY (-Deepdive-) [Caelum]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49007,7 +52715,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49054,12 +52763,32 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1699015,
+      "artist": "ZUN",
+      "title": "Magical Storm",
+      "creator": "ConsumerOfBean",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1699580,
       "artist": "SOUND HOLIC",
       "title": "Zen Jinrui no Hisoutensoku [DJ Command Remix] (feat. /Nana Takahashi) ([GB]Sanae) [Extra]",
-      "creator": "",
+      "creator": "[GB]Sanae",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49067,7 +52796,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49077,9 +52807,9 @@
       "beatmapset_id": 1700387,
       "artist": "TAMAONSEN",
       "title": "Touhou Tanoshii feat. Matsu (YuEast 2018) [x1.00]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49087,7 +52817,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49097,9 +52828,9 @@
       "beatmapset_id": 1700816,
       "artist": "Rolling Contact",
       "title": "Jerking Zipper ([OSC]Amagai) [Extra Stage]",
-      "creator": "",
+      "creator": "[OSC]Amagai",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49107,7 +52838,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49117,9 +52849,9 @@
       "beatmapset_id": 1701047,
       "artist": "Shinra-Bansho",
       "title": "Observers' Theory (-Deepdive-) [Collab Insomnia]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49127,7 +52859,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49137,9 +52870,9 @@
       "beatmapset_id": 1703338,
       "artist": "C-CLAYS",
       "title": "Welcome to Hell ([GB]Mafufu) [Welcome to SV Hell [Edit]]",
-      "creator": "",
+      "creator": "[GB]Mafufu",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49147,7 +52880,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49167,9 +52901,30 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1703912,
+      "artist": "Yuuyu",
+      "title": "Akutagawa Ryuunosuke no Kappa ~ Candid Friend",
+      "creator": "Halfslashed",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -49197,9 +52952,9 @@
       "beatmapset_id": 1705602,
       "artist": "BUTAOTOME",
       "title": "Guuzou Yuutopia ([OSC]Amagai) [Lunatic 1.05x]",
-      "creator": "",
+      "creator": "[OSC]Amagai",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49207,7 +52962,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49217,9 +52973,9 @@
       "beatmapset_id": 1705604,
       "artist": "BUTAOTOME",
       "title": "RAKUEN ([OSC]Amagai) [Lost Paradise]",
-      "creator": "",
+      "creator": "[OSC]Amagai",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49227,7 +52983,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49257,9 +53014,9 @@
       "beatmapset_id": 1706414,
       "artist": "Shinra-Bansho",
       "title": "Kakumei no bullet (-Deepdive-) [Hakurei Danmaku Collab]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49267,7 +53024,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49277,9 +53035,9 @@
       "beatmapset_id": 1709481,
       "artist": "yamata",
       "title": "Like a flower (Amathcat Remix) (-Deepdive-) [Blossom]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49287,7 +53045,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49358,9 +53117,9 @@
       "beatmapset_id": 1714032,
       "artist": "t+pazolite",
       "title": "Luv the Lunatic?? (H1Pur) [Wacky!!])",
-      "creator": "",
+      "creator": "H1Pur",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49368,7 +53127,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49378,9 +53138,9 @@
       "beatmapset_id": 1714434,
       "artist": "SEPHID feat. darkxixin",
       "title": "Fu Xiang Di Xin De Luo Ri Liu Hao ~ Little Raven (-Deepdive-) [Dai Shang Ta De Yan Jing]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49388,7 +53148,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:2nd"
+        "tmc:2nd",
+        "tournament:467"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49408,9 +53169,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -49479,9 +53241,9 @@
       "beatmapset_id": 1718985,
       "artist": "Pizuya feat. Futoumeido",
       "title": "NOiSE - noise- (-Deepdive-) [Attenuation]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49489,7 +53251,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49517,12 +53280,32 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1726109,
+      "artist": "IOSYS",
+      "title": "star river (PUNK IT VER)",
+      "creator": "ent",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1726334,
       "artist": "FELT",
       "title": "START (-Deepdive-) [Rebirth]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49530,7 +53313,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49540,9 +53324,9 @@
       "beatmapset_id": 1726430,
       "artist": "ZUN",
       "title": "At the end of spring (pieerre) [Normal]",
-      "creator": "",
+      "creator": "pieerre",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49550,7 +53334,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49590,9 +53375,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -49618,10 +53404,10 @@
       "osu_last_updated": null
     },
     {
-      "beatmapset_id": 1732806,
-      "artist": "IOSYS",
-      "title": "Choujin Hijiri no air muscle",
-      "creator": "Reiji Maigo",
+      "beatmapset_id": 1731247,
+      "artist": "Silver Forest",
+      "title": "Tsurupettan",
+      "creator": "YokesPai",
       "source": "",
       "status": "graveyard",
       "modes": [
@@ -49631,20 +53417,42 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1732806,
+      "artist": "IOSYS",
+      "title": "Choujin Hijiri no Air Muscle",
+      "creator": "bad kitten",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
         "known_touhou_artist",
+        "osu_source",
         "osucollector:6907"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": "2024-04-01T09:58:26Z"
+      "osu_last_updated": "2025-10-20T08:28:57Z"
     },
     {
       "beatmapset_id": 1736124,
       "artist": "ZUN",
       "title": "Maho no kasajizo ([Crz]hinako1804) [Namoamituofo]",
-      "creator": "",
+      "creator": "[Crz]hinako1804",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49652,7 +53460,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49662,9 +53471,9 @@
       "beatmapset_id": 1738003,
       "artist": "IOSYS",
       "title": "Marisa wa Taihen na Mono wo Nusunde Ikimashita (lemonguy) [LuNatic]",
-      "creator": "",
+      "creator": "lemonguy",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -49672,7 +53481,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49734,11 +53544,33 @@
       "evidence": [
         "known_touhou_artist",
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2023-05-09T18:24:58Z"
+    },
+    {
+      "beatmapset_id": 1755519,
+      "artist": "KISIDA KYODAN & THE AKEBOSI ROCKETS",
+      "title": "ANCIENT FLOWER",
+      "creator": "aeriform",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-07-20T06:13:26Z"
     },
     {
       "beatmapset_id": 1760520,
@@ -49798,6 +53630,26 @@
         "osucollector:6907"
       ],
       "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1769494,
+      "artist": "Kobaryo",
+      "title": "Destructive Little Sister",
+      "creator": "xidorn",
+      "source": "",
+      "status": "wip",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -49875,7 +53727,28 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1779479,
+      "artist": "UNDEAD CORPORATION",
+      "title": "and Say Good Bye...",
+      "creator": "Halfslashed",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49915,7 +53788,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -49975,9 +53849,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -50007,7 +53882,7 @@
       "artist": "IOSYS",
       "title": "Marisa Tanked My Score With an Incredible Hand",
       "creator": "Fubuki1",
-      "source": "",
+      "source": "Touhou",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -50016,11 +53891,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "known_touhou_artist",
+        "tournament:1865",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2022-09-05T05:07:21Z"
     },
     {
       "beatmapset_id": 1787722,
@@ -50041,6 +53918,27 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1790022,
+      "artist": "Astral Trip",
+      "title": "Saigetsu (Koko & Satsuki ga Tenkomori's Sagyou Bougai Remix)",
+      "creator": "toybot",
+      "source": "東方萃夢想　～ Immaterial and Missing Power.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-07-23T14:27:39Z"
     },
     {
       "beatmapset_id": 1790704,
@@ -50076,11 +53974,54 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1791284,
+      "artist": "FELT",
+      "title": "Sounding Beat - pulse",
+      "creator": "AruOtta",
+      "source": "東方輝針城　～ Double Dealing Character.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-06-03T04:16:10Z"
+    },
+    {
+      "beatmapset_id": 1795835,
+      "artist": "sakabato",
+      "title": "Hantensuru Joukei",
+      "creator": "semaphore",
+      "source": "東方文花帖　～ Shoot the Bullet.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-07-23T01:36:47Z"
     },
     {
       "beatmapset_id": 1796943,
@@ -50101,6 +54042,28 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1799071,
+      "artist": "ZUN",
+      "title": "Extend Ash ~ Houraijin",
+      "creator": "nik",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-06-26T05:38:17Z"
     },
     {
       "beatmapset_id": 1799118,
@@ -50223,6 +54186,27 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1807673,
+      "artist": "Demetori",
+      "title": "Tsuki Izuru Tokoro no Tenshi ~ Lunatic Princess",
+      "creator": "Emfaroz",
+      "source": "東方永夜抄　～ Imperishable Night",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-10-14T08:58:26Z"
+    },
+    {
       "beatmapset_id": 1808183,
       "artist": "ShinRa-Bansho",
       "title": "Charisma Rengoku Tenshin",
@@ -50244,6 +54228,28 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1808851,
+      "artist": "ShinRa-Bansho",
+      "title": "Pink Kurage to, Sotto, Kiss o Shita.",
+      "creator": "NeonMarijuana",
+      "source": "東方鬼形獣　～ Wily Beast and Weakest Creature.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2022-09-06T10:28:05Z"
+    },
+    {
       "beatmapset_id": 1809371,
       "artist": "PHOENIX Project",
       "title": "Mayonaka no Fairy Dance - Reflect The Reques",
@@ -50259,7 +54265,8 @@
       "evidence": [
         "osucollector:6907",
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50279,9 +54286,11 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:2163",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -50319,9 +54328,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -50361,9 +54371,10 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -50382,7 +54393,8 @@
       "original_themes": [],
       "evidence": [
         "osucollector:6907",
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50405,6 +54417,26 @@
         "osucollector:6907"
       ],
       "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1823772,
+      "artist": "ShinRa-Bansho",
+      "title": "I",
+      "creator": "otudou",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -50442,9 +54474,10 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
@@ -50452,9 +54485,9 @@
       "beatmapset_id": 1827113,
       "artist": "T.B.K",
       "title": "Louve d'Automne (-Deepdive-) [Automne d'Automne 1.1x (177bpm) OD8]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -50462,7 +54495,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50472,9 +54506,9 @@
       "beatmapset_id": 1829770,
       "artist": "Sephid",
       "title": "OVERPROTECTION ([Crz]FolAH1217) [EXCEEDIT x1.15]",
-      "creator": "",
+      "creator": "[Crz]FolAH1217",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -50482,7 +54516,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50543,7 +54578,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50655,9 +54691,9 @@
       "beatmapset_id": 1840749,
       "artist": "Camellia",
       "title": "Venomous Firefly (-mint-) [Insecticide 1.05x (277bpm)]",
-      "creator": "",
+      "creator": "-mint-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -50665,7 +54701,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50686,7 +54723,8 @@
       "original_themes": [],
       "evidence": [
         "osucollector:6907",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50698,7 +54736,7 @@
       "title": "Fuujin Shoujo ~ the Article by Crow (Cut Ver.)",
       "creator": "Halfslashed",
       "source": "",
-      "status": "pending",
+      "status": "ranked",
       "modes": [
         "osu"
       ],
@@ -50706,7 +54744,9 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50716,9 +54756,9 @@
       "beatmapset_id": 1844571,
       "artist": "senya",
       "title": "Yozakura ni Kimi wo Kakushite (Xzzj) [1.05 cut edited by YuEast 2018]",
-      "creator": "",
+      "creator": "Xzzj",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -50726,7 +54766,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50787,19 +54828,41 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "osucollector:6907"
+        "osucollector:6907",
+        "tournament:828"
       ],
-      "confidence": "candidate",
+      "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2022-12-09T22:15:24Z"
+    },
+    {
+      "beatmapset_id": 1851628,
+      "artist": "ZUN",
+      "title": "Daikichi Kitten",
+      "creator": "Coeminals",
+      "source": "東方虹龍洞　～ Unconnected Marketeers.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-07-28T11:35:19Z"
     },
     {
       "beatmapset_id": 1852062,
       "artist": "Sunasya Asuka",
       "title": "Yozakura Kaidou (To2) [Blossom Night]",
-      "creator": "",
+      "creator": "To2",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -50807,7 +54870,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50837,9 +54901,9 @@
       "beatmapset_id": 1853689,
       "artist": "Demetori",
       "title": "Inchlings of the Shining Needle ~ Counter-Attack of the Weak ([GB]Sanae) [Lighting Sword]",
-      "creator": "",
+      "creator": "[GB]Sanae",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -50847,7 +54911,28 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1858768,
+      "artist": "BUTAOTOME",
+      "title": "Haru no Yuki",
+      "creator": "squishi",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50897,9 +54982,9 @@
       "beatmapset_id": 1864211,
       "artist": "Nekomata master",
       "title": "Sennen no Kotowari (Bacon Haniwa) [reason [1.15x Rate]]",
-      "creator": "",
+      "creator": "Bacon Haniwa",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -50907,7 +54992,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -50918,7 +55004,7 @@
       "artist": "furulan",
       "title": "dona",
       "creator": "P_O",
-      "source": "",
+      "source": "東方永夜抄　～ Imperishable Night.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -50927,11 +55013,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "forum_queue:sd_touhou",
         "tournament:1793"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2024-09-04T20:35:18Z"
     },
     {
       "beatmapset_id": 1867631,
@@ -50995,6 +55082,27 @@
       "osu_last_updated": "2022-12-05T10:07:11Z"
     },
     {
+      "beatmapset_id": 1869137,
+      "artist": "Halozy",
+      "title": "Songs Compilation",
+      "creator": "nano desu",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-04-11T16:37:21Z"
+    },
+    {
       "beatmapset_id": 1869875,
       "artist": "Chata",
       "title": "len",
@@ -51038,9 +55146,9 @@
       "beatmapset_id": 1878634,
       "artist": "t+pazolite",
       "title": "CENSORED!! (-mint-) [EXPLICIT]",
-      "creator": "",
+      "creator": "-mint-",
       "source": "",
-      "status": "unknown",
+      "status": "pending",
       "modes": [
         "mania"
       ],
@@ -51048,7 +55156,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51075,12 +55184,54 @@
       "osu_last_updated": "2022-11-26T13:41:14Z"
     },
     {
+      "beatmapset_id": 1881723,
+      "artist": "Demetori",
+      "title": "Shinkou wa Hakanaki Ningen no Tame ni ~ Jehovah's YaHVeH",
+      "creator": "Cringe dealer",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-03-05T10:40:40Z"
+    },
+    {
+      "beatmapset_id": 1884924,
+      "artist": "ZUN",
+      "title": "G Free",
+      "creator": "Halfslashed",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-02-12T04:50:55Z"
+    },
+    {
       "beatmapset_id": 1888601,
       "artist": "COOL&CREATE",
       "title": "Lunatic Eyes ~ Invisible Full Moon (Cut Ver.) (TheFunk) [Blood Moon 1.05x (210bpm)]",
-      "creator": "",
+      "creator": "TheFunk",
       "source": "",
-      "status": "unknown",
+      "status": "loved",
       "modes": [
         "mania"
       ],
@@ -51088,7 +55239,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51099,7 +55251,7 @@
       "artist": "FELT",
       "title": "Summer Fever",
       "creator": "Camo",
-      "source": "",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -51109,19 +55261,22 @@
       "original_themes": [],
       "evidence": [
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163",
+        "tournament:828",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2023-06-23T16:32:46Z"
     },
     {
       "beatmapset_id": 1889195,
       "artist": "Laur",
       "title": "Nostalgic Blood of the Strife (Logan636) [Logan x Felix's World End]",
-      "creator": "",
+      "creator": "Logan636",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51129,7 +55284,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51140,7 +55296,7 @@
       "artist": "Unlucky Morpheus",
       "title": "Majotachi no Shanikusai",
       "creator": "gazimal",
-      "source": "",
+      "source": "秋霜玉",
       "status": "ranked",
       "modes": [
         "osu"
@@ -51150,9 +55306,12 @@
       "original_themes": [],
       "evidence": [
         "known_touhou_artist",
-        "osucollector:6907"
+        "known_touhou_metadata",
+        "mapper_tags",
+        "osucollector:6907",
+        "tournament_candidate:731"
       ],
-      "confidence": "candidate",
+      "confidence": "probable",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2023-02-05T10:27:47Z"
     },
@@ -51181,7 +55340,7 @@
       "artist": "KISIDA KYODAN & THE AKEBOSI ROCKETS",
       "title": "Fall of Fall",
       "creator": "Nilou",
-      "source": "",
+      "source": "東方風神録　～ Mountain of Faith.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -51190,11 +55349,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "forum_queue:sd_touhou",
         "tournament:1793"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2024-12-15T03:58:19Z"
+    },
+    {
+      "beatmapset_id": 1898039,
+      "artist": "ZUN",
+      "title": "The Primal Scene of Japan the Girl Saw",
+      "creator": "P_O",
+      "source": "東方風神録　～ Mountain of Faith",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-03T15:58:19Z"
     },
     {
       "beatmapset_id": 1898383,
@@ -51238,6 +55419,48 @@
       "osu_last_updated": "2023-01-05T18:47:12Z"
     },
     {
+      "beatmapset_id": 1900429,
+      "artist": "Kucchi (DARKSIDE APPROACH)",
+      "title": "Yakumo >>JOINT STRUGGLE (2019 Update)",
+      "creator": "Nowaie",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-03-10T17:26:32Z"
+    },
+    {
+      "beatmapset_id": 1900605,
+      "artist": "Minstrel",
+      "title": "Yotogibanashi no Kamikakushi",
+      "creator": "Ryuusei Aika",
+      "source": "東方萃夢想　～ Immaterial and Missing Power.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-02-18T13:12:38Z"
+    },
+    {
       "beatmapset_id": 1902658,
       "artist": "diaxart",
       "title": "Mr. Beast!!",
@@ -51271,7 +55494,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51291,7 +55515,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:1793",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51302,7 +55527,7 @@
       "artist": "Kiryu",
       "title": "Euphoric Phantasmagoria",
       "creator": "PaRaDogi",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -51311,11 +55536,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:1793",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2024-07-16T13:50:07Z"
     },
     {
       "beatmapset_id": 1909142,
@@ -51338,12 +55564,94 @@
       "osu_last_updated": "2022-12-28T21:41:15Z"
     },
     {
+      "beatmapset_id": 1911733,
+      "artist": "rerulili",
+      "title": "seisou bakuretsu - Boy",
+      "creator": "InsertUsernamev",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-10-24T07:38:13Z"
+    },
+    {
+      "beatmapset_id": 1917023,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Tengai (Cut Ver.)",
+      "creator": "whalermelon",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-01-21T22:07:06Z"
+    },
+    {
+      "beatmapset_id": 1917100,
+      "artist": "Demetori",
+      "title": "Crazy Backup Dancers ~ Orgy of the Dead",
+      "creator": "ItsWinter",
+      "source": "東方天空璋　～ Hidden Star in Four Seasons.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-07-24T19:06:13Z"
+    },
+    {
+      "beatmapset_id": 1918615,
+      "artist": "Xi",
+      "title": "Youyoumu ~ Run or Dash",
+      "creator": "OldEclipse",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1922257,
       "artist": "Stack",
       "title": "Deep Dream Dominator ([GB]Sanae) [Dream Catcher (200bpm)]",
-      "creator": "",
+      "creator": "[GB]Sanae",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51351,11 +55659,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1931120,
+      "artist": "Akatsuki Records",
+      "title": "Konsarutan!",
+      "creator": "RafaelXDP",
+      "source": "東方虹龍洞　〜 Unconnected Marketeers.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-05-15T20:06:38Z"
     },
     {
       "beatmapset_id": 1931793,
@@ -51372,6 +55702,26 @@
       "original_themes": [],
       "evidence": [
         "tournament:1793"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1936125,
+      "artist": "TAMUSIC",
+      "title": "Hexagram Epilogue",
+      "creator": "Atipir",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51398,6 +55748,46 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1943377,
+      "artist": "COOL&CREATE feat. Beat Mario",
+      "title": "Help me, ERINNNNNN!!",
+      "creator": "Bloxi",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1945457,
+      "artist": "Touhou Jihen",
+      "title": "Zetsubouteki Fukyouwaon",
+      "creator": "AdveNt",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 1950158,
       "artist": "Demetori",
       "title": "Natsukashiki Touhou no Chi ~ Sic World",
@@ -51412,6 +55802,152 @@
       "original_themes": [],
       "evidence": [
         "tournament:1793"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1953606,
+      "artist": "ZUN",
+      "title": "Border of Life",
+      "creator": "Shurelia",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-04-20T14:19:54Z"
+    },
+    {
+      "beatmapset_id": 1953729,
+      "artist": "TUMENECO",
+      "title": "Hoshi no Yume",
+      "creator": "Aruyy",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-03-23T05:12:31Z"
+    },
+    {
+      "beatmapset_id": 1954232,
+      "artist": "REDALiCE feat. Nomiya Ayumi",
+      "title": "Mami Mami Zone",
+      "creator": "Sutanrrier0",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-15T10:54:38Z"
+    },
+    {
+      "beatmapset_id": 1955038,
+      "artist": "A-One feat. Aki & Rute",
+      "title": "Drive Your Fire",
+      "creator": "HyperPigeon",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1958919,
+      "artist": "Yonder Voice",
+      "title": "Shrine Maiden - Eien no Miko",
+      "creator": "Sanch-KK",
+      "source": "東方靈異伝　～ Highly Responsive to Prayers",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-05-23T08:17:11Z"
+    },
+    {
+      "beatmapset_id": 1959309,
+      "artist": "senya",
+      "title": "Kimiiro Subliminal",
+      "creator": "Satellite",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-11-02T15:17:11Z"
+    },
+    {
+      "beatmapset_id": 1962278,
+      "artist": "Para Dot.",
+      "title": "Ultimate taste",
+      "creator": "LN-Larks",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51452,7 +55988,8 @@
       "original_themes": [],
       "evidence": [
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51479,11 +56016,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1980049,
+      "artist": "TUYU",
+      "title": "Songs Compilation",
+      "creator": "Anemone-",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-01-17T10:05:00Z"
+    },
+    {
       "beatmapset_id": 1980142,
       "artist": "Chocofan",
       "title": "LUCKY CAT",
       "creator": "Bloxi",
-      "source": "",
+      "source": "東方虹龍洞　～ Unconnected Marketeers.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -51492,12 +56049,13 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "forum_queue:sd_touhou",
         "tournament:1793",
         "tournament:1865"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2024-03-03T21:59:59Z"
     },
     {
       "beatmapset_id": 1980960,
@@ -51513,7 +56071,48 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1985153,
+      "artist": "Kanpyohgo",
+      "title": "Mannen Okigasa ni Gochui o -Festive Extended-",
+      "creator": "Angry",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1985165,
+      "artist": "BUTAOTOME",
+      "title": "Guuzou Utopia",
+      "creator": "h1dron",
+      "source": "",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51523,9 +56122,9 @@
       "beatmapset_id": 1987665,
       "artist": "LCMF",
       "title": "bankai shitekidayouda ([GB]Sanae) [Stage 1: Descend]",
-      "creator": "",
+      "creator": "[GB]Sanae",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51533,7 +56132,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51543,9 +56143,9 @@
       "beatmapset_id": 1987666,
       "artist": "Dark PHOENiX",
       "title": "Hiroari Shoots a Strange Bird ([GB]Reisen) [Stage 5: Till When?]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51553,7 +56153,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51563,9 +56164,9 @@
       "beatmapset_id": 1987668,
       "artist": "IOSYS",
       "title": "Neko Miko Reimu B (Cut Ver.) (YuEast 2018) [Stage 4: hakuneko]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51573,7 +56174,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51583,9 +56185,9 @@
       "beatmapset_id": 1987670,
       "artist": "DJ Command feat. Nana Takahashi",
       "title": "Divine War 20XX (-Deepdive-) [Stage 6: Deus Ex Idola]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51593,7 +56195,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51603,9 +56206,9 @@
       "beatmapset_id": 1987672,
       "artist": "Shibayan",
       "title": "Echo Gate (Cut Ver.) (epic man 2) [Stage 2: Desire Drive]",
-      "creator": "",
+      "creator": "epic man 2",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51613,7 +56216,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51623,9 +56227,9 @@
       "beatmapset_id": 1987682,
       "artist": "Iroha Mochi",
       "title": "Yama Kouyou (cherrychou) [Stage 3: Candid Friend]",
-      "creator": "",
+      "creator": "cherrychou",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51633,11 +56237,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1988612,
+      "artist": "Rin",
+      "title": "Ayakashi set 14 Another ~ Yoru ga Oritekuru",
+      "creator": "Halfslashed",
+      "source": "東方萃夢想　～ Immaterial and Missing Power.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-11-08T05:06:02Z"
     },
     {
       "beatmapset_id": 1989122,
@@ -51654,7 +56280,8 @@
       "original_themes": [],
       "evidence": [
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51664,9 +56291,9 @@
       "beatmapset_id": 1991141,
       "artist": "FELT",
       "title": "Katsukusa ya sarishi Nichinichi no Kageboushi (-[Ulazis]-) [Koi]",
-      "creator": "",
+      "creator": "-[Ulazis]-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51674,7 +56301,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51684,9 +56312,9 @@
       "beatmapset_id": 1991502,
       "artist": "SPACELECTRO",
       "title": "Free my mind,Free your mind [Zekk Remix] (cherrychou) [Imaginary]",
-      "creator": "",
+      "creator": "cherrychou",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51694,7 +56322,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51704,9 +56333,9 @@
       "beatmapset_id": 1991655,
       "artist": "sun3",
       "title": "Meikai Kikou (Hidden is fun) [thmc3_edit]",
-      "creator": "",
+      "creator": "Hidden is fun",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51714,7 +56343,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51724,9 +56354,9 @@
       "beatmapset_id": 1991656,
       "artist": "Komiya Mao",
       "title": "(can you) understand me? (Hidden is fun) [?]",
-      "creator": "",
+      "creator": "Hidden is fun",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51734,7 +56364,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51744,9 +56375,9 @@
       "beatmapset_id": 1992125,
       "artist": "Sephid",
       "title": "Hypothesize (AelSan) [Foresee. (w/ AlexDunk)]",
-      "creator": "",
+      "creator": "AelSan",
       "source": "",
-      "status": "unknown",
+      "status": "ranked",
       "modes": [
         "mania"
       ],
@@ -51754,7 +56385,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51764,9 +56396,9 @@
       "beatmapset_id": 1992172,
       "artist": "Masayoshi Minoshima feat. nomico",
       "title": "Lost Emotion (Amane UK Hardcore Remix) (cherrychou) [Last Dance Heaven..]",
-      "creator": "",
+      "creator": "cherrychou",
       "source": "",
-      "status": "unknown",
+      "status": "ranked",
       "modes": [
         "mania"
       ],
@@ -51774,7 +56406,28 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1992648,
+      "artist": "NH22",
+      "title": "Corrosion",
+      "creator": "Xen",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51784,9 +56437,9 @@
       "beatmapset_id": 1993039,
       "artist": "IOSYS",
       "title": "Kanbu de Tomatte Sugu Tokeru ~ Kyouki no Udongein ([GB]Reisen) [C13H16N2.HCl (Edit)]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51794,7 +56447,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51804,9 +56458,9 @@
       "beatmapset_id": 1993055,
       "artist": "ELECTR",
       "title": "Black Fluid (-Deepdive-) [Turbulence]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51814,7 +56468,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51824,9 +56479,9 @@
       "beatmapset_id": 1993059,
       "artist": "Frozen Starfall",
       "title": "Paint My Life (-Deepdive-) [Another Dream]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51834,7 +56489,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51844,9 +56500,9 @@
       "beatmapset_id": 1993067,
       "artist": "t+pazolite",
       "title": "Magical Higan Tour 2009 (-Deepdive-) [Technical Higan Tour 2023 1.05x]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51854,7 +56510,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51864,9 +56521,9 @@
       "beatmapset_id": 1993461,
       "artist": "Shinra-Bansho",
       "title": "Brain Rigid Girl ([GB]sherweifa) [THMC mapping staff'sTHMC Edit]",
-      "creator": "",
+      "creator": "[GB]sherweifa",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51874,7 +56531,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51884,9 +56542,9 @@
       "beatmapset_id": 1993909,
       "artist": "senya",
       "title": "Nagori Tori (Hidden is fun) [Lunatic]",
-      "creator": "",
+      "creator": "Hidden is fun",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51894,7 +56552,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51944,9 +56603,9 @@
       "beatmapset_id": 1994489,
       "artist": "Yonder Voice",
       "title": "Flight Night Flight (Tairits7) [Rice Jack Cake x1.15(140bpm)]",
-      "creator": "",
+      "creator": "Tairits7",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51954,7 +56613,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51964,9 +56624,9 @@
       "beatmapset_id": 1996041,
       "artist": "Akatsuki Records",
       "title": "Mizuiro Raindrop ([GB]V1do) [Lunat1c (Cut ver.)]",
-      "creator": "",
+      "creator": "[GB]V1do",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51974,7 +56634,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -51984,9 +56645,9 @@
       "beatmapset_id": 1996240,
       "artist": "Alstroemeria Records",
       "title": "ARROW RAIN ([Crz]xz1z1z) [Yuesat's | | | | | | | | | | | |]",
-      "creator": "",
+      "creator": "[Crz]xz1z1z",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -51994,19 +56655,41 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1997401,
+      "artist": "Para Dot.",
+      "title": "Hyper banquet",
+      "creator": "KogumaX",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-06-29T06:57:31Z"
+    },
+    {
       "beatmapset_id": 1997574,
       "artist": "Yuuyu / Yuuna sasara",
       "title": "Imperishable Night 2006 (2016 Refine) ([GB]Sanae) [Master (169bpm)]",
-      "creator": "",
+      "creator": "[GB]Sanae",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52014,7 +56697,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52024,9 +56708,9 @@
       "beatmapset_id": 1998346,
       "artist": "Noah",
       "title": "Black Night (N3k0ha_5h12uku) [Debug in Late at Night]",
-      "creator": "",
+      "creator": "N3k0ha_5h12uku",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52034,7 +56718,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52044,9 +56729,9 @@
       "beatmapset_id": 1998900,
       "artist": "senya",
       "title": "Mahou ga Umareta Hi ([GB]Sanae) [Magical Girl (136bpm)]",
-      "creator": "",
+      "creator": "[GB]Sanae",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52054,7 +56739,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52064,9 +56750,9 @@
       "beatmapset_id": 1999921,
       "artist": "Kyuushoku Touban",
       "title": "Deception (YuEast 2018) [omo]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52074,7 +56760,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52084,9 +56771,9 @@
       "beatmapset_id": 2000177,
       "artist": "Camellia",
       "title": "potential curve ([GB]V1do) [Challenge]",
-      "creator": "",
+      "creator": "[GB]V1do",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52094,7 +56781,48 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2000742,
+      "artist": "Kishida Kyoudan & THE Akeboshi Rockets",
+      "title": "Shinkuu no Melancholy",
+      "creator": "Atipir",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2000744,
+      "artist": "Demetori",
+      "title": "Strawberry Crisis!!",
+      "creator": "Suicune3",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:828"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52124,9 +56852,9 @@
       "beatmapset_id": 2002599,
       "artist": "t+pazolite",
       "title": "Grimed Grim Grimoire (-Deepdive-) [Mixed Mix Mixture]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52134,7 +56862,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52144,9 +56873,9 @@
       "beatmapset_id": 2002622,
       "artist": "ZYTOKINE",
       "title": "Hyakka (-Deepdive-) [Hundred Flower]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52154,7 +56883,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52164,9 +56894,9 @@
       "beatmapset_id": 2002645,
       "artist": "EastNewSound",
       "title": "Hana wa gensou no Hate ni (PORTTAYER) [Phantasmagoria x1.15]",
-      "creator": "",
+      "creator": "PORTTAYER",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52175,7 +56905,9 @@
       "original_themes": [],
       "evidence": [
         "tmc:3rd",
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52185,9 +56917,9 @@
       "beatmapset_id": 2002689,
       "artist": "3L",
       "title": "Three Magic (DiGiTAL WiNG TRANCE Remix) (Hylotl) [<3 [1.05x Rate]]",
-      "creator": "",
+      "creator": "Hylotl",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52195,7 +56927,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52205,9 +56938,9 @@
       "beatmapset_id": 2003096,
       "artist": "BUTAOTOME",
       "title": "Hakanaki Mono Ningen (YuEast 2018) [fake x1.10]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52215,7 +56948,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52225,9 +56959,9 @@
       "beatmapset_id": 2003293,
       "artist": "ALiCE'S EMOTiON",
       "title": "Last Time (t+pazolite Remix) ([GB]Reisen) [Dreamy Path]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52235,7 +56969,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52245,9 +56980,9 @@
       "beatmapset_id": 2005065,
       "artist": "Tian zZ feat.Yuezheng Ling",
       "title": "Chun Guang Xian Zu Guo ([GB]Reisen) [Suwa SUPER DANCE!!!!!]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52255,7 +56990,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52265,9 +57001,9 @@
       "beatmapset_id": 2006486,
       "artist": "katagiri",
       "title": "Breakin' Asia ([GB]Sanae) [Catastrophe]",
-      "creator": "",
+      "creator": "[GB]Sanae",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52275,7 +57011,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52285,9 +57022,9 @@
       "beatmapset_id": 2006946,
       "artist": "Akatsuki Records",
       "title": "HANIPAGANDA (YuEast 2018) [HAHAHA]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52295,7 +57032,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52305,9 +57043,9 @@
       "beatmapset_id": 2006990,
       "artist": "Kobaryo",
       "title": "Outer Occult Occupation ([GB]V1do) [Beyond Devastation]",
-      "creator": "",
+      "creator": "[GB]V1do",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52315,7 +57053,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52325,9 +57064,9 @@
       "beatmapset_id": 2007022,
       "artist": "A?",
       "title": "Marisa Nouigai Zenbu Tekishutsu (PORTTAYER) [Girls Dissection[edit] ×0.95]",
-      "creator": "",
+      "creator": "PORTTAYER",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52335,7 +57074,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52345,9 +57085,9 @@
       "beatmapset_id": 2007137,
       "artist": "uma_0002",
       "title": "Sunburnt naughty innocent girl (Doshowz) [Hard x1.15_P]",
-      "creator": "",
+      "creator": "Doshowz",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52355,7 +57095,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52385,9 +57126,9 @@
       "beatmapset_id": 2007826,
       "artist": "Chroma",
       "title": "Sukoshi Saiba a, Oeyama (PORTTAYER) [Kairiyokuranshin]",
-      "creator": "",
+      "creator": "PORTTAYER",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52395,7 +57136,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52405,9 +57147,9 @@
       "beatmapset_id": 2007984,
       "artist": "DJKurara",
       "title": "Law Of The Concrete Jungle (-Deepdive-) [Showdown]",
-      "creator": "",
+      "creator": "-Deepdive-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52415,19 +57157,62 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2008172,
+      "artist": "maritumix",
+      "title": "Blackout",
+      "creator": "dakiwii",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-10-31T00:16:45Z"
+    },
+    {
+      "beatmapset_id": 2008245,
+      "artist": "Tokyo Active NEETs",
+      "title": "Kinyaku, Juugoya, Shoujikimono no Shi",
+      "creator": "VP757",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-08-17T08:44:03Z"
+    },
+    {
       "beatmapset_id": 2008806,
       "artist": "uma vs. Morimori Atsushi",
       "title": "Kibou no Hoshi wa Seishou ni Noboru (uma vs. Morimori Atsushi Remix) (cherrychou) [Future]",
-      "creator": "",
+      "creator": "cherrychou",
       "source": "",
-      "status": "unknown",
+      "status": "pending",
       "modes": [
         "mania"
       ],
@@ -52435,7 +57220,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52445,9 +57231,9 @@
       "beatmapset_id": 2009888,
       "artist": "TAMAMOSEN",
       "title": "HOSHI NO UTSUWA ([GB]Reisen) [Phantasm Starry Sky (w/ sherweifa)]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52455,7 +57241,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52525,9 +57312,9 @@
       "beatmapset_id": 2012534,
       "artist": "Demetori",
       "title": "Faith is for the Transient People ~ Jehovah's YaHVeH (Alptraum) [SANAEchor 1.1x (242bpm)]",
-      "creator": "",
+      "creator": "Alptraum",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52535,19 +57322,41 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2014288,
+      "artist": "Schwank",
+      "title": "OPEN YOUR 3RD EYE",
+      "creator": "ralsricat",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-05-12T06:36:23Z"
+    },
+    {
       "beatmapset_id": 2014300,
       "artist": "katagiri",
       "title": "WallHakkr (YuEast 2018) [DRIVE UP!]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52555,7 +57364,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52565,9 +57375,9 @@
       "beatmapset_id": 2014377,
       "artist": "Kobaryo",
       "title": "CU73-D3V1L (Alptraum) [LVN471C]",
-      "creator": "",
+      "creator": "Alptraum",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52575,7 +57385,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52585,9 +57396,9 @@
       "beatmapset_id": 2014396,
       "artist": "Morimori Atsushi vs. uma",
       "title": "Only I'm Holy (My Angel Nilou) [1.1]",
-      "creator": "",
+      "creator": "My Angel Nilou",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52595,7 +57406,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52645,9 +57457,9 @@
       "beatmapset_id": 2016006,
       "artist": "Noma Nadeshiko",
       "title": "Sanzu no Kawa Ninngyou Gekijyou ([GB]Azukisan) [Three Scenarios Between Life and Death]",
-      "creator": "",
+      "creator": "[GB]Azukisan",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52655,7 +57467,70 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:3rd"
+        "tmc:3rd",
+        "tournament:748"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2017861,
+      "artist": "Masayoshi Minoshima",
+      "title": "Highly Responsive to Prayer feat. Mei Ayakura",
+      "creator": "Sanch-KK",
+      "source": "東方靈異伝　～ Highly Responsive to Prayers",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-09-11T16:42:27Z"
+    },
+    {
+      "beatmapset_id": 2019775,
+      "artist": "Demetori",
+      "title": "Tengu ga Miteiru ~ Eye of the Needles",
+      "creator": "ruvari",
+      "source": "東方文花帖　～ Shoot the Bullet.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-20T13:33:14Z"
+    },
+    {
+      "beatmapset_id": 2021984,
+      "artist": "ZUN",
+      "title": "Shigen no Beat ~ Pristine Beat",
+      "creator": "nik",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52665,9 +57540,9 @@
       "beatmapset_id": 2023038,
       "artist": "Down",
       "title": "Ekoro (YuEast 2018, epic man 2) [YuEast's [RO32 RC WC +Classic]]",
-      "creator": "",
+      "creator": "epic man 2",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52675,7 +57550,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52702,11 +57578,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2027407,
+      "artist": "1914",
+      "title": "FN .380 ACP#19074",
+      "creator": "Kaii__",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-09-13T23:57:21Z"
+    },
+    {
       "beatmapset_id": 2027922,
       "artist": "Syrufit feat. Mei Ayakura",
       "title": "Wheel of Fortune",
       "creator": "Sanch-KK",
-      "source": "",
+      "source": "東方怪綺談　～ Mystic Square",
       "status": "ranked",
       "modes": [
         "osu"
@@ -52715,11 +57611,54 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "forum_queue:sd_touhou",
         "tournament:1793"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2024-06-04T19:32:50Z"
+    },
+    {
+      "beatmapset_id": 2028232,
+      "artist": "Len",
+      "title": "U.N. Owen was her?",
+      "creator": "Mikelito069",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-07-17T13:27:09Z"
+    },
+    {
+      "beatmapset_id": 2028291,
+      "artist": "cYsmix",
+      "title": "Fortune Teller",
+      "creator": "TheBear53",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-07-17T15:07:53Z"
     },
     {
       "beatmapset_id": 2028493,
@@ -52740,6 +57679,27 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2031364,
+      "artist": "Masayoshi Minoshima",
+      "title": "Scolded By The Princess feat. Aki Misawa",
+      "creator": "228",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-07-22T21:36:06Z"
     },
     {
       "beatmapset_id": 2031993,
@@ -52782,11 +57742,32 @@
       "osu_last_updated": null
     },
     {
-      "beatmapset_id": 2040473,
-      "artist": "Schwank",
-      "title": "OPEN YOUR 3RD EYE",
-      "creator": "Amamya Kokoro",
-      "source": "",
+      "beatmapset_id": 2037900,
+      "artist": "Akatsuki Records",
+      "title": "Bloody Devotion",
+      "creator": "K4L1",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-20T20:09:40Z"
+    },
+    {
+      "beatmapset_id": 2039737,
+      "artist": "nominomu",
+      "title": "solar sect of nm2 ~ nuclear notelock",
+      "creator": "nominomu",
+      "source": "Scarlet's Touhou Tournament 3rd Season",
       "status": "graveyard",
       "modes": [
         "osu"
@@ -52795,11 +57776,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "mapper_tags",
+        "tournament_candidate:731"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-08-11T07:31:49Z"
+    },
+    {
+      "beatmapset_id": 2040473,
+      "artist": "Schwank",
+      "title": "OPEN YOUR 3RD EYE",
+      "creator": "Amamya Kokoro",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:1793",
+        "tournament_candidate:731"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2023-08-07T14:13:53Z"
     },
     {
       "beatmapset_id": 2044051,
@@ -52842,6 +57845,48 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2044453,
+      "artist": "ZUN",
+      "title": "Beware the Umbrella Left There Forever",
+      "creator": "Mikelito069",
+      "source": "東方星蓮船　～ Undefined Fantastic Object",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-08-21T20:27:29Z"
+    },
+    {
+      "beatmapset_id": 2044469,
+      "artist": "Liz Triangle",
+      "title": "Koisuru Recipe",
+      "creator": "rollpan",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 2044681,
       "artist": "BUTAOTOME",
       "title": "Gensou no Satellite",
@@ -52855,7 +57900,49 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2046568,
+      "artist": "Adust Rain",
+      "title": "Nevxxxxerland",
+      "creator": "Blitzifyyy",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-06-21T08:01:56Z"
+    },
+    {
+      "beatmapset_id": 2048017,
+      "artist": "Thousand Leaves",
+      "title": "Darkest night",
+      "creator": "Halfslashed",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52865,9 +57952,9 @@
       "beatmapset_id": 2048331,
       "artist": "Demetori",
       "title": "Last Remote \\~ Type A Personality (Castella) [Requiem of Koishi od7]",
-      "creator": "",
+      "creator": "Castella",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -52875,11 +57962,34 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2048430,
+      "artist": "ShinRa-Bansho",
+      "title": "Dendera Party Night",
+      "creator": "Suicune3",
+      "source": "蓮台野夜行　～ Ghostly Field Club",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "mapper_tags",
+        "tournament_candidate:731"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-08-21T15:03:02Z"
     },
     {
       "beatmapset_id": 2048969,
@@ -52902,6 +58012,215 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2051273,
+      "artist": "",
+      "title": "beatmapsets/2051273#osu/4525122",
+      "creator": "",
+      "source": "",
+      "status": "unknown",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2051949,
+      "artist": "ZUN",
+      "title": "Yumeshoushitsu ~ Lost Dream",
+      "creator": "ConsumerOfBean",
+      "source": "東方夢時空　～ The Phantasmagoria of Dim.Dream",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "known_touhou_artist",
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-08-28T03:06:44Z"
+    },
+    {
+      "beatmapset_id": 2051959,
+      "artist": "TatshMusicCircle",
+      "title": "FOUR SEASONS OF LONELINESS ver Beta feat. Sariyajin",
+      "creator": "Nao Tomori",
+      "source": "GROOVE COASTER 4MAX DIAMOND GALAXY",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "mapper_tags"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-06-11T14:03:03Z"
+    },
+    {
+      "beatmapset_id": 2052097,
+      "artist": "Asomosphere",
+      "title": "TEXTR",
+      "creator": "Amamya Kokoro",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-08-28T11:27:10Z"
+    },
+    {
+      "beatmapset_id": 2052104,
+      "artist": "adaptor",
+      "title": "iceshard",
+      "creator": "Eisbahn",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-08-28T11:35:46Z"
+    },
+    {
+      "beatmapset_id": 2053246,
+      "artist": "cYsmix",
+      "title": "Tear Rain feat. Emmy (Cut Ver.)",
+      "creator": "AmeThysTas",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-06-08T07:07:45Z"
+    },
+    {
+      "beatmapset_id": 2055269,
+      "artist": "YooSanHyakurei",
+      "title": "Sen no Yukari",
+      "creator": "oxisso",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2023-12-02T10:05:57Z"
+    },
+    {
+      "beatmapset_id": 2056207,
+      "artist": "IRON ATTACK!",
+      "title": "a little magician",
+      "creator": "Suicune3",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "osu_source",
+        "tournament_candidate:731"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-09-10T02:28:23Z"
+    },
+    {
+      "beatmapset_id": 2059306,
+      "artist": "Sephid",
+      "title": "Subterranean Blastoff",
+      "creator": "nik",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2063381,
+      "artist": "REDALiCE & aran",
+      "title": "Sweet Requiem",
+      "creator": "Noob_Oni",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-22T05:44:30Z"
+    },
+    {
       "beatmapset_id": 2065860,
       "artist": "Aoi Xia",
       "title": "Lost Blue",
@@ -52916,6 +58235,47 @@
       "original_themes": [],
       "evidence": [
         "tournament:1793"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2066206,
+      "artist": "Demetori",
+      "title": "Necrofantasia ~ Remix",
+      "creator": "vetoed",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-04-29T15:01:40Z"
+    },
+    {
+      "beatmapset_id": 2068755,
+      "artist": "IOSYS",
+      "title": "Marisa ni Taihen na Yaku de Hako ni Saremashita",
+      "creator": "Bloxi",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -52942,6 +58302,46 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2070206,
+      "artist": "Akatsuki Records",
+      "title": "Black Mirror on the Wall",
+      "creator": "Annabel",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2075280,
+      "artist": "A-One feat. Shihori",
+      "title": "Bamboo Dance",
+      "creator": "nanoya",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 2076189,
       "artist": "beatMARIO",
       "title": "Lunatic Eyes ~ Invisible Full Moon",
@@ -52960,6 +58360,28 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2080248,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Setsugetsu Ouka no Kuni",
+      "creator": "JLuca913 891",
+      "source": "東方三月精　～ Strange and Bright Nature Deity.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "known_touhou_artist",
+        "mapper_tags"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-07-10T14:49:59Z"
     },
     {
       "beatmapset_id": 2084590,
@@ -52987,7 +58409,7 @@
       "title": "Hinarin no Yakui Kankei (Edit ver.)",
       "creator": "Luscent",
       "source": "",
-      "status": "ranked",
+      "status": "pending",
       "modes": [
         "osu"
       ],
@@ -52996,11 +58418,33 @@
       "original_themes": [],
       "evidence": [
         "tournament:1793",
-        "tournament:1865"
+        "tournament:1865",
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2093561,
+      "artist": "BUTAOTOME",
+      "title": "Kurukuru Tsukai",
+      "creator": "Azyeu",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-07-09T19:18:32Z"
     },
     {
       "beatmapset_id": 2093926,
@@ -53043,6 +58487,129 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2098437,
+      "artist": "ShinRa-Bansho x COOL&CREATE",
+      "title": "Saishuu Kichiku Ze~nbu! ShinRa-Bansho",
+      "creator": "Vitas2222",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-10-04T18:52:58Z"
+    },
+    {
+      "beatmapset_id": 2098718,
+      "artist": "Shinra-Bansho",
+      "title": "signal flare",
+      "creator": "-Yua",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2101371,
+      "artist": "ShinRa-Bansho",
+      "title": "Kyokkou no Tabibito",
+      "creator": "Kuro Fuyusaki",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-04-28T02:14:22Z"
+    },
+    {
+      "beatmapset_id": 2101941,
+      "artist": "conagusuri",
+      "title": "-Rayrain-",
+      "creator": "Syph",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2102873,
+      "artist": "DJ-Technetium",
+      "title": "Poison Body ~ Forsaken Doll (MAKINA MIX)",
+      "creator": "Sanch-KK",
+      "source": "",
+      "status": "qualified",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2106961,
+      "artist": "Demetori",
+      "title": "Native Faith ~ Memory of a Free Festival",
+      "creator": "Camo",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-05-08T23:57:52Z"
+    },
+    {
       "beatmapset_id": 2108507,
       "artist": "akaneirotown",
       "title": "inori no kanata feat. Baruko, Kaigetsu Shell",
@@ -53063,12 +58630,344 @@
       "osu_last_updated": null
     },
     {
-      "beatmapset_id": 2135171,
-      "artist": "Akatsuki Records",
-      "title": "Necromantic (Cut Ver.) (PORTTAYER) [WakuwakuDokidoki]",
+      "beatmapset_id": 2114876,
+      "artist": "Foreground Eclipse",
+      "title": "You May Not Want To Hear This But",
+      "creator": "tacoyaki5",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-10-04T14:59:52Z"
+    },
+    {
+      "beatmapset_id": 2115462,
+      "artist": "Demetori",
+      "title": "Youkai no Yama ~ Mysterious Mountain",
+      "creator": "Camo",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-05-30T23:08:42Z"
+    },
+    {
+      "beatmapset_id": 2118287,
+      "artist": "Akiyama Uni feat. JUN",
+      "title": "Chitei ni Saku Bara",
+      "creator": "chang",
+      "source": "東方憑依華　～ Antinomy of Common Flowers.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-01-27T13:42:31Z"
+    },
+    {
+      "beatmapset_id": 2118758,
+      "artist": "Yui Ninomiya",
+      "title": "Konse Daikakumei (TV Size)",
+      "creator": "PortalPasha1337",
+      "source": "ようこそ実力至上主義の教室へ 3rd Season",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-08-21T10:46:38Z"
+    },
+    {
+      "beatmapset_id": 2119262,
+      "artist": "Foreground Eclipse",
+      "title": "Last Liar Standing",
+      "creator": "Qnio",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-03-08T08:45:45Z"
+    },
+    {
+      "beatmapset_id": 2121209,
+      "artist": "Para Dot.",
+      "title": "Azure Fragments",
+      "creator": "Jayblue",
+      "source": "東方怪綺談　～ Mystic Square",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-02-15T04:53:20Z"
+    },
+    {
+      "beatmapset_id": 2122073,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "curse upon me!",
+      "creator": "k0alcj",
+      "source": "東方封魔録　～ the Story of Eastern Wonderland",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-08-14T17:00:25Z"
+    },
+    {
+      "beatmapset_id": 2123533,
+      "artist": "LeaF",
+      "title": "Calamity Fortune",
+      "creator": "Renumi",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2123590,
+      "artist": "SOUND HOLIC",
+      "title": "EXISTENCE",
+      "creator": "Sanch-KK",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-06-02T21:22:47Z"
+    },
+    {
+      "beatmapset_id": 2124955,
+      "artist": "Oranges & Lemons",
+      "title": "Soramimi Cake (TV Size)",
+      "creator": "vastly",
+      "source": "あずまんが大王",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-01-25T17:45:58Z"
+    },
+    {
+      "beatmapset_id": 2128024,
+      "artist": "",
+      "title": "beatmapsets/2128024#osu/4473796",
       "creator": "",
       "source": "",
       "status": "unknown",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2128278,
+      "artist": "FELT",
+      "title": "Yearning",
+      "creator": "Eirra",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-06-09T16:26:13Z"
+    },
+    {
+      "beatmapset_id": 2130980,
+      "artist": "tsunamix",
+      "title": "Gensou wa Hakanaki Watashi no Tame ni -Shinroku-",
+      "creator": "Sanch-KK",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-06-24T22:36:18Z"
+    },
+    {
+      "beatmapset_id": 2131713,
+      "artist": "TUMENECO VS. GET IN THE RING",
+      "title": "Yumeuta - Tokubetsu na Futari no Uta",
+      "creator": "Livermorium",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2132362,
+      "artist": "senya",
+      "title": "Nagori Tori",
+      "creator": "sharpay",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-06-12T02:51:00Z"
+    },
+    {
+      "beatmapset_id": 2134870,
+      "artist": "UNDEAD CORPORATION",
+      "title": "The silent world (Instrumental Ver.)",
+      "creator": "Bloxi",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-06-14T19:11:23Z"
+    },
+    {
+      "beatmapset_id": 2135171,
+      "artist": "Akatsuki Records",
+      "title": "Necromantic (Cut Ver.) (PORTTAYER) [WakuwakuDokidoki]",
+      "creator": "PORTTAYER",
+      "source": "",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53076,11 +58975,74 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2136607,
+      "artist": "TK from Ling tosite sigure",
+      "title": "melt (with suis from Yorushika)",
+      "creator": "Laquarius",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-06-04T15:08:13Z"
+    },
+    {
+      "beatmapset_id": 2138559,
+      "artist": "FELT",
+      "title": "Plugless & Forever",
+      "creator": "[-Shabondama-]",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-05-28T12:17:28Z"
+    },
+    {
+      "beatmapset_id": 2139864,
+      "artist": "Masayoshi Minoshima feat. Akasake",
+      "title": "Crescent Moon",
+      "creator": "Sanch-KK",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-02-24T08:52:49Z"
     },
     {
       "beatmapset_id": 2140323,
@@ -53103,12 +59065,116 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2140545,
+      "artist": "Masayoshi Minoshima feat. mican*",
+      "title": "Lotus Road",
+      "creator": "Sanch-KK",
+      "source": "東方幻想郷　～ Lotus Land Story",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-02-24T11:37:51Z"
+    },
+    {
+      "beatmapset_id": 2141336,
+      "artist": "t=NODE",
+      "title": "Distorted Monster",
+      "creator": "Nyanaro",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-04-24T09:31:10Z"
+    },
+    {
+      "beatmapset_id": 2142307,
+      "artist": "-45",
+      "title": "Distance' vector algorithm",
+      "creator": "Sanch-KK",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-10-31T14:27:58Z"
+    },
+    {
+      "beatmapset_id": 2143469,
+      "artist": "Demetori",
+      "title": "Otenba Koi Musume ~ killer Tune",
+      "creator": "Quakey",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-10-04T16:23:34Z"
+    },
+    {
+      "beatmapset_id": 2146723,
+      "artist": "senya",
+      "title": "Koakuma Ringo (EUROBEAT Remix)",
+      "creator": "Sanch-KK",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 2147028,
       "artist": "NJK Record",
       "title": "Spring Of Dreams (Cut Ver.) (Miaurichesu) [Memories 1.1x]",
-      "creator": "",
+      "creator": "Miaurichesu",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53116,7 +59182,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53163,6 +59230,172 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2151146,
+      "artist": "Vaundy",
+      "title": "CHAINSAW BLOOD (TV Size)",
+      "creator": "Asahina Oleshev",
+      "source": "チェンソーマン",
+      "status": "graveyard",
+      "modes": [
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-04-01T05:51:30Z"
+    },
+    {
+      "beatmapset_id": 2151149,
+      "artist": "Shinra-Bansho",
+      "title": "Gansaku",
+      "creator": "NirtroR",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "known_touhou_artist"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-03-19T14:45:54Z"
+    },
+    {
+      "beatmapset_id": 2152855,
+      "artist": "",
+      "title": "beatmapsets/2152855#osu/4536199",
+      "creator": "",
+      "source": "",
+      "status": "unknown",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2155822,
+      "artist": "Amane (Rolling Contact)",
+      "title": "Technical Master",
+      "creator": "Suicune3",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-07T15:09:33Z"
+    },
+    {
+      "beatmapset_id": 2161238,
+      "artist": "AU",
+      "title": "U.Nknown Goose",
+      "creator": "Kiarah",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-05T17:03:42Z"
+    },
+    {
+      "beatmapset_id": 2162313,
+      "artist": "World End Symphonia",
+      "title": "Heliophobia",
+      "creator": "Jelljel",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-09-08T17:09:15Z"
+    },
+    {
+      "beatmapset_id": 2164215,
+      "artist": "",
+      "title": "beatmapsets/2164215#osu/4564743",
+      "creator": "",
+      "source": "",
+      "status": "unknown",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2171371,
+      "artist": "Demetori",
+      "title": "Higan Kikou ~ View of The River Styx",
+      "creator": "dicecream",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-18T20:57:15Z"
+    },
+    {
       "beatmapset_id": 2172367,
       "artist": "FELT",
       "title": "Last Wind",
@@ -53183,12 +59416,33 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2175777,
+      "artist": "Halozy",
+      "title": "K.O.K.O.R.O & S.A.T.O.R.A.R.E",
+      "creator": "Plugin",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-05-22T01:07:20Z"
+    },
+    {
       "beatmapset_id": 2176951,
       "artist": "SOUND HOLIC feat. Nana Takahashi",
       "title": "No Life Queen (elexire) [cut]",
-      "creator": "",
+      "creator": "elexire",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53196,7 +59450,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53223,6 +59478,48 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2183829,
+      "artist": "Aerize feat. TRASH PANDA",
+      "title": "ON FIRE",
+      "creator": "Posity",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-10-17T14:16:47Z"
+    },
+    {
+      "beatmapset_id": 2188075,
+      "artist": "Xyris",
+      "title": "Dystopian Exodus of the Magical Girls",
+      "creator": "nuclei",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-01-05T19:05:55Z"
+    },
+    {
       "beatmapset_id": 2189799,
       "artist": "Xi",
       "title": "Densetsu no Sabori Shinigami ~ Make a quick escape",
@@ -53243,6 +59540,68 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2192482,
+      "artist": "ShinRa-Bansho",
+      "title": "Instant Blue",
+      "creator": "Wachininko",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-09-22T17:24:35Z"
+    },
+    {
+      "beatmapset_id": 2192547,
+      "artist": "Beau Black",
+      "title": "Running with the King",
+      "creator": "Killer602",
+      "source": "The Lion Gaurd",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-04-10T09:07:01Z"
+    },
+    {
+      "beatmapset_id": 2193211,
+      "artist": "bunny rhyTHm x Dichroic Purpilion",
+      "title": "Mata Murasakizakura no Shita ni",
+      "creator": "[-Shabondama-]",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-05-19T13:49:18Z"
+    },
+    {
       "beatmapset_id": 2195132,
       "artist": "Kucchi",
       "title": "Yakumo >>JOINT STRUGGLE (2014 ReWorks)",
@@ -53257,6 +59616,88 @@
       "original_themes": [],
       "evidence": [
         "tournament:1865"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2195468,
+      "artist": "ShinRa-Bansho",
+      "title": "Subarashiki Guuzou Sekai",
+      "creator": "Astravan",
+      "source": "東方鬼形獣　～ Wily Beast and Weakest Creature.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-07T21:04:31Z"
+    },
+    {
+      "beatmapset_id": 2196409,
+      "artist": "Yuuhei Satellite",
+      "title": "Motenashi No Ha",
+      "creator": "dicecream",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-10T06:56:32Z"
+    },
+    {
+      "beatmapset_id": 2196661,
+      "artist": "Joost",
+      "title": "Luchtballon",
+      "creator": "Abyssgard",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-05-11T11:43:14Z"
+    },
+    {
+      "beatmapset_id": 2198692,
+      "artist": "Kikuo",
+      "title": "Oboreru Uchuu Neko",
+      "creator": "Okoayu",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53303,6 +59744,26 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2199318,
+      "artist": "O-life Japan",
+      "title": "Dorodoro-Don",
+      "creator": "-Tynamo",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
       "beatmapset_id": 2201834,
       "artist": "COOL&CREATE ft. beatMARIO",
       "title": "Rapid Ensemble",
@@ -53343,10 +59804,73 @@
       "osu_last_updated": null
     },
     {
-      "beatmapset_id": 2239541,
-      "artist": "TAMAONSEN",
-      "title": "Gensou Kappa Koushinkyoku feat. ytr",
-      "creator": "Suicune3",
+      "beatmapset_id": 2218153,
+      "artist": "Sally",
+      "title": "Remind",
+      "creator": "Mononymous",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-01-21T20:12:31Z"
+    },
+    {
+      "beatmapset_id": 2221758,
+      "artist": "Syrufit / Poplica* feat. Mei Ayakura",
+      "title": "Threat of rain",
+      "creator": "Kojio",
+      "source": "東方怪綺談　～ Mystic Square",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-07T00:11:37Z"
+    },
+    {
+      "beatmapset_id": 2223887,
+      "artist": "senya",
+      "title": "Kanjou Chemistry",
+      "creator": "SUISEI69",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-09-02T18:05:05Z"
+    },
+    {
+      "beatmapset_id": 2225614,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Uzu",
+      "creator": "Camo",
       "source": "",
       "status": "ranked",
       "modes": [
@@ -53356,11 +59880,282 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tournament:1793"
+        "tournament:2163"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2227573,
+      "artist": "Kurokotei",
+      "title": "Galaxy Collapse",
+      "creator": "Coeminals",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-08-23T20:30:41Z"
+    },
+    {
+      "beatmapset_id": 2237670,
+      "artist": "FELT",
+      "title": "New World (Cut Ver.)",
+      "creator": "espii",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-27T12:26:19Z"
+    },
+    {
+      "beatmapset_id": 2239541,
+      "artist": "TAMAONSEN",
+      "title": "Gensou Kappa Koushinkyoku feat. ytr",
+      "creator": "Suicune3",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "tournament:1793"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-09-20T22:26:57Z"
+    },
+    {
+      "beatmapset_id": 2241601,
+      "artist": "A-One feat. Kanipan.",
+      "title": "Endless, Sleepless Night",
+      "creator": "Clodsire",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-10-16T20:11:37Z"
+    },
+    {
+      "beatmapset_id": 2243304,
+      "artist": "Diao Ye Zong .feat 3L",
+      "title": "Hon no Tabibito",
+      "creator": "Ureimu",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-07T01:54:32Z"
+    },
+    {
+      "beatmapset_id": 2243445,
+      "artist": "Mano feat. -aoi-",
+      "title": "relative relation (it's all about)",
+      "creator": "Raupain",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-28T05:58:01Z"
+    },
+    {
+      "beatmapset_id": 2245015,
+      "artist": "Toa",
+      "title": "Mune No Naka De Darekaga",
+      "creator": "Otosaka-Yu",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-02T04:44:08Z"
+    },
+    {
+      "beatmapset_id": 2246160,
+      "artist": "Rolling Contact (Amane)",
+      "title": "Crimson Bride",
+      "creator": "knife_lee",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-10-06T12:40:30Z"
+    },
+    {
+      "beatmapset_id": 2248838,
+      "artist": "ShibayanRecords",
+      "title": "Trouble Kuroneko Manyuuki",
+      "creator": "Suicune3",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2249236,
+      "artist": "SOUND HOLIC",
+      "title": "Border of Life",
+      "creator": "Sanch-KK",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2252339,
+      "artist": "Unlucky Morpheus",
+      "title": "FAITH",
+      "creator": "h6zy",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-06-07T23:24:14Z"
+    },
+    {
+      "beatmapset_id": 2256311,
+      "artist": "senya",
+      "title": "Kasoku Suru Koi wa Dare mo Tomerarenai",
+      "creator": "SUISEI69",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-08-27T13:36:46Z"
+    },
+    {
+      "beatmapset_id": 2258048,
+      "artist": "TAMAONSEN",
+      "title": "COZMIC DRIVE feat. Youko",
+      "creator": "Suicune3",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-21T14:26:30Z"
     },
     {
       "beatmapset_id": 2260896,
@@ -53383,12 +60178,239 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2261278,
+      "artist": "ZUN",
+      "title": "Fuujin Shoujo (Short Ver.)",
+      "creator": "Shurelia",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2261332,
+      "artist": "Shibayan feat. Natsuki Karin",
+      "title": "vampire sabotage",
+      "creator": "urdu",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2267353,
+      "artist": "A-One feat. Aki",
+      "title": "Darkish",
+      "creator": "Cafe_deCoral",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-01-23T14:45:06Z"
+    },
+    {
+      "beatmapset_id": 2268478,
+      "artist": "HAGISOPH",
+      "title": "MAGIMARI",
+      "creator": "Stuvz",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2268892,
+      "artist": "Takamachi Walk",
+      "title": "A Desire to Disappear",
+      "creator": "Alexistain",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-10-23T22:25:26Z"
+    },
+    {
+      "beatmapset_id": 2271653,
+      "artist": "Kotoge Mai",
+      "title": "Itoshi Kimi wo Mitsuke ni",
+      "creator": "Kojio",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-27T01:05:56Z"
+    },
+    {
+      "beatmapset_id": 2272306,
+      "artist": "Iceon feat. Mayumi Morinaga",
+      "title": "Boutokuteki Sentaku no Alegria",
+      "creator": "Herazu",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-05-08T11:28:38Z"
+    },
+    {
+      "beatmapset_id": 2274446,
+      "artist": "Tsubaki",
+      "title": "Alice In Wonderland (feat. UX)",
+      "creator": "Maaadbot",
+      "source": "東方怪綺談　～ Mystic Square",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-16T15:51:05Z"
+    },
+    {
+      "beatmapset_id": 2274872,
+      "artist": "ShinRa-Bansho",
+      "title": "Instant Blue",
+      "creator": "mintIceCream_",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-13T23:04:40Z"
+    },
+    {
+      "beatmapset_id": 2275913,
+      "artist": "FELT",
+      "title": "TRULY GLORY",
+      "creator": "chromakey",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-25T17:41:26Z"
+    },
+    {
+      "beatmapset_id": 2276618,
+      "artist": "Demetori",
+      "title": "Dichromatic Lotus Butterfly ~  Red, White and Black Butterfly",
+      "creator": "Cayssa",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-11-07T23:58:43Z"
+    },
+    {
       "beatmapset_id": 2279360,
       "artist": "marasy",
       "title": "Re\\:Unknown X (cherrychou) [Lunatic (edit)]",
-      "creator": "",
+      "creator": "cherrychou",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53396,7 +60418,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53407,7 +60430,7 @@
       "artist": "Kanpyohgo",
       "title": "Kyuu Jigokukaidou o Yuku Dance.edt",
       "creator": "Suicune3",
-      "source": "",
+      "source": "東方地霊殿　～ Subterranean Animism.",
       "status": "ranked",
       "modes": [
         "osu"
@@ -53416,11 +60439,12 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
+        "forum_queue:sd_touhou",
         "tournament:1793"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "osu_last_updated": "2024-12-28T14:32:40Z"
     },
     {
       "beatmapset_id": 2281818,
@@ -53441,6 +60465,69 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2282492,
+      "artist": "SOUND HOLIC feat. Meramipop",
+      "title": "Koiiro no Yume",
+      "creator": "NekuMagetsu",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-15T19:50:37Z"
+    },
+    {
+      "beatmapset_id": 2283057,
+      "artist": "Demetori",
+      "title": "Higan Kikou ~ View of The River Styx",
+      "creator": "KomachiBaka",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-15T23:19:47Z"
+    },
+    {
+      "beatmapset_id": 2284459,
+      "artist": "Adust Rain",
+      "title": "Eleven Stud",
+      "creator": "Toumei Dragon",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-06-29T06:51:00Z"
     },
     {
       "beatmapset_id": 2285009,
@@ -53483,6 +60570,150 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2285768,
+      "artist": "ShinRa-Bansho",
+      "title": "Mugen Shitto Gekijou \"666\"",
+      "creator": "_koishi1",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-01-18T01:20:06Z"
+    },
+    {
+      "beatmapset_id": 2286190,
+      "artist": "RD-Sounds feat. Meramipop / nayuta",
+      "title": "Shiten",
+      "creator": "LY0N009",
+      "source": "東方天空璋　～ Hidden Star in Four Seasons.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-07-09T03:17:16Z"
+    },
+    {
+      "beatmapset_id": 2288012,
+      "artist": "TAMAONSEN",
+      "title": "Saigetsu (Midnight Moon Walker Remix)",
+      "creator": "Suicune3",
+      "source": "東方萃夢想　～ Immaterial and Missing Power.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-02-28T14:20:51Z"
+    },
+    {
+      "beatmapset_id": 2288529,
+      "artist": "-kairo-",
+      "title": "sanzensekai",
+      "creator": "pregnant_man",
+      "source": "",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2289073,
+      "artist": "RichaadEB & AHmusic",
+      "title": "Reach for the Moon, Immortal Smoke",
+      "creator": "HyperPigeon",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-07-07T13:54:34Z"
+    },
+    {
+      "beatmapset_id": 2289676,
+      "artist": "Skye Riley",
+      "title": "New Brain",
+      "creator": "michaelscarn60",
+      "source": "Smile 2",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-05T19:49:11Z"
+    },
+    {
+      "beatmapset_id": 2289727,
+      "artist": "REDO, BATO",
+      "title": "AO",
+      "creator": "Astridskiyy",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-08-18T12:06:16Z"
+    },
+    {
       "beatmapset_id": 2291398,
       "artist": "Fuyu",
       "title": "Echoes of Eternity",
@@ -53501,6 +60732,27 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2292162,
+      "artist": "Diao Ye Zong",
+      "title": "Trauma Merai",
+      "creator": "Aspheria",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-02-21T20:19:36Z"
     },
     {
       "beatmapset_id": 2294584,
@@ -53523,12 +60775,198 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2294590,
+      "artist": "BeatMARIO",
+      "title": "Kyouki no Hitomi ~ Invisible Full Moon",
+      "creator": "Kudou Chitose",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2294659,
+      "artist": "Xi",
+      "title": "Warabe Matsuri ~ Innocent Treasures",
+      "creator": "Quakey",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2024-12-22T12:18:43Z"
+    },
+    {
+      "beatmapset_id": 2295361,
+      "artist": "Yellow Zebra",
+      "title": "Akai Tsuki ~Story of Scarlett~",
+      "creator": "NekuMagetsu",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-05-03T17:24:29Z"
+    },
+    {
+      "beatmapset_id": 2296280,
+      "artist": "Chata",
+      "title": "Zen",
+      "creator": "Kalibe",
+      "source": "",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2300480,
+      "artist": "ALiCE'S EMOTiON",
+      "title": "Mami Mami Zone",
+      "creator": "Kayamori Ruka",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2300800,
+      "artist": "Halozy feat. Nanahira",
+      "title": "Monosugoi Kuruttoru Flan-chan ga Monosugoi Uta",
+      "creator": "Pyo",
+      "source": "",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2302194,
+      "artist": "R-Note",
+      "title": "Koiiro Magical Star",
+      "creator": "- noya -",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "graveyard",
+      "modes": [
+        "catch",
+        "mania",
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-05-24T14:02:20Z"
+    },
+    {
+      "beatmapset_id": 2304509,
+      "artist": "Set It Off",
+      "title": "Fake Ass Friends (Cut Ver.)",
+      "creator": "FiFTiFiFTi",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-10T22:06:21Z"
+    },
+    {
+      "beatmapset_id": 2309829,
+      "artist": "SOUND HOLIC",
+      "title": "Heisei Kappa Taikei (Short Ver.)",
+      "creator": "Bloxi",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-04-18T01:40:26Z"
+    },
+    {
       "beatmapset_id": 2310371,
       "artist": "Matsumoto Sara",
       "title": "Ito Hakanaki Hikari no Gotoku (Sped Up & Cut Ver.) (MyZterioN-, Hytex, Koyori Chan, fvrex, YuEast 2018) [Stage 2\\: Sakura Tears]",
-      "creator": "",
+      "creator": "MyZterioN-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53536,7 +60974,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53546,9 +60985,9 @@
       "beatmapset_id": 2310386,
       "artist": "IneSim",
       "title": "HOLOGRAPHIC XHERRY BLOSSOM (Sped Up Ver.) (AelSan) [Stage 6\\: Color]",
-      "creator": "",
+      "creator": "AelSan",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53556,7 +60995,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53566,9 +61006,9 @@
       "beatmapset_id": 2310392,
       "artist": "Sasara Yuuna",
       "title": "Oreore Shuugetsu \\~Wriggle de Pikokyon\\~ (Cut Ver.) (AutotelicBrown) [Stage 1\\: Fool Moon]",
-      "creator": "",
+      "creator": "AutotelicBrown",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53576,7 +61016,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53586,9 +61027,9 @@
       "beatmapset_id": 2310393,
       "artist": "Rolling Contact",
       "title": "Tyto Alba (YuEast 2018) [Stage 5\\: Rocking]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53596,7 +61037,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53606,9 +61048,9 @@
       "beatmapset_id": 2310402,
       "artist": "Pizuya's Cell",
       "title": "Nano Probe (PORTTAYER) [Stage 4\\: Setsuna]",
-      "creator": "",
+      "creator": "PORTTAYER",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53616,7 +61058,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53626,9 +61069,9 @@
       "beatmapset_id": 2310413,
       "artist": "sawawa",
       "title": "Seventh Doll (Hylotl) [Stage 3\\: Alice Crisis]",
-      "creator": "",
+      "creator": "Hylotl",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53636,11 +61079,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2314105,
+      "artist": "Tsubaki",
+      "title": "Alice In Wonderland (feat. UX)",
+      "creator": "oNeko",
+      "source": "東方怪綺談　～ Mystic Square",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-14T19:29:46Z"
     },
     {
       "beatmapset_id": 2314529,
@@ -53666,9 +61131,9 @@
       "beatmapset_id": 2314758,
       "artist": "Akiyama Uni",
       "title": "Azakeri no Yuugi (V1do-) [Joy]",
-      "creator": "",
+      "creator": "[GB]V1do",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53676,7 +61141,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53686,9 +61152,9 @@
       "beatmapset_id": 2314830,
       "artist": "Shibayan feat. 3L",
       "title": "Maigo no Echo (ScoliosisET) [You are the most important person to me... (nerf ver.)]",
-      "creator": "",
+      "creator": "ScoliosisET",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53696,7 +61162,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53706,9 +61173,9 @@
       "beatmapset_id": 2314977,
       "artist": "Spacelectro feat. momogami",
       "title": "Colorless ([Crz]FolAH1217, Koyori Chan, YuEast 2018, V1do-) [Colorful]",
-      "creator": "",
+      "creator": "[GB]Sanae",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53716,7 +61183,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53726,9 +61194,9 @@
       "beatmapset_id": 2314978,
       "artist": "Chocofan",
       "title": "LUCKY CAT ([Crz]FolAH1217) [UNLUCKY LN]",
-      "creator": "",
+      "creator": "[Crz]FolAH1217",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53736,7 +61204,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53746,9 +61215,9 @@
       "beatmapset_id": 2314979,
       "artist": "TAMAONSEN",
       "title": "66 Ondo (YuEast 2018) [66]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53756,7 +61225,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53766,9 +61236,9 @@
       "beatmapset_id": 2314980,
       "artist": "Jane Remover",
       "title": "me (Cut Ver.) (YuEast 2018) [u]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53776,7 +61246,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53786,9 +61257,9 @@
       "beatmapset_id": 2314982,
       "artist": "MISATO",
       "title": "Necro Fantasia (Cut Ver.) (eZmmR) [Cherry Blossom]",
-      "creator": "",
+      "creator": "eZmmR",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53796,7 +61267,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53806,9 +61278,9 @@
       "beatmapset_id": 2314987,
       "artist": "Yuuhei Satellite",
       "title": "Hatenaki Kaze no Kiseki sae \\~Ha\\~ (Cut ver.) ([Crz]Reimu) [Kochiya Sanae]",
-      "creator": "",
+      "creator": "[Crz]Reimu",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53816,19 +61288,41 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2315856,
+      "artist": "EastNewSound feat. nayuta",
+      "title": "Nijiiro Kekkai, Gekkyou no Goku",
+      "creator": "-Yua",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-30T03:51:36Z"
+    },
+    {
       "beatmapset_id": 2325598,
       "artist": "ShinRa-Bansho",
       "title": "Vodka niwa Tonic (Cut Ver.) (AelSan, [Crz]Reimu) [Alcoholism (w/ Reimu)]",
-      "creator": "",
+      "creator": "AelSan",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53836,7 +61330,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53846,9 +61341,9 @@
       "beatmapset_id": 2325599,
       "artist": "Chiyoko",
       "title": "Alice's Mad Tea Party (ERA trooperr) [Trickster's Spell 1.25x]",
-      "creator": "",
+      "creator": "trooperr",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53856,7 +61351,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53866,9 +61362,9 @@
       "beatmapset_id": 2325600,
       "artist": "A-One feat. Shihori",
       "title": "Magic Girl !! (elexire) [yup]",
-      "creator": "",
+      "creator": "elexire",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53876,7 +61372,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53886,9 +61383,9 @@
       "beatmapset_id": 2325603,
       "artist": "BUTAOTOME",
       "title": "Towa no Maigo (fvrex) [Gastronomic Alchemy]",
-      "creator": "",
+      "creator": "fvrex",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53896,7 +61393,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53906,9 +61404,9 @@
       "beatmapset_id": 2325613,
       "artist": "Akatsuki Records",
       "title": "Adieu, to this Lively Graveyard (Castella) [Zombie]",
-      "creator": "",
+      "creator": "Castella",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53916,7 +61414,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53926,9 +61425,9 @@
       "beatmapset_id": 2325616,
       "artist": "JAKAZiD & nora2r",
       "title": "Heian no Alien (Night Striker Mix) (PORTTAYER) [Speed Up X]",
-      "creator": "",
+      "creator": "PORTTAYER",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53936,7 +61435,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53966,9 +61466,9 @@
       "beatmapset_id": 2325618,
       "artist": "An",
       "title": "artcore JINJA ([GB]Reisen) [coordination JINJA]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53976,7 +61476,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -53986,9 +61487,9 @@
       "beatmapset_id": 2326028,
       "artist": "IOSYS",
       "title": "Chantikku San-Yousei no Itazura Daisensou (YuEast 2018) [Ya! / 1.10]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -53996,7 +61497,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54006,9 +61508,9 @@
       "beatmapset_id": 2326029,
       "artist": "Halozy",
       "title": "Paranoid Lost (Cut Ver.) (YuEast 2018) [I'm lost in the starry autumn sky.]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54016,7 +61518,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54026,9 +61529,9 @@
       "beatmapset_id": 2329538,
       "artist": "FELT",
       "title": "New World (Kiraz) [Reborn 1.13x (220bpm)]",
-      "creator": "",
+      "creator": "Kiraz",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54036,7 +61539,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54046,9 +61550,9 @@
       "beatmapset_id": 2329573,
       "artist": "Morimori Atsushi",
       "title": "Toono Gensou Monogatari (MRM REMIX) (V1do-) [Illusional]",
-      "creator": "",
+      "creator": "V1do-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54056,7 +61560,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54066,9 +61571,9 @@
       "beatmapset_id": 2329582,
       "artist": "Tokyo Active NEETs",
       "title": "Akahoshi Mizeraburu \\~ Hai yi Hen (Game Ver.) (AelSan) [Master 1.1x (176bpm)]",
-      "creator": "",
+      "creator": "AelSan",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54076,7 +61581,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54086,9 +61592,9 @@
       "beatmapset_id": 2329583,
       "artist": "Tomohiko Togashi feat. Kano",
       "title": "Kimi to Iu Tokuiten (Cut Ver.) (Blue\\_Potion) [Singular 1.05x]",
-      "creator": "",
+      "creator": "Blue_Potion",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54096,7 +61602,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54106,9 +61613,9 @@
       "beatmapset_id": 2329584,
       "artist": "Floating Cloud",
       "title": "Road to the moon (Castella) [Happy End]",
-      "creator": "",
+      "creator": "Castella",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54116,7 +61623,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54126,9 +61634,9 @@
       "beatmapset_id": 2329588,
       "artist": "Yuma Mizonokuchi feat. Ai Ohsera",
       "title": "Princess Lily (Xinhong1003) [Blooming]",
-      "creator": "",
+      "creator": "Xinhong1003",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54136,7 +61644,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54146,9 +61655,9 @@
       "beatmapset_id": 2329589,
       "artist": "DJ suslik",
       "title": "Made In China (Blue\\_Potion, YuEast 2018) [Save Your Soul (w/ YuEast 2018) 1.0x]",
-      "creator": "",
+      "creator": "Blue_Potion",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54156,7 +61665,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54166,9 +61676,9 @@
       "beatmapset_id": 2329595,
       "artist": "Para Dot.",
       "title": "Hyper banquet (gzdongsheng) [514nm]",
-      "creator": "",
+      "creator": "gzdongsheng",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54176,7 +61686,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54186,9 +61697,9 @@
       "beatmapset_id": 2329599,
       "artist": "Akatsuki Records",
       "title": "Rock 'n' Rock 'n' Beat (ImperialTrinity) [Bang! Bang!]",
-      "creator": "",
+      "creator": "ImperialTrinity",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54196,7 +61707,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54206,9 +61718,9 @@
       "beatmapset_id": 2329601,
       "artist": "Foreground Eclipse",
       "title": "You May Not Want To Hear This But (Ycloki) [I am here screaming, yelling and crying.]",
-      "creator": "",
+      "creator": "Ycloki",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54216,19 +61728,41 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2333219,
+      "artist": "Shinigiwa Satellite feat. Meramipop",
+      "title": "Omoikane Injection",
+      "creator": "Watanabe Akari",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-06-30T03:01:41Z"
+    },
+    {
       "beatmapset_id": 2333365,
       "artist": "FELT",
       "title": "Summer Fever (Cut Ver.) (epic man 2) [2hu diff name goes here]",
-      "creator": "",
+      "creator": "epic man 2",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54236,7 +61770,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54246,9 +61781,9 @@
       "beatmapset_id": 2333448,
       "artist": "Nuruhachi",
       "title": "Doll Judgment -Glittering Magic- (Xu seventeen) [Kinju Eishou]",
-      "creator": "",
+      "creator": "Xu seventeen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54256,7 +61791,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54266,9 +61802,9 @@
       "beatmapset_id": 2333455,
       "artist": "nachi",
       "title": "Tsuioku Summer Night (ELEMENTAS Remix) (Alptraum) [none [1.05x Rate]]",
-      "creator": "",
+      "creator": "Alptraum",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54276,7 +61812,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54286,9 +61823,9 @@
       "beatmapset_id": 2333460,
       "artist": "Houshou Marine",
       "title": "Hoihoi\\_Gensou Holoism (Cut Ver.) (Koyori Chan, YuEast 2018) [Lunatic]",
-      "creator": "",
+      "creator": "Koyori Chan",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54296,7 +61833,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54306,9 +61844,9 @@
       "beatmapset_id": 2333465,
       "artist": "K2 SOUND",
       "title": "Fairy stage (ExNeko, YuEast 2018) [LN]",
-      "creator": "",
+      "creator": "ExNeko",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54316,7 +61854,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54326,9 +61865,9 @@
       "beatmapset_id": 2333476,
       "artist": "Diao ye zong feat. Meramipop",
       "title": "Shinkirou (YuEast 2018) [Hana.]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54336,7 +61875,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54346,9 +61886,9 @@
       "beatmapset_id": 2333478,
       "artist": "ShinRa-Bansho",
       "title": "Sanyousei SAY YA!!! (Cut Ver.) (YuEast 2018) [Say! Ya! / 1.05]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54356,7 +61896,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54366,9 +61907,9 @@
       "beatmapset_id": 2333480,
       "artist": "Spacelectro feat. Momokami",
       "title": "DANCING FOX!!! (Cut Ver.) (YuEast 2018) [dancing fish!!!]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54376,7 +61917,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54386,9 +61928,9 @@
       "beatmapset_id": 2333482,
       "artist": "Ganeme",
       "title": "See you again... (Blue\\_Potion) [Immersion 1.0x]",
-      "creator": "",
+      "creator": "Blue_Potion",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54396,7 +61938,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54406,9 +61949,9 @@
       "beatmapset_id": 2333486,
       "artist": "xi-on",
       "title": "The Concealed Four Seasons (Castella) [Chromatic Sound]",
-      "creator": "",
+      "creator": "Castella",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54416,7 +61959,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54426,9 +61970,9 @@
       "beatmapset_id": 2333495,
       "artist": "cYsmix",
       "title": "Abandoned Shrine Party ([Crz]FolAH1217) [Midnight gaming +]",
-      "creator": "",
+      "creator": "[Crz]FolAH1217",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54436,7 +61980,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54466,9 +62011,9 @@
       "beatmapset_id": 2333498,
       "artist": "para Dot.",
       "title": "Colored garden (Ycloki) [Obscured Eden 1.05x (158bpm) OD8]",
-      "creator": "",
+      "creator": "Ycloki",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54476,7 +62021,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54486,9 +62032,9 @@
       "beatmapset_id": 2333528,
       "artist": "LeaF",
       "title": "Calamity Fortune (extended cut ver.) ([GB]Oceanus) [Collapse(Cut) x1.15]",
-      "creator": "",
+      "creator": "[GB]Oceanus",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54496,7 +62042,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54506,9 +62053,9 @@
       "beatmapset_id": 2333538,
       "artist": "Sally",
       "title": "Ennb\\~Abyss Flames (RiceSS) [ennb style (thmc ver.)]",
-      "creator": "",
+      "creator": "RiceSS",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54516,7 +62063,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54526,9 +62074,9 @@
       "beatmapset_id": 2337108,
       "artist": "SmileDemon",
       "title": "Doomtempo ([GB]Azukisan) [DoomLotus 150bpm edit]",
-      "creator": "",
+      "creator": "[GB]Azukisan",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54536,7 +62084,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54546,9 +62095,9 @@
       "beatmapset_id": 2337109,
       "artist": "Amane",
       "title": "Neuro Circuit (PORTTAYER) [Crazy Bass Dancers]",
-      "creator": "",
+      "creator": "PORTTAYER",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54556,7 +62105,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54566,9 +62116,9 @@
       "beatmapset_id": 2337111,
       "artist": "Asomosphere",
       "title": "Cross Commander Circuit (PORTTAYER) [Triangle Chase (edit) 1.05x]",
-      "creator": "",
+      "creator": "PORTTAYER",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54576,7 +62126,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54586,9 +62137,9 @@
       "beatmapset_id": 2337121,
       "artist": "S.S.H.",
       "title": "Genshi no Yoru \\~ Ghostly Eyes ([GB]Reisen, Xu seventeen) [Ei Yoru no Mukui. // co. Xu seventeen 1.05x]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54596,7 +62147,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54606,9 +62158,9 @@
       "beatmapset_id": 2337122,
       "artist": "BUTAOTOME",
       "title": "Mesen ([GB]Reisen) [roslaunch ittsui\\_no\\_kamikemono touhou.launch]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54616,7 +62168,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54626,9 +62179,9 @@
       "beatmapset_id": 2337199,
       "artist": "Sawawa",
       "title": "Taketori Hishou \\~Lunatic Princess (MyZterioN-) [nisemono 1.05x]",
-      "creator": "",
+      "creator": "MyZterioN-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54636,7 +62189,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54646,9 +62200,9 @@
       "beatmapset_id": 2337247,
       "artist": "Diao ye zong",
       "title": "Seiren 'Uruwashi no Ventra' (Cut ver.) (Hylotl) [UFO Romance!?]",
-      "creator": "",
+      "creator": "Hylotl",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54656,7 +62210,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54666,9 +62221,9 @@
       "beatmapset_id": 2337323,
       "artist": "dBu",
       "title": "Majotachi no Butoukai \\~ Magus (Castella) [Nightmare]",
-      "creator": "",
+      "creator": "Castella",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54676,7 +62231,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54686,9 +62242,9 @@
       "beatmapset_id": 2337373,
       "artist": "Spacelectro feat. setsunann",
       "title": "Luv the world [DJ Raisei Remix] (Cut Ver.) (gzdongsheng) [Phantom]",
-      "creator": "",
+      "creator": "gzdongsheng",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54696,7 +62252,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54706,9 +62263,9 @@
       "beatmapset_id": 2337391,
       "artist": "Shinigiwa Satellite",
       "title": "Taishoku Reality ([GB]Kita-) [Lost]",
-      "creator": "",
+      "creator": "[GB]Kita-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54716,7 +62273,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54726,9 +62284,9 @@
       "beatmapset_id": 2337396,
       "artist": "ALiCE'S EMOTiON",
       "title": "Ghostly Parapara Ship (Hardcore Edit) (V1do-) [Let's enjoy the Parapara Night! (Cut ver.)]",
-      "creator": "",
+      "creator": "V1do-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54736,7 +62294,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54746,9 +62305,9 @@
       "beatmapset_id": 2337397,
       "artist": "HAGISOPH",
       "title": "Beyond the Millennium (Blue\\_Potion, V1do-) [Lunatic Eternity (w/ Blue\\_Potion)]",
-      "creator": "",
+      "creator": "V1do-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54756,7 +62315,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54766,9 +62326,9 @@
       "beatmapset_id": 2337459,
       "artist": "Xenon",
       "title": "63HiiraossHuikgoeH53 (cut ver.) (ScoliosisET) [Gensokyo Daydream 1.05x (189bpm)]",
-      "creator": "",
+      "creator": "ScoliosisET",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54776,7 +62336,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54786,9 +62347,9 @@
       "beatmapset_id": 2337473,
       "artist": "Uten-Kekkoh",
       "title": "SYOUZYOSAKUSOUTYU (Nicknem\\_) [Egoist (THMC edit)]",
-      "creator": "",
+      "creator": "Nicknem_",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54796,11 +62357,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2338337,
+      "artist": "Masayoshi Minoshima",
+      "title": "Bad Apple!! (feat. Nomico)",
+      "creator": "Yellow_Pixel",
+      "source": "東方幻想郷　～ Lotus Land Story",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-22T13:23:59Z"
     },
     {
       "beatmapset_id": 2340182,
@@ -54826,9 +62409,9 @@
       "beatmapset_id": 2340183,
       "artist": "TAMAONSEN",
       "title": "Tairin no Soul ([GB]Reisen) [Timing no Soul]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54836,7 +62419,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54846,9 +62430,9 @@
       "beatmapset_id": 2340193,
       "artist": "Litchee",
       "title": "Fleur De Neige (ImperialTrinity) [Nacreous Iridescence 1.05x]",
-      "creator": "",
+      "creator": "ImperialTrinity",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54856,7 +62440,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54866,9 +62451,9 @@
       "beatmapset_id": 2340196,
       "artist": "Takamachi Walk",
       "title": "A Desire to Disappear (ImperialTrinity) [Forget Me Not (cut)]",
-      "creator": "",
+      "creator": "ImperialTrinity",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54876,7 +62461,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54886,9 +62472,9 @@
       "beatmapset_id": 2340227,
       "artist": "MONO",
       "title": "Fantasmagoria ([GB]Oceanus) [Phangasm 1.05x (163bpm)]",
-      "creator": "",
+      "creator": "[GB]Oceanus",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54896,7 +62482,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54906,9 +62493,9 @@
       "beatmapset_id": 2340241,
       "artist": "DJKurara",
       "title": "Crazy Aliens ([GS]hina) [Chimera (Edit)]",
-      "creator": "",
+      "creator": "[GS]hina",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54916,7 +62503,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54926,9 +62514,9 @@
       "beatmapset_id": 2340242,
       "artist": "NormalM",
       "title": "Karakasa Scramble (Saemitsu) [Tsukumogami]",
-      "creator": "",
+      "creator": "Saemitsu",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54936,7 +62524,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54946,9 +62535,9 @@
       "beatmapset_id": 2340245,
       "artist": "EastNewSound feat. Chata",
       "title": "Sound of Carnation ([GS]hina) [Echo (THMC4 Edit)]",
-      "creator": "",
+      "creator": "[GS]hina",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54956,7 +62545,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54966,9 +62556,9 @@
       "beatmapset_id": 2340381,
       "artist": "NJK Record",
       "title": "Search for the butterfly (Alptraum) [edit 1.15x (184bpm) OD8]",
-      "creator": "",
+      "creator": "Alptraum",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54976,7 +62566,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -54986,9 +62577,9 @@
       "beatmapset_id": 2340470,
       "artist": "Demetori",
       "title": "Native Faith \\~ Memory of a Free Festival (Castella) [Phantasm (cut)]",
-      "creator": "",
+      "creator": "Castella",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -54996,7 +62587,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55006,9 +62598,9 @@
       "beatmapset_id": 2340498,
       "artist": "Kurokotei",
       "title": "Scattered Faith (cherrychou, [GB]Reisen, Ycloki, YuEast 2018, AelSan, [GS]hina, Alptraum, ERA trooperr) [#2025 Most Unbelievable TB#]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55016,7 +62608,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55026,9 +62619,9 @@
       "beatmapset_id": 2340499,
       "artist": "Halozy",
       "title": "Don't let you down (YuEast 2018) [drive up! (cut)]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55036,7 +62629,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55046,9 +62640,9 @@
       "beatmapset_id": 2340507,
       "artist": "miso-nicomi records",
       "title": "Heavenly Net Breaking World (KimMui) [0.95x]",
-      "creator": "",
+      "creator": "KimMui",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55056,7 +62650,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55066,9 +62661,9 @@
       "beatmapset_id": 2340523,
       "artist": "chocofan",
       "title": "Flandol (YuEast 2018, 0DZ0) [Rising Flan!]",
-      "creator": "",
+      "creator": "0DZ0",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55076,7 +62671,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55086,9 +62682,9 @@
       "beatmapset_id": 2340544,
       "artist": "P\\*Light feat. mow\\*2",
       "title": "Homeneko Sensation (Long Ver.) (Xu seventeen) [Super Nyeeco(216bpm)]",
-      "creator": "",
+      "creator": "Xu seventeen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55096,7 +62692,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55106,9 +62703,9 @@
       "beatmapset_id": 2340562,
       "artist": "ZUN",
       "title": "Voyage 1969 (Ycloki) [Oneiric Odyssey (edit)]",
-      "creator": "",
+      "creator": "Ycloki",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55116,11 +62713,33 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2342547,
+      "artist": "Hannari",
+      "title": "Shen Bu Jian Di De Shi Yu",
+      "creator": "Doomsdaddy",
+      "source": "东方夜雀食堂",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "mapper_tags"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-03-23T22:20:38Z"
     },
     {
       "beatmapset_id": 2342737,
@@ -55146,9 +62765,9 @@
       "beatmapset_id": 2347645,
       "artist": "BUTAOTOME",
       "title": "Imanarabe (ScoliosisET) [Satort 1.05x (184bpm) OD8]",
-      "creator": "",
+      "creator": "ScoliosisET",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55156,7 +62775,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55166,9 +62786,9 @@
       "beatmapset_id": 2347671,
       "artist": "Kommisar",
       "title": "Native Faith (Chiptune ver.) ([GB]Reisen, Yuiesta) [LN YOUNGER]",
-      "creator": "",
+      "creator": "[GB]Reisen",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55176,7 +62796,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55186,9 +62807,9 @@
       "beatmapset_id": 2347686,
       "artist": "Meramipop feat. Studio \"Syrup Comfiture\"",
       "title": "Zillion Lights (Yuiesta) [Stellar]",
-      "creator": "",
+      "creator": "Yuiesta",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55196,7 +62817,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55206,9 +62828,9 @@
       "beatmapset_id": 2347687,
       "artist": "IOSYS",
       "title": "RE\\:Usatei (Yuiesta) [Usa / 1.05]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55216,7 +62838,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55226,9 +62849,9 @@
       "beatmapset_id": 2347688,
       "artist": "katagiri",
       "title": "Buta Musou (Yuiesta) [THMC Musou / 1.1]",
-      "creator": "",
+      "creator": "YuEast 2018",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55236,7 +62859,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55246,9 +62870,9 @@
       "beatmapset_id": 2347692,
       "artist": "FELT",
       "title": "Lies in Reality (Yuiesta, Micleak) [Look straight at everything you see.]",
-      "creator": "",
+      "creator": "Micleak",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55256,7 +62880,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55266,9 +62891,9 @@
       "beatmapset_id": 2347694,
       "artist": "Xenoglossy",
       "title": "Suigetsu Kyouka Koubou Issen ([GS]hina) [Mirage 1.2x (276bpm)]",
-      "creator": "",
+      "creator": "[GS]hina",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55276,7 +62901,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55286,9 +62912,9 @@
       "beatmapset_id": 2347700,
       "artist": "pocotan",
       "title": "ClownTanz (Cut Ver.) (AutotelicBrown) [ClownJacks 1.05x (168bpm)]",
-      "creator": "",
+      "creator": "AutotelicBrown",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55296,7 +62922,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55306,9 +62933,9 @@
       "beatmapset_id": 2347709,
       "artist": "UNDEAD CORPORATION",
       "title": "Bloodthirsty Nightmare Lullaby (epic man 2) [Phantom Of The Opera]",
-      "creator": "",
+      "creator": "epic man 2",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55316,7 +62943,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55326,9 +62954,9 @@
       "beatmapset_id": 2347713,
       "artist": "IOSYS",
       "title": "Bow Down, You Ignorant Fools! - The Princess' Insane All Night Hourai Live - (0DZ0) [Kaguya-sama]",
-      "creator": "",
+      "creator": "0DZ0",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55336,7 +62964,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55346,9 +62975,9 @@
       "beatmapset_id": 2347719,
       "artist": "Diao Ye Zong feat. Meramipop",
       "title": "Unprivileged Access (Cut Ver.) (V1do-) [Withering...]",
-      "creator": "",
+      "creator": "V1do-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55356,7 +62985,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55366,9 +62996,9 @@
       "beatmapset_id": 2347730,
       "artist": "Rolling Contact",
       "title": "Falling Fireworks ([Crz]FolAH1217) [.BURST]",
-      "creator": "",
+      "creator": "[Crz]FolAH1217",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55376,7 +63006,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55386,9 +63017,9 @@
       "beatmapset_id": 2347752,
       "artist": "sugosugiii & THE BEAT WIZARD",
       "title": "Between Collapse and Rebuild\\: A Scarlet Tale of Chaos and Hope (ImperialTrinity, gzdongsheng, Koyori Chan, AelSan, V1do-, [GS]hina, Alptraum) [Interweaving Phantasm]",
-      "creator": "",
+      "creator": "V1do-",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55396,7 +63027,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55406,9 +63038,9 @@
       "beatmapset_id": 2347811,
       "artist": "Laur",
       "title": "Absolute Queen ([Crz]Crysarlene) [Absolute Maker (Extended Ver.)]",
-      "creator": "",
+      "creator": "[Crz]Crysarlene",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55416,7 +63048,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55426,9 +63059,9 @@
       "beatmapset_id": 2347862,
       "artist": "Unlucky Morpheus",
       "title": "Danzai wa Amaneku Ningen no Moto ni (Ska) [1.1]",
-      "creator": "",
+      "creator": "Ska",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55436,7 +63069,8 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
@@ -55446,9 +63080,9 @@
       "beatmapset_id": 2347963,
       "artist": "UNDEAD CORPORATION",
       "title": "Flowering Night Fever (Miaurichesu, Yuiesta) [PSYCHOBREAK]",
-      "creator": "",
+      "creator": "Miaurichesu",
       "source": "",
-      "status": "unknown",
+      "status": "graveyard",
       "modes": [
         "mania"
       ],
@@ -55456,11 +63090,1520 @@
       "origin_games": [],
       "original_themes": [],
       "evidence": [
-        "tmc:4th"
+        "tmc:4th",
+        "tournament:1661"
       ],
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2352527,
+      "artist": "Akiyama Uni",
+      "title": "Touhou Hisouten (Game Ver.)",
+      "creator": "leledorf",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-09-22T14:33:53Z"
+    },
+    {
+      "beatmapset_id": 2353563,
+      "artist": "ZUN",
+      "title": "Shoutoku Legend ~ True Administrator",
+      "creator": "Doomsdaddy",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-06-25T22:24:08Z"
+    },
+    {
+      "beatmapset_id": 2354680,
+      "artist": "ZUN",
+      "title": "Meiji Juushichi-nen no Shanghai Alice",
+      "creator": "-Aki Minoriko",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-06T10:37:00Z"
+    },
+    {
+      "beatmapset_id": 2355006,
+      "artist": "Yuuhei Satellite feat. Marcia",
+      "title": "Kurenai ni Somaru Koi no Hana",
+      "creator": "Serafeim",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-06-06T10:28:10Z"
+    },
+    {
+      "beatmapset_id": 2356659,
+      "artist": "Yoon Ho Kim & Xiaonan Yan",
+      "title": "Dolia's Mermaid Song",
+      "creator": "Oakenfold-",
+      "source": "Honor of Kings",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-01-13T23:00:54Z"
+    },
+    {
+      "beatmapset_id": 2361582,
+      "artist": "Votch feat. Mitani Nana",
+      "title": "Little*Summer Party",
+      "creator": "SUISEI69",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2368873,
+      "artist": "tamaonsen",
+      "title": "Sign",
+      "creator": "Tannhauser",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2371846,
+      "artist": "Yuuhei Satellite feat. Marcia",
+      "title": "Hitomi o Tojite, Utsusu Mugen",
+      "creator": "Azasapag",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-06-09T18:50:20Z"
+    },
+    {
+      "beatmapset_id": 2374413,
+      "artist": "DJ TOTTO feat. 3L",
+      "title": "Youkakushi -Ayakashi Kakushi- (Game Ver.)",
+      "creator": "Mejiro Dober",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-13T13:42:57Z"
+    },
+    {
+      "beatmapset_id": 2375006,
+      "artist": "Demetori",
+      "title": "Pure Furies ~ Vengeance is Mine",
+      "creator": "lazysloth900",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-12-31T12:45:55Z"
+    },
+    {
+      "beatmapset_id": 2375610,
+      "artist": "ShinRa-Bansho",
+      "title": "Maru Batsu Sankaku Shikaku",
+      "creator": "seedcrack",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-08-21T14:57:21Z"
+    },
+    {
+      "beatmapset_id": 2376975,
+      "artist": "A-One feat. Aki",
+      "title": "Wanna Be My Dream",
+      "creator": "sharpay",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2378628,
+      "artist": "Down",
+      "title": "Down",
+      "creator": "Daycore",
+      "source": "",
+      "status": "qualified",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2380055,
+      "artist": "Akiyama Uni",
+      "title": "Yuuga ni Sakase, Sumizome no Sakura ~ Border of Life",
+      "creator": "Suicune3",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-10-03T04:13:04Z"
+    },
+    {
+      "beatmapset_id": 2382844,
+      "artist": "Xi",
+      "title": "Majotachi no Butoukai ~ Magus",
+      "creator": "mqno",
+      "source": "秋霜玉",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "mapper_tags"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-08-06T09:02:57Z"
+    },
+    {
+      "beatmapset_id": 2382859,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "A transient faith",
+      "creator": "Frutiger_",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-24T03:21:55Z"
+    },
+    {
+      "beatmapset_id": 2383053,
+      "artist": "Shibayan feat. 3L",
+      "title": "Gekka no Eien o Sasayaite",
+      "creator": "-Kirigiri",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-01T03:34:37Z"
+    },
+    {
+      "beatmapset_id": 2384947,
+      "artist": "beatMARIO",
+      "title": "Night of Knights (Cranky Remix)",
+      "creator": "_koishi1",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-09-09T09:11:52Z"
+    },
+    {
+      "beatmapset_id": 2385560,
+      "artist": "Andora",
+      "title": "Goodbye Yesterday (feat. Jakusansei)",
+      "creator": "R3aCt10n",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-09-28T00:49:53Z"
+    },
+    {
+      "beatmapset_id": 2389650,
+      "artist": "Halozy",
+      "title": "Crystal Snow",
+      "creator": "LY0N009",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-06-25T11:19:03Z"
+    },
+    {
+      "beatmapset_id": 2390344,
+      "artist": "Diao Ye Zong feat. Meramipop / IO",
+      "title": "Warabe Asobi",
+      "creator": "Plugin",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-23T19:15:56Z"
+    },
+    {
+      "beatmapset_id": 2390527,
+      "artist": "Masayoshi Minoshima feat. misato",
+      "title": "Necro Fantasia",
+      "creator": "The Fart Lord",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-07T16:47:34Z"
+    },
+    {
+      "beatmapset_id": 2390988,
+      "artist": "ALiCE'S EMOTiON",
+      "title": "Singing in the rain",
+      "creator": "Settia",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2392070,
+      "artist": "Girls Logic Observatory",
+      "title": "Hollow Masquerade (SA ver.)",
+      "creator": "Sagu",
+      "source": "",
+      "status": "wip",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2395055,
+      "artist": "xi",
+      "title": "Xeno Phantasm",
+      "creator": "Luscent",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2399201,
+      "artist": "Sephid",
+      "title": "Hermatical Reverie",
+      "creator": "Phten02",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2409273,
+      "artist": "ArmpitMaiden",
+      "title": "On the Edge of Paradise",
+      "creator": "NiniDialga",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-15T18:31:38Z"
+    },
+    {
+      "beatmapset_id": 2409618,
+      "artist": "ZUN (Arr. sun3)",
+      "title": "Higan Retour -idling mix-",
+      "creator": "Zekao",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-03-29T11:03:22Z"
+    },
+    {
+      "beatmapset_id": 2413164,
+      "artist": "ZUN",
+      "title": "Naki Oujo no Tame no Septette",
+      "creator": "Aspheria",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-10-06T22:22:09Z"
+    },
+    {
+      "beatmapset_id": 2416708,
+      "artist": "FELT",
+      "title": "Lost My Way",
+      "creator": "ite",
+      "source": "東方神霊廟　～ Ten Desires",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-09-19T06:39:48Z"
+    },
+    {
+      "beatmapset_id": 2418189,
+      "artist": "K.V. Kaoruko",
+      "title": "U.N. Owen was Her Majesty?",
+      "creator": "Aspheria",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-08-28T04:29:17Z"
+    },
+    {
+      "beatmapset_id": 2418954,
+      "artist": "ZUN",
+      "title": "Satori Maiden ~ 3rd Eye",
+      "creator": "Aspheria",
+      "source": "東方地霊殿　～ Subterranean Animism",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-08-13T00:20:31Z"
+    },
+    {
+      "beatmapset_id": 2423672,
+      "artist": "Amateras Records feat. KUMI",
+      "title": "Twinkle Twinkle",
+      "creator": "mercury2004",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-02-09T14:01:10Z"
+    },
+    {
+      "beatmapset_id": 2425501,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Under the scarlet sky pt,2 inst",
+      "creator": "Umi Sonoda",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania",
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-03T21:35:55Z"
+    },
+    {
+      "beatmapset_id": 2425508,
+      "artist": "Demetori",
+      "title": "Intro / Kuuchuu ni Shizumu Kishinjou ~ Counter-Clock World",
+      "creator": "lazysloth900",
+      "source": "東方輝針城　～ Double Dealing Character.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-01-26T13:10:51Z"
+    },
+    {
+      "beatmapset_id": 2426796,
+      "artist": "SYNC.ART'S feat. Sakaue Nachi",
+      "title": "Light travel distance",
+      "creator": "Aspheria",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-03-20T14:32:16Z"
+    },
+    {
+      "beatmapset_id": 2426797,
+      "artist": "RD-Sounds feat. Meramipop/nayuta",
+      "title": "Shiten",
+      "creator": "Aspheria",
+      "source": "東方天空璋　～ Hidden Star in Four Seasons.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-08-28T13:30:10Z"
+    },
+    {
+      "beatmapset_id": 2427482,
+      "artist": "Akatsuki Records",
+      "title": "Necromantic",
+      "creator": "Leksichka",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-30T11:05:53Z"
+    },
+    {
+      "beatmapset_id": 2434424,
+      "artist": "RD-Sounds feat. Yurika",
+      "title": "A-Yah-YAh-YaH-YAH!",
+      "creator": "Aspheria",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-09-13T17:47:02Z"
+    },
+    {
+      "beatmapset_id": 2437036,
+      "artist": "Batory",
+      "title": "Touhou Koumakyou Zenkyoku Arrange Medley",
+      "creator": "Aspheria",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-09-27T18:01:40Z"
+    },
+    {
+      "beatmapset_id": 2440249,
+      "artist": "FELT",
+      "title": "Little Nova",
+      "creator": "Lafayla",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-10-09T02:41:59Z"
+    },
+    {
+      "beatmapset_id": 2441742,
+      "artist": "Camellia",
+      "title": "White Crow",
+      "creator": "SUISEI69",
+      "source": "東方輝針城　～ Double Dealing Character.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-10-19T13:51:15Z"
+    },
+    {
+      "beatmapset_id": 2442680,
+      "artist": "Demetori",
+      "title": "Pure Furies ~ Vengeance is Mine",
+      "creator": "zacfr",
+      "source": "東方紺珠伝 ～ Legacy of Lunatic Kingdom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-12-11T10:48:06Z"
+    },
+    {
+      "beatmapset_id": 2442802,
+      "artist": "ZUN",
+      "title": "Illusionary White Traveler",
+      "creator": "nik",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2452339,
+      "artist": "Akiyama Uni",
+      "title": "Saigetsu",
+      "creator": "Plugin",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2453161,
+      "artist": "ShinRa-Bansho x Chocofan",
+      "title": "Touhou Ieru Kana",
+      "creator": "Ekrem Imamoglu",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-08T21:30:50Z"
+    },
+    {
+      "beatmapset_id": 2453911,
+      "artist": "Demetori",
+      "title": "Intro / Kuuchuu ni Shizumu Kishinjou ~ Counter-Clock World",
+      "creator": "tacoyaki5",
+      "source": "東方輝針城　～ Double Dealing Character.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-01-26T13:46:39Z"
+    },
+    {
+      "beatmapset_id": 2454530,
+      "artist": "Demetori",
+      "title": "Youyou Bakko ~ Who done it!!!",
+      "creator": "gay girl",
+      "source": "",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2456336,
+      "artist": "Senpi",
+      "title": "Touhou Last Boss Rush!! (Cut Ver.)",
+      "creator": "Suicune3",
+      "source": "東方Project",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-08-02T00:46:39Z"
+    },
+    {
+      "beatmapset_id": 2461093,
+      "artist": "Shibayan feat. 3L",
+      "title": "MyonMyonMyonMyonMyonMyon!",
+      "creator": "SUISEI69",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-03-21T15:47:10Z"
+    },
+    {
+      "beatmapset_id": 2470449,
+      "artist": "ShinRa-Bansho",
+      "title": "Ano Hi no Yume no Alice",
+      "creator": "Aspheria",
+      "source": "東方Project",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2025-11-28T12:18:08Z"
+    },
+    {
+      "beatmapset_id": 2489219,
+      "artist": "Akatsuki Records",
+      "title": "KARMANATIONS",
+      "creator": "Cafe_deCoral",
+      "source": "東方夢時空　～ Phantasmagoria of Dim.Dream",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-04-23T13:54:49Z"
+    },
+    {
+      "beatmapset_id": 2489801,
+      "artist": "ShinRa-Bansho",
+      "title": "Noumiso Rigid Girl",
+      "creator": "ameponzu",
+      "source": "",
+      "status": "wip",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2492855,
+      "artist": "Masayoshi Minoshima",
+      "title": "Black Pepper!! feat. nomico",
+      "creator": "Blacky Design",
+      "source": "東方幻想郷　～ Lotus Land Story",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-04-29T20:11:56Z"
+    },
+    {
+      "beatmapset_id": 2493591,
+      "artist": "",
+      "title": "beatmapsets/2493591#osu/5479622",
+      "creator": "",
+      "source": "",
+      "status": "unknown",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "candidate",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2499342,
+      "artist": "YAMAZARU",
+      "title": "KAZE (TV Size)",
+      "creator": "Soue",
+      "source": "NARUTO-ナルト-疾風伝",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-01-28T23:32:00Z"
+    },
+    {
+      "beatmapset_id": 2503873,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "Kaeruhime",
+      "creator": "NeKroMan4ik",
+      "source": "",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2505119,
+      "artist": "ZUN",
+      "title": "Youyou Bakko ~ Who done it!",
+      "creator": "nik",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2505745,
+      "artist": "Yuuhei Satellite feat. Marcia",
+      "title": "Ashita Chiru Sadame nara",
+      "creator": "Azasapag",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2509245,
+      "artist": "UI-70",
+      "title": "Mou Uta Shika Kikoenai",
+      "creator": "CrimzonSound",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2510071,
+      "artist": "Demetori",
+      "title": "Seijouki no Pierrot ~ The MadPiero Laughs",
+      "creator": "Aether Realm",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-04T01:15:38Z"
+    },
+    {
+      "beatmapset_id": 2512898,
+      "artist": "Sephid",
+      "title": "Friend",
+      "creator": "Timevid",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2512983,
+      "artist": "ZUN",
+      "title": "Magical Storm",
+      "creator": "Suicune3",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2516983,
+      "artist": "Snowman",
+      "title": "Braggartcrow's dance",
+      "creator": "Sanch-KK",
+      "source": "",
+      "status": "wip",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2517036,
+      "artist": "Retractable",
+      "title": "zombie",
+      "creator": "Nessy",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2517086,
+      "artist": "Akatsuki Records",
+      "title": "Senritsu no COLORS",
+      "creator": "Plugin",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2517314,
+      "artist": "Ga1N",
+      "title": "HOMURA-UNKNOWN-",
+      "creator": "Amano Tooko",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "tournament:2163"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2546023,
+      "artist": "Demetori",
+      "title": "Paradise ~ Deep Mountain",
+      "creator": "Wez",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-08-12T07:52:04Z"
+    },
+    {
+      "beatmapset_id": 2546025,
+      "artist": "ShinRa-Bansho",
+      "title": "lunatic love baby you",
+      "creator": "nnull-",
+      "source": "東方紺珠伝　～ Legacy of Lunatic Kingdom.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-06-06T17:01:50Z"
+    },
+    {
+      "beatmapset_id": 2563025,
+      "artist": "RD-Sounds feat. Meramipop",
+      "title": "Shinkirou",
+      "creator": "Suicune3",
+      "source": "東方心綺楼　～ Hopeless Masquerade.",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-31T21:51:31Z"
+    },
+    {
+      "beatmapset_id": 2567710,
+      "artist": "senya",
+      "title": "Kafka Naru Gunjou e",
+      "creator": "Tokyo 727",
+      "source": "東方緋想天　～ Scarlet Weather Rhapsody",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-26T15:22:05Z"
+    },
+    {
+      "beatmapset_id": 2570231,
+      "artist": "TWXNY, Sxilwix, INNXCENCE",
+      "title": "HEAVENLY JUMPSTYLE",
+      "creator": "iNyix",
+      "source": "",
+      "status": "pending",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou"
+      ],
+      "confidence": "probable",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-08-14T10:32:44Z"
+    },
+    {
+      "beatmapset_id": 2586486,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "Chirei \"Gensoukyou Engi Fuujirareshi Youkai-tachi no Page\"",
+      "creator": "Wispy",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "forum_queue:sd_touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-15",
+      "osu_last_updated": "2026-07-16T09:06:02Z"
     }
   ]
 }

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -95,6 +95,27 @@ class ClassifierTests(unittest.TestCase):
         apply_classification(item, tags="touhou zun arrangement")
         self.assertEqual(item.confidence, "probable")
 
+    def test_resolved_curated_queue_entry_is_probable(self):
+        item = Entry(
+            1,
+            artist="Unknown circle",
+            title="Unknown arrangement",
+            evidence=["forum_queue:sd_touhou"],
+            confidence="candidate",
+        )
+        apply_classification(item)
+        self.assertEqual(item.confidence, "probable")
+
+    def test_unresolved_curated_queue_entry_stays_candidate(self):
+        item = Entry(
+            1,
+            title="beatmapsets/1",
+            evidence=["forum_queue:sd_touhou"],
+            confidence="candidate",
+        )
+        apply_classification(item)
+        self.assertEqual(item.confidence, "candidate")
+
     def test_zun_composed_seihou_track_stays_candidate(self):
         item = Entry(
             2374876,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from touhou_osu.catalog import Catalog
-from touhou_osu.cli import command_discover
+from touhou_osu.cli import command_discover, command_hydrate
 from touhou_osu.models import Entry
 
 
@@ -119,6 +119,41 @@ class DiscoveryTests(unittest.TestCase):
             self.assertEqual(catalog.entries[10].last_checked, "2020-01-01")
             self.assertEqual(catalog.entries[20].confidence, "verified")
             self.assertEqual(catalog.entries[30].confidence, "verified")
+
+    def test_hydrates_incomplete_forum_source_without_oauth(self):
+        raw = {
+            "id": 42,
+            "artist": "ZUN",
+            "title": "Theme",
+            "creator": "mapper",
+            "source": "Touhou",
+            "status": "ranked",
+            "tags": "touhou",
+            "last_updated": "2026-01-01T00:00:00Z",
+            "beatmaps": [{"mode": "osu"}],
+        }
+        page = f'<script id="json-beatmapset" type="application/json">{json.dumps(raw)}</script>'
+        with tempfile.TemporaryDirectory() as directory:
+            catalog_path = Path(directory) / "catalog.json"
+            Catalog(
+                [Entry(42, evidence=["forum_queue:sd_touhou"], confidence="probable")]
+            ).save(catalog_path)
+            args = argparse.Namespace(
+                catalog=catalog_path,
+                workers=2,
+                limit=0,
+                write=True,
+                strict=True,
+            )
+
+            with patch("touhou_osu.cli.get_text", return_value=page):
+                self.assertEqual(command_hydrate(args), 0)
+
+            entry = Catalog.load(catalog_path).entries[42]
+            self.assertEqual(entry.artist, "ZUN")
+            self.assertEqual(entry.title, "Theme")
+            self.assertEqual(entry.confidence, "verified")
+            self.assertIn("osu_source", entry.evidence)
 
 
 if __name__ == "__main__":

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,6 +1,14 @@
 import unittest
+from unittest.mock import patch
 
-from touhou_osu.sources import _collector_entry, parse_beatmap_links, parse_beatmapset_page, parse_wiki_links
+from touhou_osu.sources import (
+    _collector_entry,
+    import_collector_tournament,
+    import_forum_queue,
+    parse_beatmap_links,
+    parse_beatmapset_page,
+    parse_wiki_links,
+)
 
 
 class SourceParserTests(unittest.TestCase):
@@ -34,6 +42,57 @@ class SourceParserTests(unittest.TestCase):
 
     def test_skips_unsubmitted_collector_map(self):
         self.assertIsNone(_collector_entry({"beatmapset": None}, "tournament:1", "verified"))
+
+    def test_imports_every_page_of_forum_queue(self):
+        pages = {
+            "https://osu.ppy.sh/community/forums/topics/1": """
+                <article data-post-id="10"><a href="https://osu.ppy.sh/beatmapsets/1#osu/11">Artist - one</a></article>
+                <article data-post-id="20"></article>
+            """,
+            "https://osu.ppy.sh/community/forums/topics/1?start=20": """
+                <article data-post-id="10"><a href="https://osu.ppy.sh/beatmapsets/1#osu/11">Artist - one</a></article>
+                <article data-post-id="20"></article>
+                <article data-post-id="30"><a href="https://osu.ppy.sh/beatmapsets/2#osu/22">two</a></article>
+            """,
+            "https://osu.ppy.sh/community/forums/topics/1?start=30": """
+                <article data-post-id="20"></article>
+                <article data-post-id="30"><a href="https://osu.ppy.sh/beatmapsets/2#osu/22">two</a></article>
+            """,
+        }
+        with patch("touhou_osu.sources.get_text", side_effect=pages.__getitem__):
+            entries = import_forum_queue(
+                {
+                    "slug": "sd_touhou",
+                    "url": "https://osu.ppy.sh/community/forums/topics/1",
+                }
+            )
+
+        self.assertEqual({entry.beatmapset_id for entry in entries}, {1, 2})
+        self.assertTrue(all(entry.confidence == "candidate" for entry in entries))
+        self.assertTrue(all("forum_queue:sd_touhou" in entry.evidence for entry in entries))
+
+    def test_partial_tournament_pool_stays_candidate(self):
+        payload = {
+            "rounds": [
+                {
+                    "mods": [
+                        {
+                            "maps": [
+                                {
+                                    "mode": "osu",
+                                    "beatmapset": {"id": 42, "artist": "unknown", "title": "unknown"},
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        with patch("touhou_osu.sources.get_json", return_value=payload):
+            entries = import_collector_tournament({"id": 526, "trusted": False})
+
+        self.assertEqual(entries[0].confidence, "candidate")
+        self.assertEqual(entries[0].evidence, ["tournament_candidate:526"])
 
 
 if __name__ == "__main__":

--- a/touhou_osu/classifier.py
+++ b/touhou_osu/classifier.py
@@ -147,6 +147,11 @@ def classify(entry: Entry, *, tags: str = "") -> Classification:
         evidence.add("osu_source")
         return Classification("verified", tuple(sorted(evidence)))
 
+    curated_queue_match = any(item.startswith("forum_queue:") for item in evidence)
+    resolved_metadata = bool(entry.artist and entry.title and not entry.title.startswith("beatmapsets/"))
+    if curated_queue_match and resolved_metadata:
+        return Classification("probable", tuple(sorted(evidence)))
+
     tags_match = contains_any(tags, TOUHOU_TAG_TOKENS)
     artist_match = normalize(entry.artist) in {normalize(item) for item in KNOWN_ARTISTS}
     curated_collection_match = any(item.startswith("osucollector:") for item in evidence)

--- a/touhou_osu/cli.py
+++ b/touhou_osu/cli.py
@@ -10,10 +10,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from .catalog import Catalog
+from .http import get_text
 from .models import CatalogError
 from .osu_api import MissingCredentials, OsuApi, entry_from_osu
 from .site import build, statistics
-from .sources import import_all
+from .sources import import_all, parse_beatmapset_page
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CATALOG = ROOT / "data" / "catalog.json"
@@ -61,18 +62,110 @@ def command_clean(args: argparse.Namespace) -> int:
 
 def command_import_seeds(args: argparse.Namespace) -> int:
     catalog = load_catalog(args.catalog)
-    imported, messages = import_all(load_config(args.config), workers=args.workers)
+    imported, reports = import_all(load_config(args.config), workers=args.workers)
     changed = 0
     for entry in imported:
         _, did_change = catalog.merge(entry)
         changed += did_change
-    for message in messages:
-        print(message)
+    for report in reports:
+        print(report.message())
     print(f"Merged {len(imported)} source records; {changed} catalog entries changed")
     if args.write:
         catalog.save(args.catalog)
         print(f"Wrote {args.catalog}")
     print_stats(catalog)
+    return 0
+
+
+def command_audit_sources(args: argparse.Namespace) -> int:
+    imported, reports = import_all(load_config(args.config), workers=args.workers)
+    unique = len({entry.beatmapset_id for entry in imported})
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "source_records": len(imported),
+                    "unique_beatmapsets": unique,
+                    "sources": [
+                        {
+                            "kind": report.kind,
+                            "name": report.name,
+                            "url": report.url,
+                            "beatmapsets": report.beatmapsets,
+                        }
+                        for report in reports
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    else:
+        for report in reports:
+            print(report.message())
+        print(f"Sources: {len(reports)}; records={len(imported)}; unique beatmapsets={unique}")
+    return 0
+
+
+def command_hydrate(args: argparse.Namespace) -> int:
+    """Fill incomplete source records from public osu! beatmapset pages."""
+    catalog = load_catalog(args.catalog)
+    prefixes = ("forum_queue:", "tournament_candidate:")
+    pending = [
+        entry
+        for entry in catalog.entries.values()
+        if any(item.startswith(prefixes) for item in entry.evidence)
+        and (not entry.artist or not entry.title or not entry.source or entry.status == "unknown")
+    ]
+    demoted = 0
+    for entry in pending:
+        if "manual:verified" not in entry.evidence and any(
+            item.startswith("forum_queue:") for item in entry.evidence
+        ) and entry.confidence != "candidate":
+            # A queue link proves relevance, but incomplete metadata should not
+            # be published until the public beatmapset page has been resolved.
+            entry.confidence = "candidate"
+            demoted += 1
+    pending.sort(
+        key=lambda entry: (
+            not any(item.startswith("forum_queue:") for item in entry.evidence),
+            entry.beatmapset_id,
+        )
+    )
+    if args.limit:
+        pending = pending[: args.limit]
+
+    def fetch(entry):
+        raw = parse_beatmapset_page(get_text(f"https://osu.ppy.sh/beatmapsets/{entry.beatmapset_id}"))
+        incoming = entry_from_osu(raw, evidence=entry.evidence, confidence=entry.confidence)
+        incoming.touhou_kind = entry.touhou_kind
+        incoming.origin_games = entry.origin_games
+        incoming.original_themes = entry.original_themes
+        return incoming
+
+    changed = demoted
+    failures: list[str] = []
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {executor.submit(fetch, entry): entry.beatmapset_id for entry in pending}
+        for future in as_completed(futures):
+            beatmapset_id = futures[future]
+            try:
+                incoming = future.result()
+            except Exception as exc:  # keep deleted or temporarily unavailable sets reviewable
+                failures.append(f"beatmapset {beatmapset_id}: {exc}")
+                continue
+            _, did_change = catalog.merge(incoming)
+            changed += did_change
+
+    for failure in sorted(failures):
+        print(f"warning: {failure}", file=sys.stderr)
+    print(f"Hydrated {len(pending) - len(failures)} beatmapsets; {changed} entries changed")
+    if args.write:
+        catalog.save(args.catalog)
+        print(f"Wrote {args.catalog}")
+    print_stats(catalog)
+    if failures and args.strict:
+        return 1
     return 0
 
 
@@ -176,6 +269,19 @@ def parser() -> argparse.ArgumentParser:
     clean = subparsers.add_parser("clean", help="remove generated output")
     clean.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
     clean.set_defaults(func=command_clean)
+
+    audit = subparsers.add_parser("audit-sources", help="query every configured source and report coverage")
+    audit.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    audit.add_argument("--workers", type=int, default=4)
+    audit.add_argument("--json", action="store_true")
+    audit.set_defaults(func=command_audit_sources)
+
+    hydrate = subparsers.add_parser("hydrate", help="fill incomplete source records from public pages")
+    hydrate.add_argument("--workers", type=int, default=2)
+    hydrate.add_argument("--limit", type=int, default=0, help="maximum records; use 0 for unlimited")
+    hydrate.add_argument("--write", action="store_true")
+    hydrate.add_argument("--strict", action="store_true")
+    hydrate.set_defaults(func=command_hydrate)
 
     for name, help_text, function in (
         ("import-seeds", "import configured seed sources", command_import_seeds),

--- a/touhou_osu/sources.py
+++ b/touhou_osu/sources.py
@@ -6,6 +6,7 @@ import json
 import re
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from datetime import date
 from html.parser import HTMLParser
 
@@ -14,9 +15,21 @@ from .http import get_json, get_text
 from .models import Entry, normalize_mode
 
 BEATMAPSET_RE = re.compile(r"/beatmapsets/(\d+)(?:#(osu|taiko|fruits|mania))?")
+FORUM_POST_ID_RE = re.compile(r'data-post-id="(\d+)"')
 MARKDOWN_BEATMAPSET_RE = re.compile(
     r"\[([^\n]*?)\]\(https?://osu\.ppy\.sh/beatmapsets/(\d+)(?:#(osu|taiko|fruits|mania)/\d+)?\)"
 )
+
+
+@dataclass(frozen=True)
+class SourceReport:
+    kind: str
+    name: str
+    url: str
+    beatmapsets: int
+
+    def message(self) -> str:
+        return f"{self.kind}/{self.name}: {self.beatmapsets} beatmapsets ({self.url})"
 
 
 class BeatmapLinkParser(HTMLParser):
@@ -193,13 +206,15 @@ def import_collector_collection(source: dict) -> list[Entry]:
 
 def import_collector_tournament(source: dict) -> list[Entry]:
     source_id = int(source["id"])
-    evidence = f"tournament:{source_id}"
-    payload = get_json(f"https://osucollector.com/api/tournaments/{source_id}")
+    trusted = bool(source.get("trusted", True))
+    evidence = f"tournament:{source_id}" if trusted else f"tournament_candidate:{source_id}"
+    confidence = "verified" if trusted else source.get("confidence", "candidate")
+    payload = get_json(source.get("api_url", f"https://osucollector.com/api/tournaments/{source_id}"))
     entries: dict[int, Entry] = {}
     for round_data in payload.get("rounds", []):
         for mod in round_data.get("mods", []):
             for raw in mod.get("maps", []):
-                incoming = _collector_entry(raw, evidence, "verified")
+                incoming = _collector_entry(raw, evidence, confidence)
                 if incoming is None:
                     continue
                 current = entries.get(incoming.beatmapset_id)
@@ -212,7 +227,8 @@ def import_collector_tournament(source: dict) -> list[Entry]:
 
 def import_official_pack(source: dict) -> list[Entry]:
     tag = source["tag"]
-    links = parse_beatmap_links(get_text(f"https://osu.ppy.sh/beatmaps/packs/{tag}"))
+    url = source.get("url", f"https://osu.ppy.sh/beatmaps/packs/{tag}")
+    links = parse_beatmap_links(get_text(url))
     evidence = f"official_pack:{tag}"
     return [
         Entry(
@@ -245,6 +261,70 @@ def import_wiki_tournament(source: dict) -> list[Entry]:
     ]
 
 
+def _forum_page_url(url: str, start: int | None) -> str:
+    if start is None:
+        return url
+    parsed = urllib.parse.urlsplit(url)
+    query = dict(urllib.parse.parse_qsl(parsed.query, keep_blank_values=True))
+    query["start"] = str(start)
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urllib.parse.urlencode(query), parsed.fragment)
+    )
+
+
+def import_forum_queue(source: dict) -> list[Entry]:
+    """Import every beatmapset linked in a paginated osu! forum queue."""
+    slug = source["slug"]
+    evidence = f"forum_queue:{slug}"
+    entries: dict[int, Entry] = {}
+    start: int | None = None
+    seen_last_posts: set[int] = set()
+    max_pages = int(source.get("max_pages", 20))
+
+    for _ in range(max_pages):
+        text = get_text(_forum_page_url(source["url"], start))
+        for item in parse_beatmap_links(text):
+            incoming = Entry(
+                beatmapset_id=item["id"],
+                artist=item["artist"],
+                title=item["title"],
+                modes=[item["mode"]] if item["mode"] else [],
+                evidence=[evidence],
+                # A bare forum link is kept out of the public index until its
+                # beatmapset metadata can be resolved and classified.
+                confidence="candidate",
+                last_checked=date.today().isoformat(),
+            )
+            current = entries.get(incoming.beatmapset_id)
+            if current is None:
+                entries[incoming.beatmapset_id] = incoming
+            else:
+                current.modes = sorted(set(current.modes) | set(incoming.modes))
+
+        post_ids = [int(value) for value in FORUM_POST_ID_RE.findall(text)]
+        if not post_ids:
+            raise RuntimeError(f"forum queue {slug} did not contain any forum posts")
+        last_post = post_ids[-1]
+        if last_post == start or last_post in seen_last_posts:
+            return list(entries.values())
+        seen_last_posts.add(last_post)
+        start = last_post
+
+    raise RuntimeError(f"forum queue {slug} exceeded its {max_pages}-page safety limit")
+
+
+def source_url(kind: str, source: dict) -> str:
+    if source.get("url"):
+        return source["url"]
+    if kind == "osu_collector_collections":
+        return f"https://osucollector.com/collections/{source['id']}"
+    if kind == "osu_collector_tournaments":
+        return source.get("api_url", f"https://osucollector.com/api/tournaments/{source['id']}")
+    if kind == "official_packs":
+        return f"https://osu.ppy.sh/beatmaps/packs/{source['tag']}"
+    return "unknown"
+
+
 def import_source(kind: str, source: dict) -> list[Entry]:
     if kind == "osu_collector_collections":
         return import_collector_collection(source)
@@ -254,10 +334,12 @@ def import_source(kind: str, source: dict) -> list[Entry]:
         return import_official_pack(source)
     if kind == "wiki_tournaments":
         return import_wiki_tournament(source)
+    if kind == "forum_queues":
+        return import_forum_queue(source)
     raise ValueError(f"unsupported seed source type: {kind}")
 
 
-def import_all(config: dict, *, workers: int = 4) -> tuple[list[Entry], list[str]]:
+def import_all(config: dict, *, workers: int = 4) -> tuple[list[Entry], list[SourceReport]]:
     tasks = [
         (kind, source)
         for kind in (
@@ -265,17 +347,23 @@ def import_all(config: dict, *, workers: int = 4) -> tuple[list[Entry], list[str
             "osu_collector_tournaments",
             "official_packs",
             "wiki_tournaments",
+            "forum_queues",
         )
         for source in config.get(kind, [])
     ]
     entries: list[Entry] = []
-    messages: list[str] = []
+    reports: list[SourceReport] = []
     with ThreadPoolExecutor(max_workers=workers) as executor:
         futures = {executor.submit(import_source, kind, source): (kind, source) for kind, source in tasks}
         for future in as_completed(futures):
             kind, source = futures[future]
             label = source.get("name") or source.get("tag") or source.get("edition") or source.get("id")
             imported = future.result()
+            minimum = int(source.get("minimum_entries", 1))
+            if len(imported) < minimum:
+                raise RuntimeError(
+                    f"{kind}/{label} returned {len(imported)} beatmapsets; expected at least {minimum}"
+                )
             entries.extend(imported)
-            messages.append(f"{kind}/{label}: {len(imported)} beatmapsets")
-    return entries, sorted(messages)
+            reports.append(SourceReport(kind, str(label), source_url(kind, source), len(imported)))
+    return entries, sorted(reports, key=lambda item: (item.kind, item.name.casefold()))


### PR DESCRIPTION
## Summary

- complete the requested CardinalWolf, 10S, 4-Touhou Main, official pack, tournament, TMC wiki, and sd_touhou source coverage
- add reusable live source auditing and public-page metadata hydration commands
- add fail-closed minimum source counts and candidate-first handling for mixed tournament pools
- document all 27 sources, canonical URLs, current counts, and maintenance policy
- regenerate the catalog from the expanded source set

## Catalog impact

- 2,601 -> 2,994 total beatmapsets
- 669 -> 1,296 accepted beatmapsets
- 393 additions, 0 removals, 0 confidence demotions
- 27 live sources, 6,397 source records, 2,992 unique source beatmapsets
- unresolved or deleted queue links remain candidates

## Safety decisions

- Scarlet tournament pools are candidate-first because their own description permits non-Touhou maps
- trusted Touhou-only tournaments and official packs are verified provenance
- a curated queue link becomes probable only after artist/title metadata resolves
- every configured source has a minimum entry floor so truncated upstream responses fail closed

## Validation

- `make audit-sources`
- `make check` (29 tests)
- `make build` (1,296 accepted records)
- `git diff --check`
