### PR TITLE
docs: add auto-generated catalog stats SVG

### DIFF
--- a/.github/workflows/catalog-stats.yml
+++ b/.github/workflows/catalog-stats.yml
@@ -1,0 +1,44 @@
+name: Update catalog stats
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "data/catalog.json"
+      - "scripts/generate_catalog_stats_svg.py"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: catalog-stats-main
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Fast-forward to latest main
+        run: git pull --ff-only origin main
+      - name: Generate catalog stats SVG
+        run: python scripts/generate_catalog_stats_svg.py
+      - name: Commit updated SVG
+        run: |
+          if git diff --quiet -- assets/catalog-stats.svg; then
+            echo "Catalog stats SVG is already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/catalog-stats.svg
+          git commit -m "docs: refresh catalog stats"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Pages](https://github.com/N0zoM1z0/touhou-osu-index/actions/workflows/pages.yml/badge.svg)](https://github.com/N0zoM1z0/touhou-osu-index/actions/workflows/pages.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-ff66aa.svg)](LICENSE)
 
+<p align="center">
+  <img src="assets/catalog-stats.svg" alt="Touhou osu! Index catalog statistics" width="760">
+</p>
+
 An open, reproducible index of Touhou Project music mapped in osu!. It combines
 historical collections, official beatmap packs, Touhou-only tournament pools,
 and osu! API discovery into one deduplicated catalog keyed by **beatmapset ID**.

--- a/assets/catalog-stats.svg
+++ b/assets/catalog-stats.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="150" viewBox="0 0 760 150" role="img" aria-labelledby="title desc">
+  <title id="title">Touhou osu! Index catalog statistics</title>
+  <desc id="desc">1,340 accepted beatmapsets, 1,311 verified, 29 probable, 1,652 candidates, 2 excluded.</desc>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .heading { fill: #f0f6fc; font-size: 15px; font-weight: 700; }
+    .eyebrow { fill: #8b949e; font-size: 10px; font-weight: 700; letter-spacing: 1.2px; }
+    .label { fill: #8b949e; font-size: 11px; font-weight: 600; }
+    .value { fill: #f0f6fc; font-size: 30px; font-weight: 700; }
+    .meta { fill: #8b949e; font-size: 11px; }
+    .accent { fill: #ff66aa; }
+  </style>
+  <rect width="760" height="150" rx="14" fill="#0d1117"/>
+  <rect x="0.5" y="0.5" width="759" height="149" rx="13.5" fill="none" stroke="#30363d"/>
+  <rect x="0" y="0" width="5" height="150" rx="2.5" class="accent"/>
+
+  <text x="28" y="29" class="eyebrow">CATALOG STATUS</text>
+  <text x="28" y="49" class="heading">Touhou osu! Index</text>
+
+  <line x1="226" y1="22" x2="226" y2="116" stroke="#21262d"/>
+  <line x1="480" y1="22" x2="480" y2="116" stroke="#21262d"/>
+
+  <text x="258" y="43" class="label">ACCEPTED BEATMAPSETS</text>
+  <text x="258" y="78" class="value">1,340</text>
+  <text x="258" y="99" class="meta">verified + probable</text>
+
+  <text x="512" y="43" class="label">VERIFIED BEATMAPSETS</text>
+  <text x="512" y="78" class="value">1,311</text>
+  <text x="512" y="99" class="meta">97.8% of accepted</text>
+
+  <line x1="28" y1="116" x2="732" y2="116" stroke="#21262d"/>
+  <text x="28" y="137" class="meta">29 probable  ·  1,652 in review queue  ·  2 excluded  ·  2,994 total tracked</text>
+</svg>

--- a/assets/catalog-stats.svg
+++ b/assets/catalog-stats.svg
@@ -1,33 +1,55 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="760" height="150" viewBox="0 0 760 150" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="126" viewBox="0 0 760 126" role="img" aria-labelledby="title desc">
   <title id="title">Touhou osu! Index catalog statistics</title>
-  <desc id="desc">1,340 accepted beatmapsets, 1,311 verified, 29 probable, 1,652 candidates, 2 excluded.</desc>
+  <desc id="desc">2,994 total tracked beatmapsets; 1,311 verified (43.8%).</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2a1018"/>
+      <stop offset="100%" stop-color="#150c11"/>
+    </linearGradient>
+    <clipPath id="card">
+      <rect width="760" height="126" rx="14"/>
+    </clipPath>
+  </defs>
   <style>
     text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
-    .heading { fill: #f0f6fc; font-size: 15px; font-weight: 700; }
-    .eyebrow { fill: #8b949e; font-size: 10px; font-weight: 700; letter-spacing: 1.2px; }
-    .label { fill: #8b949e; font-size: 11px; font-weight: 600; }
-    .value { fill: #f0f6fc; font-size: 30px; font-weight: 700; }
-    .meta { fill: #8b949e; font-size: 11px; }
-    .accent { fill: #ff66aa; }
+    .brand-small { fill: #dc7b88; font-size: 10px; font-weight: 800; letter-spacing: 1.8px; }
+    .brand { fill: #fff8f4; font-size: 17px; font-weight: 700; }
+    .label { fill: #bcaeb2; font-size: 11px; font-weight: 700; letter-spacing: 1.1px; }
+    .value { fill: #fffaf7; font-size: 34px; font-weight: 700; }
+    .percent { fill: #8b2032; font-size: 12px; font-weight: 800; }
   </style>
-  <rect width="760" height="150" rx="14" fill="#0d1117"/>
-  <rect x="0.5" y="0.5" width="759" height="149" rx="13.5" fill="none" stroke="#30363d"/>
-  <rect x="0" y="0" width="5" height="150" rx="2.5" class="accent"/>
 
-  <text x="28" y="29" class="eyebrow">CATALOG STATUS</text>
-  <text x="28" y="49" class="heading">Touhou osu! Index</text>
+  <rect width="760" height="126" rx="14" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="759" height="125" rx="13.5" fill="none" stroke="#5b2934"/>
 
-  <line x1="226" y1="22" x2="226" y2="116" stroke="#21262d"/>
-  <line x1="480" y1="22" x2="480" y2="116" stroke="#21262d"/>
+  <g clip-path="url(#card)" fill="none">
+    <circle cx="732" cy="63" r="86" stroke="#e05263" stroke-width="1.4" opacity="0.11"/>
+    <circle cx="732" cy="63" r="55" stroke="#f4ddd8" stroke-width="1" opacity="0.08"/>
+    <circle cx="732" cy="63" r="28" stroke="#e05263" stroke-width="1" stroke-dasharray="3 7" opacity="0.15"/>
+    <path d="M652 23 C691 9 731 12 764 32" stroke="#e05263" stroke-width="1" opacity="0.09"/>
+    <path d="M651 103 C692 117 731 114 764 94" stroke="#e05263" stroke-width="1" opacity="0.09"/>
+  </g>
 
-  <text x="258" y="43" class="label">ACCEPTED BEATMAPSETS</text>
-  <text x="258" y="78" class="value">1,340</text>
-  <text x="258" y="99" class="meta">verified + probable</text>
+  <circle cx="32" cy="63" r="14" fill="none" stroke="#e05263" stroke-width="2"/>
+  <circle cx="32" cy="63" r="4" fill="#fff8f4"/>
+  <circle cx="32" cy="45" r="2.5" fill="#e05263"/>
+  <circle cx="48" cy="70" r="2.5" fill="#e05263"/>
+  <circle cx="18" cy="75" r="2.5" fill="#e05263"/>
 
-  <text x="512" y="43" class="label">VERIFIED BEATMAPSETS</text>
-  <text x="512" y="78" class="value">1,311</text>
-  <text x="512" y="99" class="meta">97.8% of accepted</text>
+  <text x="58" y="57" class="brand-small">TOUHOU</text>
+  <text x="58" y="78" class="brand">osu! Index</text>
 
-  <line x1="28" y1="116" x2="732" y2="116" stroke="#21262d"/>
-  <text x="28" y="137" class="meta">29 probable  ·  1,652 in review queue  ·  2 excluded  ·  2,994 total tracked</text>
+  <line x1="205" y1="24" x2="205" y2="102" stroke="#6a303b" opacity="0.75"/>
+
+  <text x="242" y="47" class="label">TOTAL BEATMAPSETS</text>
+  <text x="242" y="83" class="value">2,994</text>
+
+  <line x1="452" y1="36" x2="452" y2="90" stroke="#6a303b" opacity="0.55"/>
+
+  <text x="488" y="47" class="label">VERIFIED</text>
+  <text x="488" y="83" class="value">1,311</text>
+  <rect x="616" y="58" width="72" height="25" rx="12.5" fill="#fff3ed"/>
+  <text x="652" y="75" class="percent" text-anchor="middle">43.8%</text>
+
+  <rect x="0" y="0" width="760" height="3" rx="1.5" fill="#d63f52"/>
 </svg>

--- a/scripts/generate_catalog_stats_svg.py
+++ b/scripts/generate_catalog_stats_svg.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Generate the README catalog statistics card from the canonical catalog."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOG_PATH = ROOT / "data" / "catalog.json"
+OUTPUT_PATH = ROOT / "assets" / "catalog-stats.svg"
+
+
+def fmt(value: int) -> str:
+    return f"{value:,}"
+
+
+def load_stats() -> dict[str, int]:
+    raw = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    entries = raw.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("catalog entries must be a list")
+
+    counts = Counter(entry.get("confidence") for entry in entries)
+    verified = counts["verified"]
+    probable = counts["probable"]
+
+    return {
+        "accepted": verified + probable,
+        "verified": verified,
+        "probable": probable,
+        "candidate": counts["candidate"],
+        "excluded": counts["excluded"],
+        "total": len(entries),
+    }
+
+
+def render_svg(stats: dict[str, int]) -> str:
+    accepted = stats["accepted"]
+    verified = stats["verified"]
+    verified_ratio = (verified / accepted * 100) if accepted else 0
+
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="760" height="150" viewBox="0 0 760 150" role="img" aria-labelledby="title desc">
+  <title id="title">Touhou osu! Index catalog statistics</title>
+  <desc id="desc">{fmt(accepted)} accepted beatmapsets, {fmt(verified)} verified, {fmt(stats["probable"])} probable, {fmt(stats["candidate"])} candidates, {fmt(stats["excluded"])} excluded.</desc>
+  <style>
+    text {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }}
+    .heading {{ fill: #f0f6fc; font-size: 15px; font-weight: 700; }}
+    .eyebrow {{ fill: #8b949e; font-size: 10px; font-weight: 700; letter-spacing: 1.2px; }}
+    .label {{ fill: #8b949e; font-size: 11px; font-weight: 600; }}
+    .value {{ fill: #f0f6fc; font-size: 30px; font-weight: 700; }}
+    .meta {{ fill: #8b949e; font-size: 11px; }}
+    .accent {{ fill: #ff66aa; }}
+  </style>
+  <rect width="760" height="150" rx="14" fill="#0d1117"/>
+  <rect x="0.5" y="0.5" width="759" height="149" rx="13.5" fill="none" stroke="#30363d"/>
+  <rect x="0" y="0" width="5" height="150" rx="2.5" class="accent"/>
+
+  <text x="28" y="29" class="eyebrow">CATALOG STATUS</text>
+  <text x="28" y="49" class="heading">Touhou osu! Index</text>
+
+  <line x1="226" y1="22" x2="226" y2="116" stroke="#21262d"/>
+  <line x1="480" y1="22" x2="480" y2="116" stroke="#21262d"/>
+
+  <text x="258" y="43" class="label">ACCEPTED BEATMAPSETS</text>
+  <text x="258" y="78" class="value">{fmt(accepted)}</text>
+  <text x="258" y="99" class="meta">verified + probable</text>
+
+  <text x="512" y="43" class="label">VERIFIED BEATMAPSETS</text>
+  <text x="512" y="78" class="value">{fmt(verified)}</text>
+  <text x="512" y="99" class="meta">{verified_ratio:.1f}% of accepted</text>
+
+  <line x1="28" y1="116" x2="732" y2="116" stroke="#21262d"/>
+  <text x="28" y="137" class="meta">{fmt(stats["probable"])} probable  ·  {fmt(stats["candidate"])} in review queue  ·  {fmt(stats["excluded"])} excluded  ·  {fmt(stats["total"])} total tracked</text>
+</svg>
+'''
+
+
+def main() -> None:
+    stats = load_stats()
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(render_svg(stats), encoding="utf-8")
+    print(
+        "Generated catalog stats: "
+        f"accepted={stats['accepted']} verified={stats['verified']} total={stats['total']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_catalog_stats_svg.py
+++ b/scripts/generate_catalog_stats_svg.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-from collections import Counter
 from pathlib import Path
 
 
@@ -17,75 +16,84 @@ def fmt(value: int) -> str:
     return f"{value:,}"
 
 
-def load_stats() -> dict[str, int]:
+def load_stats() -> tuple[int, int]:
     raw = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
     entries = raw.get("entries")
     if not isinstance(entries, list):
         raise ValueError("catalog entries must be a list")
 
-    counts = Counter(entry.get("confidence") for entry in entries)
-    verified = counts["verified"]
-    probable = counts["probable"]
-
-    return {
-        "accepted": verified + probable,
-        "verified": verified,
-        "probable": probable,
-        "candidate": counts["candidate"],
-        "excluded": counts["excluded"],
-        "total": len(entries),
-    }
+    total = len(entries)
+    verified = sum(entry.get("confidence") == "verified" for entry in entries)
+    return total, verified
 
 
-def render_svg(stats: dict[str, int]) -> str:
-    accepted = stats["accepted"]
-    verified = stats["verified"]
-    verified_ratio = (verified / accepted * 100) if accepted else 0
+def render_svg(total: int, verified: int) -> str:
+    verified_ratio = (verified / total * 100) if total else 0
 
-    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="760" height="150" viewBox="0 0 760 150" role="img" aria-labelledby="title desc">
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="760" height="126" viewBox="0 0 760 126" role="img" aria-labelledby="title desc">
   <title id="title">Touhou osu! Index catalog statistics</title>
-  <desc id="desc">{fmt(accepted)} accepted beatmapsets, {fmt(verified)} verified, {fmt(stats["probable"])} probable, {fmt(stats["candidate"])} candidates, {fmt(stats["excluded"])} excluded.</desc>
+  <desc id="desc">{fmt(total)} total tracked beatmapsets; {fmt(verified)} verified ({verified_ratio:.1f}%).</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2a1018"/>
+      <stop offset="100%" stop-color="#150c11"/>
+    </linearGradient>
+    <clipPath id="card">
+      <rect width="760" height="126" rx="14"/>
+    </clipPath>
+  </defs>
   <style>
     text {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }}
-    .heading {{ fill: #f0f6fc; font-size: 15px; font-weight: 700; }}
-    .eyebrow {{ fill: #8b949e; font-size: 10px; font-weight: 700; letter-spacing: 1.2px; }}
-    .label {{ fill: #8b949e; font-size: 11px; font-weight: 600; }}
-    .value {{ fill: #f0f6fc; font-size: 30px; font-weight: 700; }}
-    .meta {{ fill: #8b949e; font-size: 11px; }}
-    .accent {{ fill: #ff66aa; }}
+    .brand-small {{ fill: #dc7b88; font-size: 10px; font-weight: 800; letter-spacing: 1.8px; }}
+    .brand {{ fill: #fff8f4; font-size: 17px; font-weight: 700; }}
+    .label {{ fill: #bcaeb2; font-size: 11px; font-weight: 700; letter-spacing: 1.1px; }}
+    .value {{ fill: #fffaf7; font-size: 34px; font-weight: 700; }}
+    .percent {{ fill: #8b2032; font-size: 12px; font-weight: 800; }}
   </style>
-  <rect width="760" height="150" rx="14" fill="#0d1117"/>
-  <rect x="0.5" y="0.5" width="759" height="149" rx="13.5" fill="none" stroke="#30363d"/>
-  <rect x="0" y="0" width="5" height="150" rx="2.5" class="accent"/>
 
-  <text x="28" y="29" class="eyebrow">CATALOG STATUS</text>
-  <text x="28" y="49" class="heading">Touhou osu! Index</text>
+  <rect width="760" height="126" rx="14" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="759" height="125" rx="13.5" fill="none" stroke="#5b2934"/>
 
-  <line x1="226" y1="22" x2="226" y2="116" stroke="#21262d"/>
-  <line x1="480" y1="22" x2="480" y2="116" stroke="#21262d"/>
+  <g clip-path="url(#card)" fill="none">
+    <circle cx="732" cy="63" r="86" stroke="#e05263" stroke-width="1.4" opacity="0.11"/>
+    <circle cx="732" cy="63" r="55" stroke="#f4ddd8" stroke-width="1" opacity="0.08"/>
+    <circle cx="732" cy="63" r="28" stroke="#e05263" stroke-width="1" stroke-dasharray="3 7" opacity="0.15"/>
+    <path d="M652 23 C691 9 731 12 764 32" stroke="#e05263" stroke-width="1" opacity="0.09"/>
+    <path d="M651 103 C692 117 731 114 764 94" stroke="#e05263" stroke-width="1" opacity="0.09"/>
+  </g>
 
-  <text x="258" y="43" class="label">ACCEPTED BEATMAPSETS</text>
-  <text x="258" y="78" class="value">{fmt(accepted)}</text>
-  <text x="258" y="99" class="meta">verified + probable</text>
+  <circle cx="32" cy="63" r="14" fill="none" stroke="#e05263" stroke-width="2"/>
+  <circle cx="32" cy="63" r="4" fill="#fff8f4"/>
+  <circle cx="32" cy="45" r="2.5" fill="#e05263"/>
+  <circle cx="48" cy="70" r="2.5" fill="#e05263"/>
+  <circle cx="18" cy="75" r="2.5" fill="#e05263"/>
 
-  <text x="512" y="43" class="label">VERIFIED BEATMAPSETS</text>
-  <text x="512" y="78" class="value">{fmt(verified)}</text>
-  <text x="512" y="99" class="meta">{verified_ratio:.1f}% of accepted</text>
+  <text x="58" y="57" class="brand-small">TOUHOU</text>
+  <text x="58" y="78" class="brand">osu! Index</text>
 
-  <line x1="28" y1="116" x2="732" y2="116" stroke="#21262d"/>
-  <text x="28" y="137" class="meta">{fmt(stats["probable"])} probable  ·  {fmt(stats["candidate"])} in review queue  ·  {fmt(stats["excluded"])} excluded  ·  {fmt(stats["total"])} total tracked</text>
+  <line x1="205" y1="24" x2="205" y2="102" stroke="#6a303b" opacity="0.75"/>
+
+  <text x="242" y="47" class="label">TOTAL BEATMAPSETS</text>
+  <text x="242" y="83" class="value">{fmt(total)}</text>
+
+  <line x1="452" y1="36" x2="452" y2="90" stroke="#6a303b" opacity="0.55"/>
+
+  <text x="488" y="47" class="label">VERIFIED</text>
+  <text x="488" y="83" class="value">{fmt(verified)}</text>
+  <rect x="616" y="58" width="72" height="25" rx="12.5" fill="#fff3ed"/>
+  <text x="652" y="75" class="percent" text-anchor="middle">{verified_ratio:.1f}%</text>
+
+  <rect x="0" y="0" width="760" height="3" rx="1.5" fill="#d63f52"/>
 </svg>
 '''
 
 
 def main() -> None:
-    stats = load_stats()
+    total, verified = load_stats()
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT_PATH.write_text(render_svg(stats), encoding="utf-8")
-    print(
-        "Generated catalog stats: "
-        f"accepted={stats['accepted']} verified={stats['verified']} total={stats['total']}"
-    )
+    OUTPUT_PATH.write_text(render_svg(total, verified), encoding="utf-8")
+    ratio = (verified / total * 100) if total else 0
+    print(f"Generated catalog stats: total={total} verified={verified} ({ratio:.1f}%)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a compact Touhou-inspired catalog statistics card to the README
- generate the SVG deterministically from `data/catalog.json`
- show only the two requested headline values: total tracked beatmapsets and verified beatmapsets
- show the verified share of the full catalog next to the verified count
- automatically refresh the committed SVG after catalog changes land on `main`

## Current generated values

- total tracked: 2,994
- verified: 1,311 (43.8%)

The visual uses a restrained red/white shrine palette with subtle danmaku/spell-circle motifs. The displayed numbers are generated by `scripts/generate_catalog_stats_svg.py`; they are not intended to be maintained manually.