### PR TITLE
data: systematically audit Border of Life coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,12 @@ provenance. Please keep changes small and evidence-backed.
    by evidence. Do not guess from a character background.
 6. Run `make check` and `make build`.
 
+For composition-centered completeness passes, follow
+[`docs/systematic-theme-audit-workflow.md`](docs/systematic-theme-audit-workflow.md).
+Theme/title search results are discovery evidence only: lock the composition
+boundary first, direct-refetch retained beatmapsets, and document false-positive
+or unresolved boundaries alongside accepted IDs.
+
 Manual evidence is sticky: automated refreshes update osu! metadata but do not
 override `manual:verified`, `manual:excluded`, or a reviewed `manual:candidate`
 boundary. Use `manual:candidate` when an item is relevant enough to retain for

--- a/data/catalog/0000000-0024999.json
+++ b/data/catalog/0000000-0024999.json
@@ -97,17 +97,23 @@
       "modes": [
         "osu"
       ],
-      "touhou_kind": "unknown",
-      "origin_games": [],
-      "original_themes": [],
+      "touhou_kind": "mixed",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ボーダーオブライフ",
+        "幽雅に咲かせ、墨染の桜 ～ Border of Life"
+      ],
       "evidence": [
+        "audit:border-of-life-2026-08",
         "discovery_query:Touhou",
         "osu_source",
         "osucollector:1402",
         "osucollector:1405"
       ],
       "confidence": "verified",
-      "last_checked": "2026-08-15",
+      "last_checked": "2026-08-22",
       "osu_last_updated": "2008-12-05T18:38:57Z"
     },
     {
@@ -1487,21 +1493,28 @@
       "artist": "IOSYS",
       "title": "Border of Extacy",
       "creator": "Shinxyn",
-      "source": "",
+      "source": "Touhou",
       "status": "approved",
       "modes": [
         "osu"
       ],
-      "touhou_kind": "unknown",
-      "origin_games": [],
-      "original_themes": [],
+      "touhou_kind": "mixed",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ネクロファンタジア",
+        "ボーダーオブライフ"
+      ],
       "evidence": [
+        "audit:border-of-life-2026-08",
         "known_touhou_artist",
+        "osu_source",
         "osucollector:1402",
         "osucollector:1407"
       ],
-      "confidence": "candidate",
-      "last_checked": "2026-08-15",
+      "confidence": "verified",
+      "last_checked": "2026-08-22",
       "osu_last_updated": "2010-07-03T05:00:47Z"
     },
     {
@@ -5028,6 +5041,31 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2010-03-31T14:15:20Z"
+    },
+    {
+      "beatmapset_id": 14408,
+      "artist": "Nazz-can",
+      "title": "Border of Life",
+      "creator": "beat4you",
+      "source": "Touhou",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "arrangement",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ボーダーオブライフ"
+      ],
+      "evidence": [
+        "audit:border-of-life-2026-08",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-22",
+      "osu_last_updated": "2010-03-30T10:04:33Z"
     },
     {
       "beatmapset_id": 14431,

--- a/data/catalog/0025000-0049999.json
+++ b/data/catalog/0025000-0049999.json
@@ -1284,20 +1284,27 @@
       "artist": "Gojou Kai",
       "title": "Border of Life",
       "creator": "IceBeam",
-      "source": "",
+      "source": "Touhou",
       "status": "ranked",
       "modes": [
         "osu"
       ],
-      "touhou_kind": "unknown",
-      "origin_games": [],
-      "original_themes": [],
+      "touhou_kind": "mixed",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ボーダーオブライフ",
+        "幽雅に咲かせ、墨染の桜 ～ Border of Life"
+      ],
       "evidence": [
+        "audit:border-of-life-2026-08",
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405"
       ],
-      "confidence": "candidate",
-      "last_checked": "2026-08-15",
+      "confidence": "verified",
+      "last_checked": "2026-08-22",
       "osu_last_updated": "2011-05-24T19:14:16Z"
     },
     {

--- a/data/catalog/0700000-0799999.json
+++ b/data/catalog/0700000-0799999.json
@@ -1203,17 +1203,23 @@
       "modes": [
         "taiko"
       ],
-      "touhou_kind": "unknown",
-      "origin_games": [],
-      "original_themes": [],
+      "touhou_kind": "mixed",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ネクロファンタジア",
+        "ボーダーオブライフ"
+      ],
       "evidence": [
+        "audit:border-of-life-2026-08",
         "discovery_query:IOSYS",
         "discovery_query:source=Perfect Cherry Blossom",
         "discovery_query:source=東方妖々夢",
         "osu_source"
       ],
       "confidence": "verified",
-      "last_checked": "2026-08-21",
+      "last_checked": "2026-08-22",
       "osu_last_updated": "2018-08-26T20:20:06Z"
     },
     {

--- a/data/catalog/0800000-0899999.json
+++ b/data/catalog/0800000-0899999.json
@@ -650,17 +650,23 @@
       "modes": [
         "taiko"
       ],
-      "touhou_kind": "unknown",
-      "origin_games": [],
-      "original_themes": [],
+      "touhou_kind": "mixed",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ネクロファンタジア",
+        "ボーダーオブライフ"
+      ],
       "evidence": [
+        "audit:border-of-life-2026-08",
         "discovery_query:IOSYS",
         "discovery_query:source=Perfect Cherry Blossom",
         "discovery_query:source=東方妖々夢",
         "osu_source"
       ],
       "confidence": "verified",
-      "last_checked": "2026-08-21",
+      "last_checked": "2026-08-22",
       "osu_last_updated": "2018-08-26T00:38:33Z"
     },
     {

--- a/data/catalog/1000000-1099999.json
+++ b/data/catalog/1000000-1099999.json
@@ -47,22 +47,28 @@
       "artist": "Rin",
       "title": "Ayakashi set 12 Another ~ Border of Life",
       "creator": "pishifat",
-      "source": "",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
       "status": "ranked",
       "modes": [
         "osu"
       ],
-      "touhou_kind": "unknown",
-      "origin_games": [],
-      "original_themes": [],
+      "touhou_kind": "arrangement",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ボーダーオブライフ"
+      ],
       "evidence": [
+        "audit:border-of-life-2026-08",
+        "osu_source",
         "osucollector:1402",
         "osucollector:1405",
         "osucollector:1407",
         "osucollector:6907"
       ],
-      "confidence": "candidate",
-      "last_checked": "2026-08-15",
+      "confidence": "verified",
+      "last_checked": "2026-08-22",
       "osu_last_updated": "2019-07-25T23:15:17Z"
     },
     {

--- a/data/catalog/1200000-1299999.json
+++ b/data/catalog/1200000-1299999.json
@@ -846,23 +846,28 @@
     {
       "beatmapset_id": 1235944,
       "artist": "Rin",
-      "title": "Ayakashi set 12 Another ~ Border of Life (LaoXiao-) [Jack of Life]",
+      "title": "Ayakashi set 12 Another ~ Border of Life",
       "creator": "LaoXiao-",
       "source": "",
       "status": "graveyard",
       "modes": [
         "mania"
       ],
-      "touhou_kind": "unknown",
-      "origin_games": [],
-      "original_themes": [],
+      "touhou_kind": "arrangement",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ボーダーオブライフ"
+      ],
       "evidence": [
+        "audit:border-of-life-2026-08",
         "tmc:1st",
         "tournament:466"
       ],
       "confidence": "verified",
-      "last_checked": "2026-08-15",
-      "osu_last_updated": null
+      "last_checked": "2026-08-22",
+      "osu_last_updated": "2020-08-14T13:48:08Z"
     },
     {
       "beatmapset_id": 1236758,
@@ -1277,6 +1282,33 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2021-05-28T14:58:14Z"
+    },
+    {
+      "beatmapset_id": 1248505,
+      "artist": "GET IN THE RING",
+      "title": "Phosphor",
+      "creator": "Zelq",
+      "source": "",
+      "status": "graveyard",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "mixed",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom.",
+        "東方神霊廟 ～ Ten Desires."
+      ],
+      "original_themes": [
+        "ゴーストリード",
+        "ボーダーオブライフ"
+      ],
+      "evidence": [
+        "audit:border-of-life-2026-08",
+        "manual:verified"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-22",
+      "osu_last_updated": "2020-09-08T23:28:17Z"
     },
     {
       "beatmapset_id": 1248686,

--- a/data/catalog/1900000-1999999.json
+++ b/data/catalog/1900000-1999999.json
@@ -1154,16 +1154,21 @@
       "modes": [
         "osu"
       ],
-      "touhou_kind": "unknown",
-      "origin_games": [],
-      "original_themes": [],
+      "touhou_kind": "original",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ボーダーオブライフ"
+      ],
       "evidence": [
+        "audit:border-of-life-2026-08",
         "known_touhou_artist",
         "osu_source",
         "tournament_candidate:731"
       ],
       "confidence": "verified",
-      "last_checked": "2026-08-15",
+      "last_checked": "2026-08-22",
       "osu_last_updated": "2023-04-20T14:19:54Z"
     },
     {

--- a/data/catalog/2200000-2299999.json
+++ b/data/catalog/2200000-2299999.json
@@ -975,6 +975,31 @@
       "osu_last_updated": "2026-07-21T14:26:30Z"
     },
     {
+      "beatmapset_id": 2258223,
+      "artist": "ZUN",
+      "title": "Border of Life",
+      "creator": "nik",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "original",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ボーダーオブライフ"
+      ],
+      "evidence": [
+        "audit:border-of-life-2026-08",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-22",
+      "osu_last_updated": "2025-04-22T14:33:58Z"
+    },
+    {
       "beatmapset_id": 2260896,
       "artist": "8686m",
       "title": "Akogare",

--- a/data/catalog/2400000-2499999.json
+++ b/data/catalog/2400000-2499999.json
@@ -902,6 +902,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2443688,
+      "artist": "ZUN",
+      "title": "Border of Life",
+      "creator": "Hivie",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "original",
+      "origin_games": [
+        "東方妖々夢 ～ Perfect Cherry Blossom."
+      ],
+      "original_themes": [
+        "ボーダーオブライフ"
+      ],
+      "evidence": [
+        "audit:border-of-life-2026-08",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-08-22",
+      "osu_last_updated": "2025-10-29T14:29:26Z"
+    },
+    {
       "beatmapset_id": 2444992,
       "artist": "FELT",
       "title": "Sounding Beat & pulse",

--- a/docs/source-audit-2026-08-border-of-life.md
+++ b/docs/source-audit-2026-08-border-of-life.md
@@ -1,0 +1,87 @@
+# ボーダーオブライフ / Border of Life systematic search audit
+
+Date: 2026-08-22
+
+## Scope
+
+This audit targets ZUN's `ボーダーオブライフ`, the Stage 6 boss second theme from `東方妖々夢 ～ Perfect Cherry Blossom.`. It deliberately distinguishes that composition from the separate Stage 6 theme `幽雅に咲かせ、墨染の桜 ～ Border of Life`, even though osu! titles and English-language discographies often shorten either work to `Border of Life`.
+
+Search-title similarity is discovery evidence only. A set is accepted into this audit only after its current public osu! beatmapset identity is resolved and its recording can be tied to the target composition by explicit game/source metadata or composition-level discography evidence.
+
+## Composition ground truth
+
+The main arrangement corpus is Touhou Arrangement Chronicle's original-song page for `ボーダーオブライフ`:
+
+- https://touhou.arrangement-chronicle.com/original_song/%E6%9D%B1%E6%96%B9%E5%A6%96%E3%80%85%E5%A4%A2/%E3%83%9C%E3%83%BC%E3%83%80%E3%83%BC%E3%82%AA%E3%83%96%E3%83%A9%E3%82%A4%E3%83%95
+
+The page identifies the original game as Perfect Cherry Blossom and exposes a large arrangement corpus. Its live arrangement / circle / album counts are volatile and are not used as an acceptance criterion; the page is used as a discovery and composition-chain reference, not as proof that every search hit is in scope.
+
+Important cross-checks used for ambiguous recordings:
+
+- `SYNC.ART'S - ボーダーオブライフ` from `Secret Seven` is explicitly listed as a **mixed arrangement** of both `幽雅に咲かせ、墨染の桜 ～ Border of Life` and `ボーダーオブライフ` on the Arrangement Chronicle target page.
+- `IOSYS - Border of extacy` and its karaoke version are explicitly listed there as **mixed arrangements** of `ボーダーオブライフ` and `ネクロファンタジア`.
+- `Rin - Ayakashi set 12 Another ～ ボーダーオブライフ` is documented by Touhou Wiki as an arrangement of `ボーダーオブライフ`: https://en.touhouwiki.net/wiki/House_set_of_%22Perfect_Cherry_Blossom%22
+- `GET IN THE RING - Phosphor` is documented as a mixed arrangement of `ボーダーオブライフ` and `ゴーストリード`: https://en.touhouwiki.net/wiki/Lyrics%3A_Phosphor and https://touhou.arrangement-chronicle.com/circle/GET%20IN%20THE%20RING/arrange_songs
+- `nazz-can - ボーダーオブライフ` is explicitly mapped to the target composition in `桜華幻奏`: https://thwiki.cc/%E6%A1%9C%E8%8F%AF%E5%B9%BB%E5%A5%8F
+
+## Applied catalog changes
+
+The implementation re-fetches every accepted beatmapset from its public osu! beatmapset page immediately before writing. The audit adds **4 previously absent beatmapsets**:
+
+| Beatmapset | Recording | Classification | Structured originals |
+| ---: | --- | --- | --- |
+| `14408` | Nazz-can - Border of Life | arrangement | `ボーダーオブライフ` |
+| `1248505` | GET IN THE RING - Phosphor | mixed | `ボーダーオブライフ`; `ゴーストリード` |
+| `2258223` | ZUN - Border of Life | original | `ボーダーオブライフ` |
+| `2443688` | ZUN - Border of Life | original | `ボーダーオブライフ` |
+
+`1248505` has a blank osu! source, so its verified judgment is sticky (`manual:verified`) and rests on the independent composition-level sources above. The other three current osu! pages carry explicit Touhou / Perfect Cherry Blossom source metadata.
+
+The audit also enriches **8 existing catalog rows** with structured composition provenance and refreshes their current public metadata:
+
+| Beatmapset | Recording | Classification | Structured originals |
+| ---: | --- | --- | --- |
+| `3573` | Gojou Kai - Border of Life | mixed | `幽雅に咲かせ、墨染の桜 ～ Border of Life`; `ボーダーオブライフ` |
+| `7932` | IOSYS - Border of Extacy | mixed | `ボーダーオブライフ`; `ネクロファンタジア` |
+| `28891` | Gojou Kai - Border of Life | mixed | same Secret Seven recording / originals as `3573` |
+| `732190` | IOSYS - Border of extacy (Karaoke Ver) | mixed | `ボーダーオブライフ`; `ネクロファンタジア` |
+| `819351` | IOSYS - Border of extacy (Karaoke Ver) | mixed | `ボーダーオブライフ`; `ネクロファンタジア` |
+| `1001360` | Rin - Ayakashi set 12 Another ~ Border of Life | arrangement | `ボーダーオブライフ` |
+| `1235944` | Rin - Ayakashi set 12 Another ~ Border of Life | arrangement | `ボーダーオブライフ` |
+| `1953606` | ZUN - Border of Life | original | `ボーダーオブライフ` |
+
+The earlier audit draft had held `732190` and `1235944` because their wrapper identity could not be directly re-verified at that time. Both public osu! beatmapset pages resolve on 2026-08-22, so that temporary identity boundary no longer applies. Their existing confidence/provenance is preserved; this audit only refreshes public metadata and adds composition structure.
+
+## Explicit false-positive boundary
+
+The following title-family hits were reviewed but are **not** target-composition additions:
+
+- `1168786` — BLANKFIELD - Border Of Life
+- `2249236` — SOUND HOLIC - Border of Life
+- `388424` — Aojiru - Border of Life
+- `12508` — Silver Forest - Sakase * Sakase
+- `17628` — SYNC.ART'S feat. Sakaue Nachi - Forever Cherryblossom
+
+These resolve to `幽雅に咲かせ、墨染の桜 ～ Border of Life` or otherwise fail the target-composition chain. In particular, the Arrangement Chronicle page for the Sumizome theme separately lists `Forever cherryblossom`, demonstrating why English `Border of Life` tokens cannot be treated as an exact composition key:
+
+- https://touhou.arrangement-chronicle.com/original_song/%E6%9D%B1%E6%96%B9%E5%A6%96%E3%80%85%E5%A4%A2/%E5%B9%BD%E9%9B%85%E3%81%AB%E5%92%B2%E3%81%8B%E3%81%9B%E3%80%81%E5%A2%A8%E6%9F%93%E3%81%AE%E6%A1%9C%E3%80%80%EF%BD%9E%20Border%20of%20Life
+
+A historical OCL Fall 2024 pool reference to `ZUN - Border of Life (perchance) [Final Stage]` remains documentation-only because the audit still has no direct numeric beatmapset identity to merge. A textual pool label is not enough to invent an ID.
+
+## Reproducibility and write boundary
+
+1. Start from the documented target composition, not from the ambiguous English display title.
+2. Search exact/direct aliases plus arrangement-title/artist tuples obtained from composition-level sources.
+3. Compare numeric beatmapset IDs against the catalog before review.
+4. Direct-refetch each retained ID from its current public osu! beatmapset page.
+5. Require explicit source metadata or an independently documented composition chain before verification.
+6. Record mixed works with all supported Touhou originals instead of forcing them into a single-theme arrangement bucket.
+7. Preserve false positives and unresolved identities in the audit rather than silently accepting or guessing them.
+8. Save through `Catalog.save(data/catalog)` so numeric ordering, shard placement, and recursive shard limits remain deterministic.
+9. Run `make check`, `make build`, and `git diff --check` before committing the shard changes.
+
+## Implementation validation
+
+The completed shard migration was exercised in GitHub Actions `Validate` run **#217** on 2026-08-22. The migration direct-refetched all 12 retained beatmapsets, applied the remaining six enrichments and two additions on top of the four records already staged earlier in the branch, and saved through the canonical `Catalog.save(data/catalog)` path.
+
+The validated post-audit catalog contains **3,993 beatmapsets** (`candidate=1641`, `excluded=2`, `probable=29`, `verified=2321`) with **2,350 accepted** records. `make check` ran **63 tests**, all passing; `make build` produced 2,350 accepted beatmapsets; and `git diff --check` passed before the validated data tree was committed. The one-shot migration helper removed itself and restored `.github/workflows/validate.yml` to the normal read-only workflow before pushing. The resulting tree was then squashed into the PR's final history and separately passed the normal pull-request validation workflow, so no migration machinery remains in the final PR diff.

--- a/docs/systematic-theme-audit-workflow.md
+++ b/docs/systematic-theme-audit-workflow.md
@@ -1,0 +1,87 @@
+# Systematic theme audit workflow
+
+This workflow is for composition-centered completeness passes such as `Night of Knights`, `竹取飛翔 ～ Lunatic Princess`, or `ボーダーオブライフ`. It complements source ingestion: source imports answer “what does this curated source contain?”, while a theme audit asks “which osu! beatmapsets use this specific composition or a documented derivative of it?”.
+
+## 1. Lock the composition boundary first
+
+Write down the canonical original title, source game, and any collision-prone aliases before searching osu!. Do not let an English display title silently broaden the target. If two Touhou originals share words in translated titles, treat them as separate composition keys.
+
+For derivative targets, document the parent chain as well. A remix of a famous arrangement is not automatically equivalent to every arrangement of the same ZUN original.
+
+## 2. Build an evidence-backed search corpus
+
+Prefer composition-level sources that expose title, artist/circle, and original-song metadata. Useful sources include official artist/circle pages, release tracklists, official game/song pages, Touhou Arrangement Chronicle, and well-maintained Touhou discography wikis.
+
+Record search tuples rather than bare keywords whenever a title is generic:
+
+```text
+(title, artist-or-circle guard, documented original composition)
+```
+
+Direct Japanese titles and distinctive aliases may be searched without an artist guard. Generic English titles should normally require one.
+
+## 3. Search broadly; accept narrowly
+
+Search results are candidates, not verification. Use controlled aliases, punctuation variants, and status buckets when default ranking can hide older graveyard material. De-duplicate by numeric beatmapset ID before review.
+
+For every retained candidate:
+
+1. compare the numeric ID against the current catalog;
+2. direct-refetch the current public osu! beatmapset page or API object;
+3. require the fetched ID, artist, and title to match the reviewed candidate;
+4. verify the composition through current osu! source metadata or an independent composition-level source;
+5. keep unresolved/deleted identities out of automatic promotion.
+
+Do not infer a beatmapset ID from a tournament label, screenshot, mapper name, or title alone.
+
+## 4. Classify structured provenance
+
+Use `touhou_kind` to describe the recording represented by the beatmapset:
+
+- `original`: the ZUN/original-game recording of the target composition;
+- `arrangement`: a recording derived from one or more Touhou originals with no supported non-Touhou ingredient;
+- `mixed`: a mashup/medley/recording with multiple supported originals where representing only one would be misleading;
+- `unknown`: keep this only when the composition relationship itself is not sufficiently established.
+
+Fill `origin_games` and `original_themes` with every supported Touhou source used by the recording. Do not guess extra themes from character association, album concept, mapper tags, or similar-title collisions.
+
+Use `manual:verified` only when the catalog judgment depends on reviewed composition evidence that an automated refresh cannot reconstruct from current osu! metadata. Existing sticky manual boundaries must not be overwritten casually.
+
+## 5. Preserve the negative boundary
+
+A useful audit records why plausible hits were not accepted. Keep explicit sections for:
+
+- same-title but different-composition collisions;
+- independent arrangements of a nearby theme;
+- unresolved/deleted beatmapset identities;
+- weak mapper-tag or search-token matches;
+- mixed works whose target ingredient is plausible but not independently sourced.
+
+This prevents future searches from re-litigating the same false positives and keeps “coverage” from drifting into keyword matching.
+
+## 6. Write through the canonical catalog API
+
+`data/catalog/` is the canonical store. Let `Catalog.save()` choose and rewrite shards rather than hand-maintaining range boundaries. The save path guarantees numeric ordering and recursively partitions populated 100,000-ID base ranges so every shard remains at or below the repository record limit.
+
+A theme audit should make the smallest semantic change possible: add genuinely absent beatmapsets, enrich already-known target rows, and leave unrelated records untouched.
+
+## 7. Validate before review
+
+Run the repository checks after the final write:
+
+```sh
+make check
+make build
+git diff --check
+```
+
+Inspect the resulting diff as an audit artifact. Confirm that:
+
+- only expected shards changed;
+- newly added IDs are in the correct ranges and sorted;
+- existing rows changed only in intended metadata/provenance fields;
+- catalog cardinality increased by exactly the expected number of new IDs;
+- no generated aggregate was accidentally committed under `data/`;
+- the audit document names accepted, excluded, and unresolved boundaries.
+
+For large passes, include counts and accepted-ID groups in the audit document so another contributor can reproduce the decision boundary without re-running the entire discovery process.


### PR DESCRIPTION
## Summary

Completes the systematic osu! coverage audit for **ボーダーオブライフ / Border of Life**, Yuyuko Saigyouji's second Stage 6 theme from *東方妖々夢 ～ Perfect Cherry Blossom.*

The canonical catalog is now sharded, so the previously blocked data changes have been applied directly to `data/catalog/` through the repository's normal `Catalog.save()` path.

### Catalog reconciliation completed

**4 previously absent beatmapsets added:**

- `14408` — Nazz-can - Border of Life — arrangement of `ボーダーオブライフ`
- `1248505` — GET IN THE RING - Phosphor — mixed (`ボーダーオブライフ` + `ゴーストリード`), sticky `manual:verified`
- `2258223` — ZUN - Border of Life — original
- `2443688` — ZUN - Border of Life — original

**8 existing rows enriched with structured composition provenance:**

- `3573` — Gojou Kai - Border of Life — mixed (`幽雅に咲かせ、墨染の桜 ～ Border of Life` + `ボーダーオブライフ`)
- `7932` — IOSYS - Border of Extacy — mixed (`ボーダーオブライフ` + `ネクロファンタジア`)
- `28891` — Gojou Kai - Border of Life — same mixed *Secret Seven* recording
- `732190` — IOSYS - Border of extacy (Karaoke Ver) — mixed
- `819351` — IOSYS - Border of extacy (Karaoke Ver) — mixed
- `1001360` — Rin - Ayakashi set 12 Another ~ Border of Life — arrangement
- `1235944` — Rin - Ayakashi set 12 Another ~ Border of Life — arrangement
- `1953606` — ZUN - Border of Life — original

The two identities held in the earlier draft (`732190` and `1235944`) both resolve through their public osu! beatmapset pages as of 2026-08-22, so that temporary identity hold is removed.

### False-positive boundary preserved

The English phrase `Border of Life` is not treated as a composition key. Reviewed non-target hits including `1168786`, `2249236`, `388424`, `12508`, and `17628` remain excluded from this target-composition audit. The OCL Fall 2024 textual pool reference remains documentation-only because no direct numeric beatmapset identity is available.

### Durable documentation

- `docs/source-audit-2026-08-border-of-life.md` records the composition boundary, evidence, accepted IDs, exclusions, unresolved identity boundary, and completed validation.
- `docs/systematic-theme-audit-workflow.md` records the reusable composition-centered audit workflow.
- `CONTRIBUTING.md` links the workflow and documents shard-safe catalog editing.

A post-implementation review hardened the audit doc further: volatile Arrangement Chronicle corpus counts are no longer hard-coded as ground truth, and stale references to the intermediate pre-squash data commit were removed.

### Validation

GitHub Actions **Validate #217** completed successfully while applying the remaining shard changes:

- direct-refetched all 12 retained beatmapsets
- `Catalog.save(data/catalog)` completed with deterministic shard placement/sorting
- **63 tests passed** via `make check`
- post-audit catalog: **3,993 beatmapsets** (`candidate=1641`, `excluded=2`, `probable=29`, `verified=2321`)
- `make build`: **2,350 accepted beatmapsets**
- `git diff --check`: passed

The generated data tree was cleaned of the one-shot helper and restored to the normal read-only `validate.yml`. After the additional three-pass review and documentation hardening, the branch was squashed again to one final commit: `28f54c40` (`data: complete Border of Life systematic audit`). The final squashed head passed the normal pull-request workflow in **Validate #222**, with both `make check` and `make build` completed successfully.

Final PR state: **1 commit ahead of `main`, 12 changed files, mergeable, no temporary migration/script/workflow files in the diff.**