### PR TITLE
data: add 239 reviewed Touhou beatmapsets

### DIFF
--- a/data/catalog/0100000-0199999.json
+++ b/data/catalog/0100000-0199999.json
@@ -3367,6 +3367,30 @@
       "osu_last_updated": "2015-11-11T13:45:28Z"
     },
     {
+      "beatmapset_id": 177908,
+      "artist": "Mohican Sandbag",
+      "title": "U.N.Owen is dead",
+      "creator": "OnosakiHito",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2015-03-11T13:48:52Z"
+    },
+    {
       "beatmapset_id": 178018,
       "artist": "Senpi-",
       "title": "The First Part of Touhou EX Boss Rush!!",

--- a/data/catalog/0300000-0399999.json
+++ b/data/catalog/0300000-0399999.json
@@ -1386,6 +1386,30 @@
       "osu_last_updated": "2016-03-31T09:41:12Z"
     },
     {
+      "beatmapset_id": 328117,
+      "artist": "Kurokotei",
+      "title": "Galaxy Collapse",
+      "creator": "Sayaka-",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:Touhou",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2015-10-11T21:09:07Z"
+    },
+    {
       "beatmapset_id": 328600,
       "artist": "BeatMARIO (COOL&CREATE)",
       "title": "Night of Knights (Flowering Night Remix)",

--- a/data/catalog/0600000-0699999.json
+++ b/data/catalog/0600000-0699999.json
@@ -664,6 +664,30 @@
       "osu_last_updated": "2017-08-16T16:10:39Z"
     },
     {
+      "beatmapset_id": 625519,
+      "artist": "senya",
+      "title": "Zankyou wa Nariyamazu",
+      "creator": "Absolute Zero",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2019-05-31T18:12:47Z"
+    },
+    {
       "beatmapset_id": 625538,
       "artist": "beatMARIO/COOL&CREATE",
       "title": "Night of Nights",

--- a/data/catalog/1100000-1199999.json
+++ b/data/catalog/1100000-1199999.json
@@ -1692,6 +1692,30 @@
       "osu_last_updated": "2024-06-04T00:24:44Z"
     },
     {
+      "beatmapset_id": 1151507,
+      "artist": "senya",
+      "title": "Hitorishizuka",
+      "creator": "PaRaDogi",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-25T16:42:49Z"
+    },
+    {
       "beatmapset_id": 1151630,
       "artist": "Rin",
       "title": "Muenzuka set 09 ~ Hana wa Gensou no Mama ni",

--- a/data/catalog/1200000-1299999.json
+++ b/data/catalog/1200000-1299999.json
@@ -97,6 +97,30 @@
       "osu_last_updated": "2020-10-28T04:59:26Z"
     },
     {
+      "beatmapset_id": 1205704,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Without the end",
+      "creator": "_Vex",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2020-09-11T20:06:39Z"
+    },
+    {
       "beatmapset_id": 1206509,
       "artist": "RichaadEB",
       "title": "Night of Nights (Metal Cover)",
@@ -1102,6 +1126,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2020-09-05T10:50:48Z"
+    },
+    {
+      "beatmapset_id": 1241563,
+      "artist": "senya",
+      "title": "Tsuki ni Murakumo Hana ni Kaze (PV ver.)",
+      "creator": "BlackBq",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-01-11T09:38:21Z"
     },
     {
       "beatmapset_id": 1242775,
@@ -2240,6 +2288,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1267528,
+      "artist": "ShinRa-Bansho",
+      "title": "Tsuki ni Murakumo Hana ni Kaze ShinRa-Bansho Ver",
+      "creator": "Spectator",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-04-07T05:43:22Z"
+    },
+    {
       "beatmapset_id": 1267975,
       "artist": "Rin",
       "title": "Lunatic set 15 ~ The Moon as Seen from the Shrine",
@@ -2530,6 +2602,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2021-02-08T16:38:13Z"
+    },
+    {
+      "beatmapset_id": 1275058,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Under the scarlet sky pt. 3",
+      "creator": "Hivie",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2020-12-28T14:10:06Z"
     },
     {
       "beatmapset_id": 1275896,
@@ -2867,6 +2963,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-10-23T17:53:44Z"
+    },
+    {
+      "beatmapset_id": 1284535,
+      "artist": "ShinRa-Bansho",
+      "title": "Aqua Terrarium",
+      "creator": "Yukari_Sama",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-01-27T13:11:10Z"
     },
     {
       "beatmapset_id": 1285290,

--- a/data/catalog/1300000-1399999.json
+++ b/data/catalog/1300000-1399999.json
@@ -1378,6 +1378,31 @@
       "osu_last_updated": "2023-02-09T19:51:16Z"
     },
     {
+      "beatmapset_id": 1348852,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Without the end",
+      "creator": "Maxim-Miau",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-04-12T19:37:24Z"
+    },
+    {
       "beatmapset_id": 1349559,
       "artist": "C.H.S",
       "title": "C.H.S- Luv\\*Lab\\*Poison 22ate! (Cut Ver.) (Hytex) [Insane]",
@@ -1549,6 +1574,30 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1360248,
+      "artist": "LeaF",
+      "title": "Wizdomiot (extended ver.)",
+      "creator": "FAMoss",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-03-21T16:11:18Z"
     },
     {
       "beatmapset_id": 1361691,
@@ -1981,6 +2030,31 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-10-02T12:38:21Z"
+    },
+    {
+      "beatmapset_id": 1382136,
+      "artist": "senya",
+      "title": "Tsukiwa ni Megurasareta Kioku",
+      "creator": "Satellite",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-28T16:44:57Z"
     },
     {
       "beatmapset_id": 1383882,

--- a/data/catalog/1400000-1499999.json
+++ b/data/catalog/1400000-1499999.json
@@ -449,6 +449,30 @@
       "osu_last_updated": "2024-12-07T10:45:45Z"
     },
     {
+      "beatmapset_id": 1437794,
+      "artist": "ShinRa-Bansho",
+      "title": "I",
+      "creator": "Yukari_Sama",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-05-01T05:07:57Z"
+    },
+    {
       "beatmapset_id": 1438522,
       "artist": "DJKurara",
       "title": "White Hair Little Swords Girl (guden) [Massacre]",
@@ -693,6 +717,32 @@
       "osu_last_updated": "2022-03-15T13:09:32Z"
     },
     {
+      "beatmapset_id": 1446247,
+      "artist": "senya",
+      "title": "Songs Compilation II",
+      "creator": "Serafeim",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-06-08T12:56:07Z"
+    },
+    {
       "beatmapset_id": 1449940,
       "artist": "Camellia",
       "title": "Ultimate Ascension",
@@ -827,6 +877,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-06-18T07:36:39Z"
+    },
+    {
+      "beatmapset_id": 1461736,
+      "artist": "Demetori",
+      "title": "Kourou ~ Eastern Dream",
+      "creator": "228",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-05-21T08:47:14Z"
     },
     {
       "beatmapset_id": 1461937,
@@ -1637,6 +1712,31 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1499636,
+      "artist": "A-One feat. Shihori",
+      "title": "DAY BREAKER",
+      "creator": "Deif",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-12-17T19:12:56Z"
     }
   ]
 }

--- a/data/catalog/1500000-1599999.json
+++ b/data/catalog/1500000-1599999.json
@@ -1236,6 +1236,30 @@
       "osu_last_updated": "2021-08-22T04:56:03Z"
     },
     {
+      "beatmapset_id": 1556887,
+      "artist": "Halozy",
+      "title": "Kikoku Doukoku Jigokuraku",
+      "creator": "Schopfer",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-03-12T18:06:13Z"
+    },
+    {
       "beatmapset_id": 1556967,
       "artist": "tsukiyama sae/matsu",
       "title": "Night of Knights (Amateras Records Remix)",
@@ -1448,6 +1472,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1565933,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "self-claim existence",
+      "creator": "Surou",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-22T18:17:13Z"
     },
     {
       "beatmapset_id": 1569597,

--- a/data/catalog/1600000-1699999.json
+++ b/data/catalog/1600000-1699999.json
@@ -1175,6 +1175,30 @@
       "osu_last_updated": "2025-06-15T18:33:24Z"
     },
     {
+      "beatmapset_id": 1648038,
+      "artist": "Halozy",
+      "title": "K.O.K.O.R.O & S.A.T.O.R.A.R.E",
+      "creator": "ler1211",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-12-20T14:54:23Z"
+    },
+    {
       "beatmapset_id": 1648145,
       "artist": "Shiiki Reku",
       "title": "Rhythmy (-Deepdive-) [Till I'm laid]",

--- a/data/catalog/1700000-1799999.json
+++ b/data/catalog/1700000-1799999.json
@@ -1496,6 +1496,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1762719,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Embraced by the Flame",
+      "creator": "KawaiiBass",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-05-26T12:20:34Z"
+    },
+    {
       "beatmapset_id": 1763125,
       "artist": "Diabolic Phantasma",
       "title": "Liberation",
@@ -1661,6 +1685,30 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1772154,
+      "artist": "ShinRa-Bansho",
+      "title": "Mugen Shitto Gekijou \"666\"",
+      "creator": "gaston_2199",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-24T21:09:54Z"
     },
     {
       "beatmapset_id": 1774462,

--- a/data/catalog/1800000-1899999.json
+++ b/data/catalog/1800000-1899999.json
@@ -1012,6 +1012,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1849213,
+      "artist": "ZUN",
+      "title": "Hartmann no Youkai Shoujo",
+      "creator": "Kukkai",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-20T13:17:08Z"
+    },
+    {
       "beatmapset_id": 1849728,
       "artist": "Demetori",
       "title": "Furuki Yuanxian ~ Death Echo",
@@ -1032,6 +1057,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-01-03T01:45:18Z"
+    },
+    {
+      "beatmapset_id": 1849967,
+      "artist": "IOSYS feat. 3L",
+      "title": "Gyouretsu no Dekiru Eirin Shinryoujo (Cut Ver.)",
+      "creator": "Bloxi",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-10-06T16:46:29Z"
     },
     {
       "beatmapset_id": 1850841,
@@ -1206,6 +1255,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1856797,
+      "artist": "Minorti & HAGISOPH",
+      "title": "Cruciv",
+      "creator": "Mattay",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-10-19T17:04:59Z"
+    },
+    {
       "beatmapset_id": 1857465,
       "artist": "Conagusuri",
       "title": "Hina Choco Dark Matter",
@@ -1286,6 +1359,30 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1862313,
+      "artist": "ShinRa-Bansho",
+      "title": "Zenryoku Happy Life",
+      "creator": "-Maruko-",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-09T04:41:01Z"
     },
     {
       "beatmapset_id": 1863675,
@@ -1616,6 +1713,32 @@
       "osu_last_updated": "2022-10-25T10:06:57Z"
     },
     {
+      "beatmapset_id": 1873233,
+      "artist": "ShinRa-Bansho x Yuuhei Satellite & Shoujo Fractal",
+      "title": "Genso Connect",
+      "creator": "Xzzj",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-01-14T05:55:05Z"
+    },
+    {
       "beatmapset_id": 1874741,
       "artist": "senya",
       "title": "Nihil Kagura",
@@ -1680,6 +1803,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-09-09T00:42:38Z"
+    },
+    {
+      "beatmapset_id": 1878367,
+      "artist": "Batory",
+      "title": "Touhou Koumakyou Zenkyoku Arrange Medley",
+      "creator": "yassu-",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Touhou",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-01-05T20:46:17Z"
     },
     {
       "beatmapset_id": 1878634,
@@ -1965,6 +2113,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1889476,
+      "artist": "Marisa",
+      "title": "Stop Posting About The Precious Thing",
+      "creator": "Faputa",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-11-27T04:21:00Z"
+    },
+    {
       "beatmapset_id": 1890591,
       "artist": "Chata",
       "title": "Sora to Heikou ni Sou Kyokusen",
@@ -2077,6 +2250,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-12-15T03:58:19Z"
+    },
+    {
+      "beatmapset_id": 1894970,
+      "artist": "Unlucky Morpheus x UNDEAD CORPORATION",
+      "title": "Jealousy Inst ver",
+      "creator": "GudMeem",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-09-24T03:42:35Z"
     },
     {
       "beatmapset_id": 1898039,

--- a/data/catalog/1900000-1999999.json
+++ b/data/catalog/1900000-1999999.json
@@ -264,6 +264,30 @@
       "osu_last_updated": "2022-12-28T21:41:15Z"
     },
     {
+      "beatmapset_id": 1909974,
+      "artist": "Masayoshi Minoshima feat. mikicco",
+      "title": "Wall of Flowers",
+      "creator": "228",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-26T14:04:51Z"
+    },
+    {
       "beatmapset_id": 1911345,
       "artist": "beatMARIO",
       "title": "Night of Knights",
@@ -362,6 +386,30 @@
       "osu_last_updated": "2023-01-16T18:06:50Z"
     },
     {
+      "beatmapset_id": 1914040,
+      "artist": "Masayoshi Minoshima feat. nomico",
+      "title": "Dreaming",
+      "creator": "Annabel",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-08-07T05:09:32Z"
+    },
+    {
       "beatmapset_id": 1914522,
       "artist": "Halozy",
       "title": "Don't let you down",
@@ -385,6 +433,30 @@
       "osu_last_updated": "2023-12-22T17:34:32Z"
     },
     {
+      "beatmapset_id": 1915183,
+      "artist": "Kanpyohgo",
+      "title": "Shoujo Satori -3rd.eye- Trance.edt",
+      "creator": "Antti",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-01-09T17:37:22Z"
+    },
+    {
       "beatmapset_id": 1915251,
       "artist": "ALiCE'S EMOTiON",
       "title": "Be Back ON!",
@@ -405,6 +477,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-07-20T13:59:27Z"
+    },
+    {
+      "beatmapset_id": 1915805,
+      "artist": "Halozy",
+      "title": "Masshiro na Yuki",
+      "creator": "Suarin",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-04-28T08:10:43Z"
     },
     {
       "beatmapset_id": 1915969,
@@ -521,6 +617,32 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-01-08T14:03:19Z"
+    },
+    {
+      "beatmapset_id": 1919687,
+      "artist": "ZUN",
+      "title": "Touhou Youyoumu Stage 6 Soundtrack",
+      "creator": "Genjuro",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Touhou",
+        "discovery_query:ZUN",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-01-10T14:09:36Z"
     },
     {
       "beatmapset_id": 1921039,
@@ -705,6 +827,81 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-01-23T03:26:17Z"
+    },
+    {
+      "beatmapset_id": 1927811,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "Itooshiki Mono ni, Utsukushiki Mono ni",
+      "creator": "Halfslashed",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-30T20:17:52Z"
+    },
+    {
+      "beatmapset_id": 1927927,
+      "artist": "ZUN",
+      "title": "Fuujin Shoujo",
+      "creator": "yassu-",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-04-09T13:04:26Z"
+    },
+    {
+      "beatmapset_id": 1927992,
+      "artist": "ShinRa-Bansho",
+      "title": "I",
+      "creator": "-Unlimit-",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-20T16:10:14Z"
     },
     {
       "beatmapset_id": 1928690,
@@ -893,6 +1090,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1936480,
+      "artist": "Diao Ye Zong feat. Kushi",
+      "title": "Yuumeikyou o Wakatsu Koto",
+      "creator": "Heilia",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-20T16:15:40Z"
+    },
+    {
       "beatmapset_id": 1936770,
       "artist": "Masayoshi Minoshima",
       "title": "Bad Apple!! feat. nomico",
@@ -962,6 +1183,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-04-13T13:42:16Z"
+    },
+    {
+      "beatmapset_id": 1941687,
+      "artist": "8686m",
+      "title": "Memai",
+      "creator": "Venix",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-05-01T19:09:05Z"
     },
     {
       "beatmapset_id": 1942555,
@@ -1051,6 +1296,32 @@
       "osu_last_updated": "2023-03-22T16:23:41Z"
     },
     {
+      "beatmapset_id": 1945081,
+      "artist": "ZUN",
+      "title": "Touhou 7 Nonstop Medley",
+      "creator": "Luscent",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Touhou",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-29T19:27:50Z"
+    },
+    {
       "beatmapset_id": 1945457,
       "artist": "Touhou Jihen",
       "title": "Zetsubouteki Fukyouwaon",
@@ -1070,6 +1341,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1949019,
+      "artist": "Syrufit feat. Mei Ayakura",
+      "title": "Tsukikage Shoujo",
+      "creator": "Delette",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Syrufit",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-05-30T17:59:14Z"
     },
     {
       "beatmapset_id": 1950158,
@@ -1300,6 +1595,56 @@
       "osu_last_updated": "2023-06-01T15:33:56Z"
     },
     {
+      "beatmapset_id": 1960735,
+      "artist": "ZUN",
+      "title": "Bucuresti no Ningyoushi",
+      "creator": "PixelGlory",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-11-22T23:24:16Z"
+    },
+    {
+      "beatmapset_id": 1961523,
+      "artist": "ZUN",
+      "title": "Mottomo Sumiwataru Sora to Umi",
+      "creator": "Nyanaro",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-12T19:22:56Z"
+    },
+    {
       "beatmapset_id": 1961847,
       "artist": "IOSYS",
       "title": "Choujin Hijiri no Air Muscle (Cut Ver.)",
@@ -1364,6 +1709,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1962897,
+      "artist": "Tengu no Mai",
+      "title": "Kowaku no Hitomi",
+      "creator": "NeKroMan4ik",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-24T19:34:52Z"
+    },
+    {
       "beatmapset_id": 1964364,
       "artist": "Hanataba",
       "title": "Night of Knights",
@@ -1389,6 +1758,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-05-28T15:16:00Z"
+    },
+    {
+      "beatmapset_id": 1964631,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Adore Your Pain",
+      "creator": "roxorotto",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-19T16:30:14Z"
     },
     {
       "beatmapset_id": 1969221,
@@ -1506,6 +1899,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-03-01T20:55:37Z"
+    },
+    {
+      "beatmapset_id": 1976303,
+      "artist": "IOSYS",
+      "title": "Marisa wa Taihen na Mono wo Nusunde Ikimashita",
+      "creator": "Hugged",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-09-27T14:51:03Z"
     },
     {
       "beatmapset_id": 1976379,
@@ -1924,6 +2342,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1989147,
+      "artist": "A-One feat. Shihori",
+      "title": "ToRyan-Se",
+      "creator": "Qnio",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:Adust Rain",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-03-13T22:22:59Z"
+    },
+    {
       "beatmapset_id": 1989400,
       "artist": "beatMARIO",
       "title": "Night of Knights",
@@ -2171,6 +2614,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1992653,
+      "artist": "Yellow Zebra",
+      "title": "Melody!",
+      "creator": "Verti",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-04T17:47:20Z"
     },
     {
       "beatmapset_id": 1993039,
@@ -2557,6 +3024,54 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1999204,
+      "artist": "Xi",
+      "title": "Rokujuu-nen Me no Shinsoku Saiban ~ Rapidity is a justice",
+      "creator": "Camo",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-17T17:31:35Z"
+    },
+    {
+      "beatmapset_id": 1999580,
+      "artist": "EastNewSound",
+      "title": "Koisuru Kimochi",
+      "creator": "__Ag",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-06-04T05:52:30Z"
     },
     {
       "beatmapset_id": 1999921,

--- a/data/catalog/2000000-2099999.json
+++ b/data/catalog/2000000-2099999.json
@@ -683,6 +683,30 @@
       "osu_last_updated": "2023-07-10T21:07:24Z"
     },
     {
+      "beatmapset_id": 2011128,
+      "artist": "RD-Sounds feat. Meramipop",
+      "title": "enemy of the society",
+      "creator": "Ideal",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-10T17:57:51Z"
+    },
+    {
       "beatmapset_id": 2011367,
       "artist": "Demetori",
       "title": "Strawberry Crisis!!",
@@ -701,6 +725,57 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2011555,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Flowering Night Fever",
+      "creator": "Deif",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-03T21:46:28Z"
+    },
+    {
+      "beatmapset_id": 2011565,
+      "artist": "A-One feat. ayaponzu*",
+      "title": "Justice Monster",
+      "creator": "F D Flourite",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-02T16:12:28Z"
     },
     {
       "beatmapset_id": 2011767,
@@ -743,6 +818,55 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2013277,
+      "artist": "ZUN",
+      "title": "Shiryou no Yozakura",
+      "creator": "nanoya",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-07T17:19:18Z"
+    },
+    {
+      "beatmapset_id": 2013928,
+      "artist": "Down",
+      "title": "Duo Cup",
+      "creator": "nanoya",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-15T15:05:38Z"
     },
     {
       "beatmapset_id": 2014288,
@@ -954,6 +1078,32 @@
       "osu_last_updated": "2024-12-20T13:33:14Z"
     },
     {
+      "beatmapset_id": 2020128,
+      "artist": "Demetori",
+      "title": "Gensou, Yume no Owari",
+      "creator": "Daihmuddah",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:C-CLAYS",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-25T12:54:52Z"
+    },
+    {
       "beatmapset_id": 2020285,
       "artist": "AUTUMN+GHOST feat. Akira Complex",
       "title": "PURE FURY",
@@ -1041,6 +1191,103 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2023965,
+      "artist": "--RAYvateinn--",
+      "title": "Touhou Medley P - vol.5",
+      "creator": "Wither",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:Touhou",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-30T14:36:41Z"
+    },
+    {
+      "beatmapset_id": 2023974,
+      "artist": "senya",
+      "title": "Tsuki ni Murakumo Hana ni Kaze",
+      "creator": "nanoya",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-03-16T23:18:21Z"
+    },
+    {
+      "beatmapset_id": 2024061,
+      "artist": "8686m",
+      "title": "I Love You From Greenwich",
+      "creator": "Gibune",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-21T01:10:50Z"
+    },
+    {
+      "beatmapset_id": 2024106,
+      "artist": "Yellow Zebra",
+      "title": "Saisei ~Bird can sing~",
+      "creator": "BeautifulKisa",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-04-25T19:08:09Z"
+    },
+    {
       "beatmapset_id": 2024278,
       "artist": "Akiyama Uni",
       "title": "The Grimoire of Alice",
@@ -1087,6 +1334,55 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-07-11T23:24:13Z"
+    },
+    {
+      "beatmapset_id": 2025539,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "Saifu 'Kamiasobi no Uta'",
+      "creator": "chen_sawthis01",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-27T03:25:40Z"
+    },
+    {
+      "beatmapset_id": 2025551,
+      "artist": "Adust Rain",
+      "title": "Eleven Stud",
+      "creator": "[LS]Yunxmi",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Adust Rain",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-11-29T12:25:52Z"
     },
     {
       "beatmapset_id": 2027407,
@@ -1328,6 +1624,55 @@
       "osu_last_updated": "2025-03-20T20:09:40Z"
     },
     {
+      "beatmapset_id": 2037983,
+      "artist": "A-One feat. Rute",
+      "title": "Spider's Blood",
+      "creator": "Hugged",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-09-02T17:34:01Z"
+    },
+    {
+      "beatmapset_id": 2039585,
+      "artist": "senya",
+      "title": "Saihate no Kotoba",
+      "creator": "Satellite",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-07-28T11:31:44Z"
+    },
+    {
       "beatmapset_id": 2039737,
       "artist": "nominomu",
       "title": "solar sect of nm2 ~ nuclear notelock",
@@ -1560,6 +1905,30 @@
       "osu_last_updated": "2024-09-03T00:29:45Z"
     },
     {
+      "beatmapset_id": 2046139,
+      "artist": "Halozy",
+      "title": "S.A.T.O.R.A.R.E",
+      "creator": "Camo",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-11-26T21:55:57Z"
+    },
+    {
       "beatmapset_id": 2046568,
       "artist": "Adust Rain",
       "title": "Nevxxxxerland",
@@ -1601,6 +1970,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-07-21T20:12:52Z"
+    },
+    {
+      "beatmapset_id": 2047786,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "Sono Tadashiki Kotoba no Moto ni",
+      "creator": "doulph",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-04T10:06:46Z"
     },
     {
       "beatmapset_id": 2048017,
@@ -1712,6 +2106,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2049284,
+      "artist": "Alstroemeria Records + Studio \"Syrup Comfiture\"",
+      "title": "Against, Perfect Cherry Blossom.",
+      "creator": "-Koppe-",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Syrufit",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-10T11:29:57Z"
     },
     {
       "beatmapset_id": 2049581,
@@ -1834,6 +2253,55 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-09-01T18:01:08Z"
+    },
+    {
+      "beatmapset_id": 2051546,
+      "artist": "ALiCE'S EMOTiON",
+      "title": "Cold Rain",
+      "creator": "SenSenko",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Adust Rain",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-17T16:02:37Z"
+    },
+    {
+      "beatmapset_id": 2051619,
+      "artist": "Sasara Yuuna",
+      "title": "Fushigi Monogatari",
+      "creator": "Halfslashed",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-04T00:50:42Z"
     },
     {
       "beatmapset_id": 2051633,
@@ -1971,6 +2439,29 @@
       "osu_last_updated": "2023-08-28T11:35:46Z"
     },
     {
+      "beatmapset_id": 2052920,
+      "artist": "BLANKFIELD",
+      "title": "Falling Falls",
+      "creator": "radar",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-30T00:29:31Z"
+    },
+    {
       "beatmapset_id": 2053246,
       "artist": "cYsmix",
       "title": "Tear Rain feat. Emmy (Cut Ver.)",
@@ -2011,6 +2502,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2023-12-02T10:05:57Z"
+    },
+    {
+      "beatmapset_id": 2055714,
+      "artist": "Houshou Marine with Holoism Fantasy",
+      "title": "Hoihoi*Gensou Holoism",
+      "creator": "Secre",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:COOL&CREATE",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-11-13T13:42:11Z"
     },
     {
       "beatmapset_id": 2056127,
@@ -2061,6 +2577,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-09-10T02:28:23Z"
+    },
+    {
+      "beatmapset_id": 2057639,
+      "artist": "Halozy",
+      "title": "Suna no Hoshi (Blue Twinkle Trance Remix / Version 2.0)",
+      "creator": "by-ad",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-01T14:56:43Z"
     },
     {
       "beatmapset_id": 2059306,
@@ -2154,6 +2694,57 @@
       "osu_last_updated": "2024-12-22T05:44:30Z"
     },
     {
+      "beatmapset_id": 2063410,
+      "artist": "Halozy",
+      "title": "Masshiro na Yuki",
+      "creator": "Yuumeikyou",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-17T12:04:20Z"
+    },
+    {
+      "beatmapset_id": 2064233,
+      "artist": "Demetori",
+      "title": "Natsukashiki Touhou no Chi ~ Sic World",
+      "creator": "M4xWasHere",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Touhou",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-30T03:52:32Z"
+    },
+    {
       "beatmapset_id": 2065860,
       "artist": "Aoi Xia",
       "title": "Lost Blue",
@@ -2194,6 +2785,54 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-04-29T15:01:40Z"
+    },
+    {
+      "beatmapset_id": 2066221,
+      "artist": "last little while",
+      "title": "again",
+      "creator": "AnnouncerF",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-11-04T21:17:12Z"
+    },
+    {
+      "beatmapset_id": 2066498,
+      "artist": "IOSYS",
+      "title": "Miracle Hinacle",
+      "creator": "Djulus",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-23T16:13:42Z"
     },
     {
       "beatmapset_id": 2067431,
@@ -2258,6 +2897,29 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2069637,
+      "artist": "EastNewSound feat. Chata & nayuta",
+      "title": "Yuune Zekka, Ryouran no Sai",
+      "creator": "PandaHero",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-20T20:02:34Z"
+    },
+    {
       "beatmapset_id": 2070206,
       "artist": "Akatsuki Records",
       "title": "Black Mirror on the Wall",
@@ -2300,6 +2962,29 @@
       "osu_last_updated": "2024-04-29T09:59:32Z"
     },
     {
+      "beatmapset_id": 2072347,
+      "artist": "Unlucky Morpheus",
+      "title": "FAITH",
+      "creator": "Erowdi",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-20T14:13:27Z"
+    },
+    {
       "beatmapset_id": 2073247,
       "artist": "ShinRa-Bansho",
       "title": "Charisma Rengoku Tenshin",
@@ -2321,6 +3006,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-10-18T19:52:19Z"
+    },
+    {
+      "beatmapset_id": 2074627,
+      "artist": "A-One feat. Shihori",
+      "title": "Magic Girl !!",
+      "creator": "lit120",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-12T21:16:42Z"
     },
     {
       "beatmapset_id": 2074686,
@@ -2388,6 +3098,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2076628,
+      "artist": "Shoujo Fractal",
+      "title": "Samayoi no Mei ~Amatsu~",
+      "creator": "-Yua",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-26T11:12:19Z"
     },
     {
       "beatmapset_id": 2076663,
@@ -2502,6 +3236,30 @@
       "osu_last_updated": "2025-07-10T14:49:59Z"
     },
     {
+      "beatmapset_id": 2080874,
+      "artist": "IOSYS",
+      "title": "Saint Marisa no Okurimono",
+      "creator": "danissima",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-29T22:25:28Z"
+    },
+    {
       "beatmapset_id": 2080903,
       "artist": "beatMARIO",
       "title": "Night Of Knights",
@@ -2573,6 +3331,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2084799,
+      "artist": "A-One feat. Aki",
+      "title": "Wanna Be My Dream",
+      "creator": "Amefystol",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-21T16:33:22Z"
+    },
+    {
       "beatmapset_id": 2084917,
       "artist": "senya",
       "title": "Kanjou Chemistry (Drum 'n' Bass Remix)",
@@ -2593,6 +3376,32 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-03-16T00:08:59Z"
+    },
+    {
+      "beatmapset_id": 2086046,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "Mudai \"Soratobu Miko to Futsuu no Mahoutsukai no Itsumo no Mainichi\"",
+      "creator": "dahkjdas",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-19T13:01:24Z"
     },
     {
       "beatmapset_id": 2086454,
@@ -2642,6 +3451,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-09-28T04:05:26Z"
+    },
+    {
+      "beatmapset_id": 2087883,
+      "artist": "8686m",
+      "title": "SPINACH AND SAMON CREAM PASTA",
+      "creator": "Disguise",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-08T16:48:17Z"
     },
     {
       "beatmapset_id": 2088431,
@@ -2736,6 +3569,30 @@
       "osu_last_updated": "2024-01-07T15:58:44Z"
     },
     {
+      "beatmapset_id": 2089093,
+      "artist": "IOSYS",
+      "title": "Marisa wa Taihen na Mono o Nusunde Ikimashita",
+      "creator": "Molybdenum",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-01T21:09:38Z"
+    },
+    {
       "beatmapset_id": 2091456,
       "artist": "Akatsuki Records",
       "title": "S.A.R.I.E.L.",
@@ -2800,6 +3657,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2095104,
+      "artist": "Adust Rain",
+      "title": "Imperfect Cherry Blossom",
+      "creator": "Erowdi",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Adust Rain",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-19T14:23:06Z"
+    },
+    {
       "beatmapset_id": 2097827,
       "artist": "Akiyama Uni",
       "title": "Kanjou no Matenrou ~ Cosmic Mind",
@@ -2818,6 +3699,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2097924,
+      "artist": "camel ytpmv",
+      "title": "CAMELLO MULTIVERSE",
+      "creator": "Ognjen3800",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-03-24T00:59:27Z"
     },
     {
       "beatmapset_id": 2098437,
@@ -2839,6 +3744,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2025-10-04T18:52:58Z"
+    },
+    {
+      "beatmapset_id": 2098448,
+      "artist": "Aizawa feat. Nakae Mitsuki",
+      "title": "Flutter Girl",
+      "creator": "Deif",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-11T15:55:38Z"
     },
     {
       "beatmapset_id": 2098718,

--- a/data/catalog/2100000-2199999.json
+++ b/data/catalog/2100000-2199999.json
@@ -2,6 +2,30 @@
   "schema_version": 1,
   "entries": [
     {
+      "beatmapset_id": 2101141,
+      "artist": ".new label",
+      "title": "run dev -- -u",
+      "creator": "TWEEKER",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-31T21:12:56Z"
+    },
+    {
       "beatmapset_id": 2101371,
       "artist": "ShinRa-Bansho",
       "title": "Kyokkou no Tabibito",
@@ -42,6 +66,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2102240,
+      "artist": "ShinRa-Bansho",
+      "title": "I",
+      "creator": "Ratarok",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-03-12T07:54:52Z"
     },
     {
       "beatmapset_id": 2102873,
@@ -115,6 +164,30 @@
       "osu_last_updated": "2023-12-18T00:09:52Z"
     },
     {
+      "beatmapset_id": 2106026,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Embraced by the Flame",
+      "creator": "-Joakh",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-09T01:07:20Z"
+    },
+    {
       "beatmapset_id": 2106961,
       "artist": "Demetori",
       "title": "Native Faith ~ Memory of a Free Festival",
@@ -156,6 +229,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-05-09T15:48:24Z"
+    },
+    {
+      "beatmapset_id": 2107618,
+      "artist": "FELT",
+      "title": "Prayer Blue",
+      "creator": "nanoya",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-24T13:30:59Z"
     },
     {
       "beatmapset_id": 2108507,
@@ -220,6 +316,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-03-31T13:06:28Z"
+    },
+    {
+      "beatmapset_id": 2111234,
+      "artist": "Takamachi Walk",
+      "title": "Until the End of This Dream",
+      "creator": "Wither",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-15T16:10:39Z"
     },
     {
       "beatmapset_id": 2112194,
@@ -358,6 +479,31 @@
       "osu_last_updated": "2024-10-04T14:59:52Z"
     },
     {
+      "beatmapset_id": 2114955,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Killing Me If You Can (Guitar Instrumental Ver.)",
+      "creator": "M4xWasHere",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-02T18:43:46Z"
+    },
+    {
       "beatmapset_id": 2115462,
       "artist": "Demetori",
       "title": "Youkai no Yama ~ Mysterious Mountain",
@@ -377,6 +523,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-05-30T23:08:42Z"
+    },
+    {
+      "beatmapset_id": 2115856,
+      "artist": "senya",
+      "title": "Iro wa Nioedo Chirinuru o",
+      "creator": "-Kazuha",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-04-23T04:59:07Z"
     },
     {
       "beatmapset_id": 2116110,
@@ -470,6 +640,82 @@
       "osu_last_updated": "2026-03-08T08:45:45Z"
     },
     {
+      "beatmapset_id": 2119924,
+      "artist": "ZUN",
+      "title": "Naki Oujo no Tame no Septette",
+      "creator": "perchance",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-17T22:27:23Z"
+    },
+    {
+      "beatmapset_id": 2120349,
+      "artist": "ALiCE'S EMOTiON",
+      "title": "Tag",
+      "creator": "Sanch-KK",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-24T14:49:46Z"
+    },
+    {
+      "beatmapset_id": 2120472,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Necrophilia",
+      "creator": "keksikosu",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-02T11:11:38Z"
+    },
+    {
       "beatmapset_id": 2121209,
       "artist": "Para Dot.",
       "title": "Azure Fragments",
@@ -551,6 +797,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-06-02T21:22:47Z"
+    },
+    {
+      "beatmapset_id": 2124429,
+      "artist": "tsunamix",
+      "title": "new moon illusion",
+      "creator": "Gibune",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:C-CLAYS",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-26T21:29:18Z"
     },
     {
       "beatmapset_id": 2124955,
@@ -679,6 +950,81 @@
       "osu_last_updated": "2026-06-09T16:26:13Z"
     },
     {
+      "beatmapset_id": 2128728,
+      "artist": "Dark PHOENiX",
+      "title": "Hiroari Kechou o Iru Koto",
+      "creator": "Camo",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-31T22:52:37Z"
+    },
+    {
+      "beatmapset_id": 2128889,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Everything will freeze",
+      "creator": "LeCandy",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-06T15:46:30Z"
+    },
+    {
+      "beatmapset_id": 2129313,
+      "artist": "senya",
+      "title": "Tamashii no Katari ni Michibikarete",
+      "creator": "Satellite",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-13T18:04:00Z"
+    },
+    {
       "beatmapset_id": 2130980,
       "artist": "tsunamix",
       "title": "Gensou wa Hakanaki Watashi no Tame ni -Shinroku-",
@@ -748,6 +1094,30 @@
       "osu_last_updated": "2024-08-02T10:46:18Z"
     },
     {
+      "beatmapset_id": 2132288,
+      "artist": "tsunamix",
+      "title": "Period. ~ Zetsubou to Hametsu no Kyoukai de Shiru Kibou",
+      "creator": "FAMoss",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:C-CLAYS",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-04-22T14:33:41Z"
+    },
+    {
       "beatmapset_id": 2132362,
       "artist": "senya",
       "title": "Nagori Tori",
@@ -767,6 +1137,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-06-12T02:51:00Z"
+    },
+    {
+      "beatmapset_id": 2132719,
+      "artist": "IOSYS feat. Nanahira",
+      "title": "Shinchoku Dou Desu ka?",
+      "creator": "My Angel RangE",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-11T13:27:44Z"
     },
     {
       "beatmapset_id": 2134870,
@@ -841,6 +1236,31 @@
       "osu_last_updated": "2025-10-16T01:15:15Z"
     },
     {
+      "beatmapset_id": 2136127,
+      "artist": "tsunamix",
+      "title": "new moon illusion",
+      "creator": "zekk",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:C-CLAYS",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-18T14:22:30Z"
+    },
+    {
       "beatmapset_id": 2136607,
       "artist": "TK from Ling tosite sigure",
       "title": "melt (with suis from Yorushika)",
@@ -859,6 +1279,31 @@
       "confidence": "probable",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-06-04T15:08:13Z"
+    },
+    {
+      "beatmapset_id": 2138161,
+      "artist": "DJ SHARPNEL feat. Ichinose Ruru",
+      "title": "Trauma Saimin Shoujo Satori!",
+      "creator": "Flask",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-15T14:42:31Z"
     },
     {
       "beatmapset_id": 2138418,
@@ -1255,6 +1700,53 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2148164,
+      "artist": "Pizuya's Cell feat. Meramipop",
+      "title": "Losing your season",
+      "creator": "FuJu",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-09T11:54:37Z"
+    },
+    {
+      "beatmapset_id": 2148241,
+      "artist": "ZUN",
+      "title": "Necrofantasia",
+      "creator": "hz404",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-06-03T11:24:37Z"
+    },
+    {
       "beatmapset_id": 2148434,
       "artist": "Halozy",
       "title": "Tanjoubi no Kodomotachi",
@@ -1397,6 +1889,31 @@
       "osu_last_updated": "2024-08-06T09:05:19Z"
     },
     {
+      "beatmapset_id": 2151953,
+      "artist": "IOSYS",
+      "title": "Scarlet Keisatsu no Ghetto Patrol 24-ji",
+      "creator": "Rocma",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-08-23T09:02:45Z"
+    },
+    {
       "beatmapset_id": 2152855,
       "artist": "",
       "title": "beatmapsets/2152855#osu/4536199",
@@ -1415,6 +1932,30 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2153229,
+      "artist": "ShinRa-Bansho",
+      "title": "YOSUZU Melody Heart",
+      "creator": "garfieldrpg112",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-07T14:16:12Z"
     },
     {
       "beatmapset_id": 2154094,
@@ -1516,6 +2057,34 @@
       "osu_last_updated": "2024-03-28T19:52:16Z"
     },
     {
+      "beatmapset_id": 2156450,
+      "artist": "ZUN",
+      "title": "Natsukashiki Touhou no Chi ~ Old World",
+      "creator": "rrhine",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:Touhou",
+        "discovery_query:ZUN",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-10-27T12:01:01Z"
+    },
+    {
       "beatmapset_id": 2161238,
       "artist": "AU",
       "title": "U.Nknown Goose",
@@ -1601,6 +2170,30 @@
       "osu_last_updated": "2024-07-18T15:44:22Z"
     },
     {
+      "beatmapset_id": 2167421,
+      "artist": "Demetori",
+      "title": "Necrofantasia ~ Remix",
+      "creator": "Mimiliaa",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-30T15:51:13Z"
+    },
+    {
       "beatmapset_id": 2171371,
       "artist": "Demetori",
       "title": "Higan Kikou ~ View of The River Styx",
@@ -1622,6 +2215,30 @@
       "osu_last_updated": "2025-03-18T20:57:15Z"
     },
     {
+      "beatmapset_id": 2171520,
+      "artist": "Saitama Saisyu Heiki & Aether",
+      "title": "Yuuga ni Sakase, Sumizome no Sakura",
+      "creator": "sjoy",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-29T12:21:30Z"
+    },
+    {
       "beatmapset_id": 2172367,
       "artist": "FELT",
       "title": "Last Wind",
@@ -1640,6 +2257,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2173216,
+      "artist": "ZUN",
+      "title": "Inada Hime-sama ni Shikarareru kara",
+      "creator": "BeautifulKisa",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-17T19:55:58Z"
     },
     {
       "beatmapset_id": 2175777,
@@ -1663,6 +2305,30 @@
       "osu_last_updated": "2025-05-22T01:07:20Z"
     },
     {
+      "beatmapset_id": 2176171,
+      "artist": "Shoujo Fractal",
+      "title": "Samayoi no Mei ~Amatsu~",
+      "creator": "Okoratu",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-24T21:04:51Z"
+    },
+    {
       "beatmapset_id": 2176951,
       "artist": "SOUND HOLIC feat. Nana Takahashi",
       "title": "No Life Queen (elexire) [cut]",
@@ -1682,6 +2348,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2177908,
+      "artist": "Sally",
+      "title": "Remind",
+      "creator": "The Law",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-29T22:14:00Z"
     },
     {
       "beatmapset_id": 2179566,
@@ -1707,6 +2396,30 @@
       "osu_last_updated": "2024-05-13T15:46:09Z"
     },
     {
+      "beatmapset_id": 2180270,
+      "artist": "ALADDIN",
+      "title": "Kimi no Tonari",
+      "creator": "nanoya",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Syrufit",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-13T12:04:49Z"
+    },
+    {
       "beatmapset_id": 2182178,
       "artist": "25-ji, Nightcord de. x Hatsune Miku",
       "title": "Bad Apple!! feat. SEKAI",
@@ -1725,6 +2438,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-08-11T11:06:27Z"
+    },
+    {
+      "beatmapset_id": 2182821,
+      "artist": "ALiCE'S EMOTiON",
+      "title": "Last Time",
+      "creator": "dasdwqdf",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-20T14:22:08Z"
     },
     {
       "beatmapset_id": 2182936,
@@ -1835,6 +2573,103 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-11-14T06:27:11Z"
+    },
+    {
+      "beatmapset_id": 2184864,
+      "artist": "ShinRa-Bansho",
+      "title": "Instant Blue",
+      "creator": "seedcrack",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-30T15:23:31Z"
+    },
+    {
+      "beatmapset_id": 2185163,
+      "artist": "xi-on",
+      "title": "Rokujuunenme no Touhou Saiban ~ Fate of Sixty Years",
+      "creator": "Moete",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:Touhou",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-24T13:02:14Z"
+    },
+    {
+      "beatmapset_id": 2186014,
+      "artist": "Demetori",
+      "title": "Fuujin Shoujo",
+      "creator": "CallieCube",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-30T18:34:57Z"
+    },
+    {
+      "beatmapset_id": 2186687,
+      "artist": "BUTAOTOME",
+      "title": "Hana",
+      "creator": "Luscent",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-12T17:59:15Z"
     },
     {
       "beatmapset_id": 2187567,
@@ -1981,6 +2816,54 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2190615,
+      "artist": "Demetori",
+      "title": "Fuujin Shoujo",
+      "creator": "sstari",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-17T22:17:39Z"
+    },
+    {
+      "beatmapset_id": 2190658,
+      "artist": "Saitama Saisyu Heiki",
+      "title": "Shanghai Kouchakan",
+      "creator": "sjoy",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-06T02:12:58Z"
+    },
+    {
       "beatmapset_id": 2191004,
       "artist": "TatshMusicCircle feat. Tsukiko",
       "title": "Floating Darkness...",
@@ -2040,6 +2923,30 @@
       "confidence": "probable",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-04-10T09:07:01Z"
+    },
+    {
+      "beatmapset_id": 2193011,
+      "artist": "Yellow Zebra",
+      "title": "Believe heart!",
+      "creator": "BeautifulKisa",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-11T11:36:06Z"
     },
     {
       "beatmapset_id": 2193211,
@@ -2133,6 +3040,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2195327,
+      "artist": "Shibayan feat. 3L",
+      "title": "MyonMyonMyonMyonMyonMyon!",
+      "creator": "eZmmR",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:ShibayanRecords",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-19T11:02:24Z"
+    },
+    {
       "beatmapset_id": 2195468,
       "artist": "ShinRa-Bansho",
       "title": "Subarashiki Guuzou Sekai",
@@ -2193,6 +3124,32 @@
       "confidence": "probable",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2025-05-11T11:43:14Z"
+    },
+    {
+      "beatmapset_id": 2198377,
+      "artist": "Halozy",
+      "title": "Kagami",
+      "creator": "-Tynamo",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-07-07T02:51:37Z"
     },
     {
       "beatmapset_id": 2198692,

--- a/data/catalog/2200000-2299999.json
+++ b/data/catalog/2200000-2299999.json
@@ -22,6 +22,29 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2202176,
+      "artist": "moro",
+      "title": "Sickness",
+      "creator": "Genjuro",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-08-07T20:47:36Z"
+    },
+    {
       "beatmapset_id": 2204403,
       "artist": "beatMARIO",
       "title": "Night of Knights",
@@ -48,6 +71,56 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-07-22T18:01:34Z"
+    },
+    {
+      "beatmapset_id": 2205023,
+      "artist": "Adust Rain",
+      "title": "EViL DANCE",
+      "creator": "ler1211",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Adust Rain",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-04T18:17:57Z"
+    },
+    {
+      "beatmapset_id": 2205623,
+      "artist": "RD-Sounds feat. Kushi",
+      "title": "Takeyabu no Naka",
+      "creator": "tokiko",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-19T17:04:34Z"
     },
     {
       "beatmapset_id": 2205747,
@@ -154,6 +227,55 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-07-04T14:28:11Z"
+    },
+    {
+      "beatmapset_id": 2210397,
+      "artist": "senya",
+      "title": "Sokubaku Anemonation",
+      "creator": "Satellite",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-28T08:44:29Z"
+    },
+    {
+      "beatmapset_id": 2211447,
+      "artist": "ZUN",
+      "title": "U.N. Owen wa Kanojo Nano ka?",
+      "creator": "sstari",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-19T19:36:18Z"
     },
     {
       "beatmapset_id": 2212169,
@@ -289,6 +411,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-07-23T06:33:43Z"
+    },
+    {
+      "beatmapset_id": 2217940,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Everything will freeze",
+      "creator": "Worthlessnut9",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-27T01:46:23Z"
     },
     {
       "beatmapset_id": 2218153,
@@ -563,6 +710,82 @@
       "osu_last_updated": "2026-05-20T23:49:23Z"
     },
     {
+      "beatmapset_id": 2235405,
+      "artist": "ZUN",
+      "title": "Shinkou wa Hakanaki Ningen no Tame ni",
+      "creator": "xcx",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-15T14:11:20Z"
+    },
+    {
+      "beatmapset_id": 2236173,
+      "artist": "IOSYS",
+      "title": "Makudo wa Taihen na Mono o Tsukutte Ikimashita",
+      "creator": "Bloxi",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-10-12T03:28:51Z"
+    },
+    {
+      "beatmapset_id": 2237545,
+      "artist": "IOSYS",
+      "title": "Makudo wa Taihen na Mono o Tsukutte Ikimashita",
+      "creator": "Blacky Design",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-07T22:42:12Z"
+    },
+    {
       "beatmapset_id": 2237670,
       "artist": "FELT",
       "title": "New World (Cut Ver.)",
@@ -625,6 +848,56 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-09-20T22:26:57Z"
+    },
+    {
+      "beatmapset_id": 2239880,
+      "artist": "DJKurara",
+      "title": "Crazy Aliens",
+      "creator": "Genjuro",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-10T14:56:39Z"
+    },
+    {
+      "beatmapset_id": 2240721,
+      "artist": "Rin",
+      "title": "Muenzuka set 02 ~ Oriental Dark Flight",
+      "creator": "Annabel",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-05T12:39:07Z"
     },
     {
       "beatmapset_id": 2241601,
@@ -800,6 +1073,29 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2250094,
+      "artist": "t=NODE",
+      "title": "Riverside View II ~ Finale ~",
+      "creator": "Shurelia",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-26T21:13:52Z"
+    },
+    {
       "beatmapset_id": 2250270,
       "artist": "beatMARIO",
       "title": "Night of Knights (Cranky Remix)",
@@ -875,6 +1171,81 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-06-07T23:24:14Z"
+    },
+    {
+      "beatmapset_id": 2253507,
+      "artist": "Akatsuki Records",
+      "title": "Mizuiro Raindrop",
+      "creator": "Wither",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Adust Rain",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-21T05:34:33Z"
+    },
+    {
+      "beatmapset_id": 2254017,
+      "artist": "Sally",
+      "title": "Reikon Mythology",
+      "creator": "Syoko",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-10-23T21:34:48Z"
+    },
+    {
+      "beatmapset_id": 2254112,
+      "artist": "IOSYS",
+      "title": "Cirno no Perfect Sansuu Kyoushitsu (Short Ver.)",
+      "creator": "iRedi",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-12T11:55:52Z"
     },
     {
       "beatmapset_id": 2255745,
@@ -954,6 +1325,56 @@
       "osu_last_updated": "2024-10-05T06:00:16Z"
     },
     {
+      "beatmapset_id": 2257913,
+      "artist": "ZUN",
+      "title": "Furuki Yuanxian",
+      "creator": "nik",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-08T18:55:11Z"
+    },
+    {
+      "beatmapset_id": 2258024,
+      "artist": "FELT",
+      "title": "Lost / Lies in Reality",
+      "creator": "Mir",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-18T13:45:59Z"
+    },
+    {
       "beatmapset_id": 2258048,
       "artist": "TAMAONSEN",
       "title": "COZMIC DRIVE feat. Youko",
@@ -998,6 +1419,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-22",
       "osu_last_updated": "2025-04-22T14:33:58Z"
+    },
+    {
+      "beatmapset_id": 2259588,
+      "artist": "beatMARIO",
+      "title": "Saishuu Kichiku Imouto Flandre-S (Camellia's Remix)",
+      "creator": "f_ronte",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:COOL&CREATE",
+        "discovery_query:ShibayanRecords",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-31T13:27:28Z"
     },
     {
       "beatmapset_id": 2260896,
@@ -1088,6 +1534,32 @@
       "osu_last_updated": "2025-01-07T04:51:52Z"
     },
     {
+      "beatmapset_id": 2266581,
+      "artist": "Syrufit feat. Mei Ayakura",
+      "title": "Tsukikage Shoujo (Poplica* Remix)",
+      "creator": "big snag",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Syrufit",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-30T09:43:00Z"
+    },
+    {
       "beatmapset_id": 2267353,
       "artist": "A-One feat. Aki",
       "title": "Darkish",
@@ -1107,6 +1579,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2025-01-23T14:45:06Z"
+    },
+    {
+      "beatmapset_id": 2267663,
+      "artist": "Syrufit / Poplica* feat. Mei Ayakura",
+      "title": "Stellar",
+      "creator": "milr_",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "discovery_query:Syrufit",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-10-27T23:31:12Z"
     },
     {
       "beatmapset_id": 2268478,
@@ -1179,6 +1676,30 @@
       "osu_last_updated": "2024-10-23T13:00:12Z"
     },
     {
+      "beatmapset_id": 2271602,
+      "artist": "senya",
+      "title": "Sakuretsu Irony",
+      "creator": "Satellite",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-04T09:06:50Z"
+    },
+    {
       "beatmapset_id": 2271653,
       "artist": "Kotoge Mai",
       "title": "Itoshi Kimi wo Mitsuke ni",
@@ -1197,6 +1718,31 @@
       "confidence": "probable",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-11-27T01:05:56Z"
+    },
+    {
+      "beatmapset_id": 2271678,
+      "artist": "A-One feat. misa",
+      "title": "Only Treasure",
+      "creator": "-Mikan",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-13T15:02:34Z"
     },
     {
       "beatmapset_id": 2272306,
@@ -1218,6 +1764,79 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2025-05-08T11:28:38Z"
+    },
+    {
+      "beatmapset_id": 2272466,
+      "artist": "TAMAONSEN",
+      "title": "Dear Rainy Day feat. TINY PLANETS",
+      "creator": "kuuti",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Adust Rain",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-01T10:16:33Z"
+    },
+    {
+      "beatmapset_id": 2273085,
+      "artist": "Diao Ye Zong feat. Meramipop",
+      "title": "Shifu \"Hakurei Meimei Kettouhou Fukoku no Gi\"",
+      "creator": "Rita Summers",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-22T20:26:23Z"
+    },
+    {
+      "beatmapset_id": 2274433,
+      "artist": "FELT",
+      "title": "Can't look away",
+      "creator": "Sotarks",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-20T17:41:01Z"
     },
     {
       "beatmapset_id": 2274446,
@@ -1309,6 +1928,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-01-12T16:13:47Z"
+    },
+    {
+      "beatmapset_id": 2275606,
+      "artist": "senya",
+      "title": "Anata ga Inai Yokaze",
+      "creator": "Dailycare",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-12T06:13:15Z"
     },
     {
       "beatmapset_id": 2275913,
@@ -1451,6 +2095,32 @@
       "osu_last_updated": "2024-11-15T14:42:29Z"
     },
     {
+      "beatmapset_id": 2280680,
+      "artist": "UNDEAD CORPORATION",
+      "title": "MEGALOMANIA",
+      "creator": "Daycore",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-23T14:48:19Z"
+    },
+    {
       "beatmapset_id": 2280703,
       "artist": "senya",
       "title": "Chiisana Hari no Youna",
@@ -1522,6 +2192,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-01-26T19:15:34Z"
+    },
+    {
+      "beatmapset_id": 2281545,
+      "artist": "IOSYS",
+      "title": "Koi no Hyouketsu Otenba Yukemuri Cirno Onsen",
+      "creator": "allein",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-16T18:57:44Z"
     },
     {
       "beatmapset_id": 2281583,
@@ -1825,6 +2520,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2288990,
+      "artist": "LeaF",
+      "title": "Calamity Fortune",
+      "creator": "Usagi_",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-14T17:50:31Z"
+    },
+    {
       "beatmapset_id": 2289073,
       "artist": "RichaadEB & AHmusic",
       "title": "Reach for the Moon, Immortal Smoke",
@@ -1933,6 +2653,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2292081,
+      "artist": "lucky",
+      "title": "Friends of Kagami",
+      "creator": "Bloxi",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-21T23:17:14Z"
+    },
+    {
       "beatmapset_id": 2292162,
       "artist": "Diao Ye Zong",
       "title": "Trauma Merai",
@@ -1996,6 +2741,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-03-12T13:34:18Z"
+    },
+    {
+      "beatmapset_id": 2293757,
+      "artist": "FELT",
+      "title": "Prayer Blue",
+      "creator": "pregnant_man",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-15T14:32:16Z"
     },
     {
       "beatmapset_id": 2294584,
@@ -2098,6 +2866,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2299734,
+      "artist": "Halozy",
+      "title": "Paranoid Lost (Cut Ver.)",
+      "creator": "Erowdi",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-07-31T23:21:51Z"
     }
   ]
 }

--- a/data/catalog/2300000-2399999.json
+++ b/data/catalog/2300000-2399999.json
@@ -42,6 +42,55 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2301090,
+      "artist": "ZUN",
+      "title": "Touhou 7 Nonstop Medley",
+      "creator": "Kukkai",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Touhou",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-02-08T10:28:43Z"
+    },
+    {
+      "beatmapset_id": 2302143,
+      "artist": "Takamachi Walk",
+      "title": "Timeless Dissonance",
+      "creator": "Hinsvar",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-02T05:51:57Z"
+    },
+    {
       "beatmapset_id": 2302194,
       "artist": "R-Note",
       "title": "Koiiro Magical Star",
@@ -63,6 +112,32 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-05-24T14:02:20Z"
+    },
+    {
+      "beatmapset_id": 2303547,
+      "artist": "ZUN",
+      "title": "Furuki Yuanxian",
+      "creator": "xcx",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-04T03:02:53Z"
     },
     {
       "beatmapset_id": 2303814,
@@ -135,6 +210,55 @@
       "osu_last_updated": "2025-01-07T11:58:00Z"
     },
     {
+      "beatmapset_id": 2304999,
+      "artist": "Mikuru",
+      "title": "M.C. Donald wa Dance ni Muchuu Nano ka? Saishuu Kichiku Doukeshi Donald-M",
+      "creator": "an3",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:COOL&CREATE",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-01T10:59:45Z"
+    },
+    {
+      "beatmapset_id": 2306433,
+      "artist": "Rin",
+      "title": "Daishibyo set 10 ~ Oomiwa Shinwaden",
+      "creator": "Annabel",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-13T07:05:25Z"
+    },
+    {
       "beatmapset_id": 2306655,
       "artist": "RD-Sounds feat. Meramipop",
       "title": "Shoot the shrine maiden!",
@@ -155,6 +279,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-02-28T14:22:58Z"
+    },
+    {
+      "beatmapset_id": 2306814,
+      "artist": "Demetori",
+      "title": "Shinkou wa Hakanaki Ningen no Tame ni ~ Jehovah's YaHVeH",
+      "creator": "-Rustyy",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-25T15:32:23Z"
     },
     {
       "beatmapset_id": 2306894,
@@ -180,6 +327,55 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-01-11T21:06:44Z"
+    },
+    {
+      "beatmapset_id": 2307224,
+      "artist": "FELT",
+      "title": "Can't look away",
+      "creator": "Irone OSU",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-02-09T13:41:27Z"
+    },
+    {
+      "beatmapset_id": 2308571,
+      "artist": "Morimori Atsushi",
+      "title": "Toono Gensou Monogatari (MRM REMIX)",
+      "creator": "FAMoss",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-12T15:53:22Z"
     },
     {
       "beatmapset_id": 2309829,
@@ -329,6 +525,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2313285,
+      "artist": "Shibayan feat. yana",
+      "title": "Watashi wa Koneko",
+      "creator": "Genjuro",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:ShibayanRecords",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-02-19T13:50:49Z"
+    },
+    {
       "beatmapset_id": 2313313,
       "artist": "Halozy",
       "title": "GO 4 IT",
@@ -458,6 +678,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2314842,
+      "artist": "Halozy",
+      "title": "Secret Sister Complex",
+      "creator": "milr_",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-02-02T16:31:12Z"
     },
     {
       "beatmapset_id": 2314977,
@@ -647,6 +892,154 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-03-21T11:41:32Z"
+    },
+    {
+      "beatmapset_id": 2318139,
+      "artist": "Poplica* feat. Mei Ayakura",
+      "title": "farewell",
+      "creator": "SUISEI69",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-22T17:47:15Z"
+    },
+    {
+      "beatmapset_id": 2320547,
+      "artist": "Morimori Atsushi",
+      "title": "Txxs or get the fxxk out!!",
+      "creator": "FAMoss",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-15T15:26:30Z"
+    },
+    {
+      "beatmapset_id": 2320727,
+      "artist": "Demetori",
+      "title": "Kamisabita Kosenjou ~ Suwa Foughten Field",
+      "creator": "gay girl",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-10T19:43:39Z"
+    },
+    {
+      "beatmapset_id": 2321881,
+      "artist": "senya",
+      "title": "Senka Ryouran",
+      "creator": "Serafeim",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-06T13:13:12Z"
+    },
+    {
+      "beatmapset_id": 2323094,
+      "artist": "Silver Forest",
+      "title": "Phantasm Brigade",
+      "creator": "Luscent",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-31T02:15:41Z"
+    },
+    {
+      "beatmapset_id": 2324476,
+      "artist": "senya",
+      "title": "Cinderella Avatar",
+      "creator": "Satellite",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-03T11:50:58Z"
     },
     {
       "beatmapset_id": 2325579,
@@ -905,6 +1298,32 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-04-13T17:12:37Z"
+    },
+    {
+      "beatmapset_id": 2328066,
+      "artist": "-45",
+      "title": "Luna Projection",
+      "creator": "Radiownd",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-18T18:12:01Z"
     },
     {
       "beatmapset_id": 2329538,
@@ -1628,6 +2047,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2337322,
+      "artist": "MISATO",
+      "title": "Necro Fantasia",
+      "creator": "Bastian",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-01T16:12:46Z"
+    },
+    {
       "beatmapset_id": 2337323,
       "artist": "dBu",
       "title": "Majotachi no Butoukai \\~ Magus (Castella) [Nightmare]",
@@ -2244,6 +2687,31 @@
       "osu_last_updated": "2026-01-02T22:37:58Z"
     },
     {
+      "beatmapset_id": 2346142,
+      "artist": "Halozy feat. Nanahira",
+      "title": "Monosugoi Ikioi de Keine ga Monosugoi Uta",
+      "creator": "Sotarks",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-06T11:57:13Z"
+    },
+    {
       "beatmapset_id": 2346402,
       "artist": "RichaadEB",
       "title": "Night of Nights (Metal Cover)",
@@ -2652,6 +3120,31 @@
       "osu_last_updated": "2025-04-07T14:28:55Z"
     },
     {
+      "beatmapset_id": 2350118,
+      "artist": "Halozy",
+      "title": "Masshiro na Yuki",
+      "creator": "A-40",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-05T17:59:03Z"
+    },
+    {
       "beatmapset_id": 2350651,
       "artist": "Beat Mario",
       "title": "Night of Knights",
@@ -2722,6 +3215,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-10-10T16:09:41Z"
+    },
+    {
+      "beatmapset_id": 2351192,
+      "artist": "Hatsunetsumiko's",
+      "title": "I Wish (2018 re-recording)",
+      "creator": "Luscent",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-09T21:35:31Z"
     },
     {
       "beatmapset_id": 2351463,
@@ -2989,6 +3505,55 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2364061,
+      "artist": "UNDEAD CORPORATION",
+      "title": "MEGALOMANIA",
+      "creator": "BlackBN",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-05T02:49:12Z"
+    },
+    {
+      "beatmapset_id": 2365832,
+      "artist": "ShinRa-Bansho",
+      "title": "Sayonara History",
+      "creator": "wenect",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-06-22T15:40:00Z"
+    },
+    {
       "beatmapset_id": 2366473,
       "artist": "beatMARIO / COOL&CREATE",
       "title": "Super Night of Nights [Beat Mario x Maron]",
@@ -3160,6 +3725,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2025-06-09T18:50:20Z"
+    },
+    {
+      "beatmapset_id": 2372053,
+      "artist": "UNDEAD CORPORATION",
+      "title": "MEGALOMANIA",
+      "creator": "[-Omni-]",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-07-15T20:43:46Z"
     },
     {
       "beatmapset_id": 2372075,
@@ -3362,6 +3952,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-07-13T19:20:40Z"
+    },
+    {
+      "beatmapset_id": 2376812,
+      "artist": "Silver Forest",
+      "title": "Kero (9) destiny",
+      "creator": "iRedi",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-07-19T08:54:20Z"
     },
     {
       "beatmapset_id": 2376975,
@@ -3691,6 +4304,55 @@
       "osu_last_updated": "2025-08-10T19:41:09Z"
     },
     {
+      "beatmapset_id": 2389297,
+      "artist": "Rin",
+      "title": "Moriya set 11 ReEdit ~ Onbashira no Hakaba",
+      "creator": "Annabel",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-06-21T06:07:06Z"
+    },
+    {
+      "beatmapset_id": 2389626,
+      "artist": "ZUN",
+      "title": "Touhou 10 Nonstop Medley",
+      "creator": "Kukkai",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:Touhou",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-10-04T10:46:50Z"
+    },
+    {
       "beatmapset_id": 2389650,
       "artist": "Halozy",
       "title": "Crystal Snow",
@@ -3902,6 +4564,57 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2397276,
+      "artist": "ShinRa-Bansho",
+      "title": "Heart in Wonderland",
+      "creator": "Zawajiro",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-08-20T06:41:04Z"
+    },
+    {
+      "beatmapset_id": 2397704,
+      "artist": "senya",
+      "title": "Tsuzurenu Mori no Shoujo",
+      "creator": "dahkjdas",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-01T16:26:46Z"
     },
     {
       "beatmapset_id": 2399201,

--- a/data/catalog/2400000-2499999.json
+++ b/data/catalog/2400000-2499999.json
@@ -249,6 +249,31 @@
       "osu_last_updated": "2026-04-23T22:52:50Z"
     },
     {
+      "beatmapset_id": 2412257,
+      "artist": "Kurokotei",
+      "title": "Galaxy Collapse",
+      "creator": "Ilay",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-21T12:48:57Z"
+    },
+    {
       "beatmapset_id": 2412845,
       "artist": "beatMARIO",
       "title": "Night of Knights",
@@ -539,6 +564,31 @@
       "osu_last_updated": "2025-08-13T00:20:31Z"
     },
     {
+      "beatmapset_id": 2419751,
+      "artist": "UNDEAD CORPORATION",
+      "title": "MEGALOMANIA",
+      "creator": "Concepte",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-09-21T20:24:16Z"
+    },
+    {
       "beatmapset_id": 2421483,
       "artist": "beatMARIO x MARON",
       "title": "Chou Night of Knights",
@@ -719,6 +769,79 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-07-30T11:05:53Z"
+    },
+    {
+      "beatmapset_id": 2429034,
+      "artist": "Demetori",
+      "title": "Natsukashiki Touhou no Chi ~ Sic World",
+      "creator": "Madoka Ayukawa",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Touhou",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-07-10T16:56:21Z"
+    },
+    {
+      "beatmapset_id": 2433072,
+      "artist": "Halozy feat. Tsubaki",
+      "title": "Kyun Kyun Tamaran Inaba-tan.",
+      "creator": "Den59",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-24T19:14:10Z"
+    },
+    {
+      "beatmapset_id": 2434263,
+      "artist": "Demetori",
+      "title": "Furuki Yuanxian",
+      "creator": "- Satori",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-09-23T14:27:03Z"
     },
     {
       "beatmapset_id": 2434424,
@@ -927,6 +1050,31 @@
       "osu_last_updated": "2025-10-29T14:29:26Z"
     },
     {
+      "beatmapset_id": 2444840,
+      "artist": "Masayoshi Minoshima feat. misato",
+      "title": "Necro Fantasia (Eunomia Ver.)",
+      "creator": "STaLeRGooD",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-11-08T10:15:32Z"
+    },
+    {
       "beatmapset_id": 2444992,
       "artist": "FELT",
       "title": "Sounding Beat & pulse",
@@ -947,6 +1095,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-02-17T16:17:44Z"
+    },
+    {
+      "beatmapset_id": 2445629,
+      "artist": "Unlucky Morpheus",
+      "title": "BPM210 no Shanghai Alice (Instrumental)",
+      "creator": "h6zy",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-08T20:32:51Z"
     },
     {
       "beatmapset_id": 2449780,
@@ -1020,6 +1193,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2453058,
+      "artist": "ZUN",
+      "title": "Aokigahara no Densetsu",
+      "creator": "Nyanaro",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-25T15:27:46Z"
+    },
+    {
       "beatmapset_id": 2453161,
       "artist": "ShinRa-Bansho x Chocofan",
       "title": "Touhou Ieru Kana",
@@ -1062,6 +1260,31 @@
       "osu_last_updated": "2026-01-26T13:46:39Z"
     },
     {
+      "beatmapset_id": 2454428,
+      "artist": "ZUN",
+      "title": "Sacred Forest",
+      "creator": "Nyanaro",
+      "source": "東方錦上京 〜 Fossilized Wonders.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Fossilized Wonders",
+        "discovery_query:source=東方錦上京",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-08-12T01:29:08Z"
+    },
+    {
       "beatmapset_id": 2454530,
       "artist": "Demetori",
       "title": "Youyou Bakko ~ Who done it!!!",
@@ -1080,6 +1303,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2455952,
+      "artist": "komasy",
+      "title": "the primal scene of hyperflip the girl saw",
+      "creator": "komasy",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-05T16:11:14Z"
     },
     {
       "beatmapset_id": 2456336,
@@ -1130,6 +1376,30 @@
       "osu_last_updated": "2025-11-06T12:20:10Z"
     },
     {
+      "beatmapset_id": 2459983,
+      "artist": "Yonder Voice",
+      "title": "Arigatou",
+      "creator": "akyito",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-08-02T10:04:39Z"
+    },
+    {
       "beatmapset_id": 2461093,
       "artist": "Shibayan feat. 3L",
       "title": "MyonMyonMyonMyonMyonMyon!",
@@ -1151,6 +1421,101 @@
       "osu_last_updated": "2026-03-21T15:47:10Z"
     },
     {
+      "beatmapset_id": 2462140,
+      "artist": "senya",
+      "title": "Tokuiten no Kaibutsuteki Kanjou",
+      "creator": "Satellite",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-12-10T18:02:58Z"
+    },
+    {
+      "beatmapset_id": 2463988,
+      "artist": "senya",
+      "title": "Tokuiten no Kaibutsuteki Kanjou",
+      "creator": "Luscent",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-06T09:06:53Z"
+    },
+    {
+      "beatmapset_id": 2466317,
+      "artist": "Liz Triangle",
+      "title": "Renge Hanabi",
+      "creator": "61mgb",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-12-27T21:30:37Z"
+    },
+    {
+      "beatmapset_id": 2469450,
+      "artist": "Unlucky Morpheus",
+      "title": "Kamigami ga Koishita Gensoukyou",
+      "creator": "[TCD] Ena-suki",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-04T08:16:59Z"
+    },
+    {
       "beatmapset_id": 2470449,
       "artist": "ShinRa-Bansho",
       "title": "Ano Hi no Yume no Alice",
@@ -1170,6 +1535,104 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2025-11-28T12:18:08Z"
+    },
+    {
+      "beatmapset_id": 2471841,
+      "artist": "Tsubaki",
+      "title": "Kyun Kyun Tamaran Inaba-tan. (Cut Ver.)",
+      "creator": "mirac1e_xf",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-16T04:41:13Z"
+    },
+    {
+      "beatmapset_id": 2473158,
+      "artist": "FELT",
+      "title": "Puppet in the Dark (Part I & II)",
+      "creator": "Ryuusei Aika",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-01T13:17:57Z"
+    },
+    {
+      "beatmapset_id": 2474510,
+      "artist": "Xi",
+      "title": "Rokujuu-nen Me no Shinsoku Saiban ~ Rapidity is a justice",
+      "creator": "[Karcher]",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-31T16:39:53Z"
+    },
+    {
+      "beatmapset_id": 2474975,
+      "artist": "Kurokotei",
+      "title": "Galaxy Collapse",
+      "creator": "SuzumeAyase",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-19T11:33:21Z"
     },
     {
       "beatmapset_id": 2475212,
@@ -1199,6 +1662,80 @@
       "osu_last_updated": "2025-12-08T13:17:14Z"
     },
     {
+      "beatmapset_id": 2476206,
+      "artist": "Halozy",
+      "title": "Deconstruction Star",
+      "creator": "4sbet1",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-10T16:05:23Z"
+    },
+    {
+      "beatmapset_id": 2477983,
+      "artist": "Halozy feat. Nanahira",
+      "title": "Monosugoi Satori Gear de Reimu ga Monosugoi Uta",
+      "creator": "Tokyo 727",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-26T05:52:09Z"
+    },
+    {
+      "beatmapset_id": 2478777,
+      "artist": "Akatsuki Records",
+      "title": "ENDLESS FANTASY (Short Ver.)",
+      "creator": "sharpay",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-02T05:43:31Z"
+    },
+    {
       "beatmapset_id": 2479858,
       "artist": "Para Dot.",
       "title": "Infinite haze",
@@ -1219,6 +1756,32 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-05-06T16:52:46Z"
+    },
+    {
+      "beatmapset_id": 2480698,
+      "artist": "Liz Triangle",
+      "title": "Ruby",
+      "creator": "Enon",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-12-21T16:30:28Z"
     },
     {
       "beatmapset_id": 2482656,
@@ -1248,6 +1811,30 @@
       "osu_last_updated": "2026-01-17T18:10:40Z"
     },
     {
+      "beatmapset_id": 2483592,
+      "artist": "RUON feat. Meramipop",
+      "title": "Secret Desire - Dyes Remix -",
+      "creator": "Gsuncraft",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-13T05:54:19Z"
+    },
+    {
       "beatmapset_id": 2484594,
       "artist": "beatMARIO",
       "title": "Night of Knights (Cranky Remix)",
@@ -1274,6 +1861,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-12-28T00:51:53Z"
+    },
+    {
+      "beatmapset_id": 2489023,
+      "artist": "Demetori",
+      "title": "Kanjou no Matenrou ~ World's End",
+      "creator": "rinkiha",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-17T00:23:36Z"
     },
     {
       "beatmapset_id": 2489219,
@@ -1315,6 +1925,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2490353,
+      "artist": "senya",
+      "title": "Iro wa Jou e to Izanau",
+      "creator": "yakisode",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-18T12:12:20Z"
     },
     {
       "beatmapset_id": 2492855,
@@ -1387,6 +2022,30 @@
       "osu_last_updated": "2026-01-25T09:43:55Z"
     },
     {
+      "beatmapset_id": 2498268,
+      "artist": "ShinRa-Bansho",
+      "title": "Noumiso Rigid Girl",
+      "creator": "J-99",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-29T14:49:36Z"
+    },
+    {
       "beatmapset_id": 2499169,
       "artist": "beatMARIO (COOL&CREATE)",
       "title": "Night of Nights (Camellia's \"Once Upon a Night\" Remix)",
@@ -1412,6 +2071,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-06-03T13:57:39Z"
+    },
+    {
+      "beatmapset_id": 2499259,
+      "artist": "A-One feat. Aki",
+      "title": "Darkish",
+      "creator": "azphyx",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-07-12T00:31:34Z"
     },
     {
       "beatmapset_id": 2499342,

--- a/data/catalog/2500000-2599999.json
+++ b/data/catalog/2500000-2599999.json
@@ -155,6 +155,31 @@
       "osu_last_updated": "2026-03-29T01:02:51Z"
     },
     {
+      "beatmapset_id": 2512437,
+      "artist": "senya",
+      "title": "Kyoumei Shinai Ai no Katachi",
+      "creator": "Serafeim",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-24T12:05:20Z"
+    },
+    {
       "beatmapset_id": 2512768,
       "artist": "Beat Mario",
       "title": "Night of Nights",
@@ -332,6 +357,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2521633,
+      "artist": "Halozy",
+      "title": "Paranoid Lost",
+      "creator": "Gruetzig",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-24T13:41:37Z"
+    },
+    {
       "beatmapset_id": 2523604,
       "artist": "beatMARIO",
       "title": "Night of Nights (Flowering nights remix)",
@@ -383,6 +432,57 @@
       "osu_last_updated": "2026-03-24T21:10:25Z"
     },
     {
+      "beatmapset_id": 2524315,
+      "artist": "UNDEAD CORPORATION",
+      "title": "The Beginning",
+      "creator": "Reenix",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-04-12T18:49:28Z"
+    },
+    {
+      "beatmapset_id": 2524382,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Without the end",
+      "creator": "Nakano-",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-04-29T15:23:45Z"
+    },
+    {
       "beatmapset_id": 2524653,
       "artist": "beatMARIO",
       "title": "Night of Knights",
@@ -408,6 +508,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-03-18T14:26:00Z"
+    },
+    {
+      "beatmapset_id": 2524683,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Under the scarlet sky pt,1 inst",
+      "creator": "Umi Sonoda",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-18T21:03:25Z"
     },
     {
       "beatmapset_id": 2525813,
@@ -512,6 +637,31 @@
       "osu_last_updated": "2026-06-09T12:23:36Z"
     },
     {
+      "beatmapset_id": 2528001,
+      "artist": "A-One feat. Aki",
+      "title": "Zenmai Koidokei (T.E.B Summer Mix) (Game Ver.)",
+      "creator": "Cafe_deCoral",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-07T05:47:11Z"
+    },
+    {
       "beatmapset_id": 2528392,
       "artist": "beatMARIO",
       "title": "Night of Knights",
@@ -537,6 +687,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-05-24T23:02:55Z"
+    },
+    {
+      "beatmapset_id": 2529930,
+      "artist": "FELT",
+      "title": "Summer Fever",
+      "creator": "Stereotype",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-04-03T14:58:32Z"
     },
     {
       "beatmapset_id": 2530780,
@@ -566,6 +740,29 @@
       "osu_last_updated": "2026-04-03T18:16:33Z"
     },
     {
+      "beatmapset_id": 2531939,
+      "artist": "Unlucky Morpheus",
+      "title": "Danzai wa Amaneku Ningen no Moto ni",
+      "creator": "yakisode",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-04-22T18:31:34Z"
+    },
+    {
       "beatmapset_id": 2532070,
       "artist": "-45",
       "title": "Crimsonic dimension",
@@ -586,6 +783,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-04-11T18:24:07Z"
+    },
+    {
+      "beatmapset_id": 2532082,
+      "artist": "Kanpyohgo",
+      "title": "Unmei no Dark Side -Rolling Gothic mix",
+      "creator": "kartofle",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-15T02:10:00Z"
     },
     {
       "beatmapset_id": 2532207,
@@ -617,6 +837,31 @@
       "osu_last_updated": "2026-04-01T13:53:46Z"
     },
     {
+      "beatmapset_id": 2533832,
+      "artist": "A-One feat. Aki",
+      "title": "Zenmai Koidokei (T.E.B Summer Mix) (Game Ver.)",
+      "creator": "Masayume",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-07T19:50:53Z"
+    },
+    {
       "beatmapset_id": 2534273,
       "artist": "beatMARIO x S3RL",
       "title": "Night of Knights X Bass Slut",
@@ -642,6 +887,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-04-05T12:02:34Z"
+    },
+    {
+      "beatmapset_id": 2535184,
+      "artist": "Halozy",
+      "title": "143",
+      "creator": "HFIG",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-04-28T00:27:01Z"
     },
     {
       "beatmapset_id": 2536810,
@@ -693,6 +962,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-04-10T21:49:31Z"
+    },
+    {
+      "beatmapset_id": 2536961,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Under the scarlet sky pt,1 inst",
+      "creator": "Mekadon",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-16T22:18:03Z"
     },
     {
       "beatmapset_id": 2539015,
@@ -793,6 +1087,54 @@
       "osu_last_updated": "2026-06-06T17:01:50Z"
     },
     {
+      "beatmapset_id": 2549679,
+      "artist": "Halozy",
+      "title": "143",
+      "creator": "yakisode",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-07T05:47:55Z"
+    },
+    {
+      "beatmapset_id": 2550161,
+      "artist": "senya",
+      "title": "Kanjou Chemistry (Drum 'n' Bass Remix)",
+      "creator": "yakisode",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-08T04:59:23Z"
+    },
+    {
       "beatmapset_id": 2550415,
       "artist": "beatMARIO",
       "title": "Night of Knights",
@@ -820,6 +1162,53 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-05-07T22:58:01Z"
+    },
+    {
+      "beatmapset_id": 2550684,
+      "artist": "Halozy",
+      "title": "Genryuu Kaiko (Cut Ver.)",
+      "creator": "[-E S I A-]",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-12T11:37:03Z"
+    },
+    {
+      "beatmapset_id": 2550836,
+      "artist": "Unlucky Morpheus",
+      "title": "Danzai wa Amaneku Ningen no Moto ni",
+      "creator": "Maiiy",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-08-08T10:18:59Z"
     },
     {
       "beatmapset_id": 2553057,
@@ -851,6 +1240,30 @@
       "osu_last_updated": "2026-08-07T07:23:52Z"
     },
     {
+      "beatmapset_id": 2553532,
+      "artist": "senya",
+      "title": "Cinderella Avatar",
+      "creator": "yakisode",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-10T23:47:18Z"
+    },
+    {
       "beatmapset_id": 2554426,
       "artist": "NoKANY",
       "title": "Kinki to Hiiro Gensou -The Primary Plasm-",
@@ -871,6 +1284,102 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-07-15T05:05:44Z"
+    },
+    {
+      "beatmapset_id": 2556827,
+      "artist": "Unlucky Morpheus",
+      "title": "Kamigami ga Koishita Gensoukyou",
+      "creator": "tmk",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-08-17T15:27:44Z"
+    },
+    {
+      "beatmapset_id": 2557046,
+      "artist": "Halozy",
+      "title": "Three Magic (DiGiTAL WiNG TRANCE Remix)",
+      "creator": "Daletto",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-02T13:23:41Z"
+    },
+    {
+      "beatmapset_id": 2557613,
+      "artist": "Halozy",
+      "title": "Masshiro na Yuki (Cut Ver.)",
+      "creator": "[-E S I A-]",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-07-10T03:59:40Z"
+    },
+    {
+      "beatmapset_id": 2559362,
+      "artist": "Halozy",
+      "title": "Sakura Saku Utopia",
+      "creator": "Hata no Kokoro",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-29T11:56:43Z"
     },
     {
       "beatmapset_id": 2561367,
@@ -1072,6 +1581,30 @@
       "osu_last_updated": "2026-08-14T14:46:22Z"
     },
     {
+      "beatmapset_id": 2586381,
+      "artist": "ryu5150",
+      "title": "Extend Ash",
+      "creator": "reisen91937",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-08-20T15:44:41Z"
+    },
+    {
       "beatmapset_id": 2586486,
       "artist": "Diao Ye Zong feat. Meramipop",
       "title": "Chirei \"Gensoukyou Engi Fuujirareshi Youkai-tachi no Page\"",
@@ -1091,6 +1624,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-07-16T09:06:02Z"
+    },
+    {
+      "beatmapset_id": 2586507,
+      "artist": "Halozy",
+      "title": "Masshiro na Yuki",
+      "creator": "aminos111",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:coverage-200plus-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-08-02T17:00:12Z"
     }
   ]
 }

--- a/docs/source-audit-2026-09-coverage-200plus.md
+++ b/docs/source-audit-2026-09-coverage-200plus.md
@@ -1,0 +1,131 @@
+# Coverage audit: 200+ absent explicit-source Touhou beatmapsets (2026-09)
+
+## Scope
+
+This pass searches every configured osu! API discovery query against the current canonical catalog, but only inserts beatmapsets that were absent from `main` and that independently satisfy the repository's existing automatic `verified` rule through current explicit osu! `source` metadata.
+
+No `manual:verified` override, artist-only inference, mapper-tag-only inference, tournament blanket trust, or collection-only promotion is used in this batch.
+
+## Search breadth
+
+- configured discovery queries: **89**
+- cursor pages requested per query: up to **8**
+- unique beatmapsets seen across all queries: **5272**
+- unique search hits absent from the base catalog: **2887**
+- absent hits already classifiable as explicit-source `verified`: **466**
+- base catalog cardinality: **3993**
+
+## Verification pipeline
+
+Every retained beatmapset passed all of these checks:
+
+1. numeric `beatmapset_id` is absent from the base catalog;
+2. rediscovered through one or more configured osu! API queries, retaining the exact `discovery_query:*` evidence;
+3. search-result metadata classifies as `verified` because current osu! `source` is an exact accepted Touhou alias or a recognized official Touhou game source;
+4. direct `/api/v2/beatmapsets/{id}` refetch returns the same ID / artist / title / creator / source / status and still classifies as explicit-source `verified`;
+5. the public `https://osu.ppy.sh/beatmapsets/{id}` page is fetched separately and its embedded canonical beatmapset JSON matches the direct API identity/source/status and still classifies as explicit-source `verified`;
+6. the final write adds only new IDs and uses `Catalog.save()` for deterministic shard placement and sorting.
+
+Direct API refetch: **466 accepted / 0 rejected** from the search-verified absent pool.
+
+Public-page refetch of the diversified preselection: **265 accepted / 55 rejected**.
+
+## Accepted result
+
+- new beatmapsets added: **239**
+- final catalog cardinality: **4232**
+- source specificity: **212 recognized game-source rows**, **27 exact generic Touhou-source rows**
+- status distribution: ranked=239
+- mode presence: catch=21, mania=34, osu=136, taiko=52
+- discovery corroboration: 2 queries=29, 3 queries=100, 4 queries=81, 5 queries=27, 6 queries=1, 7 queries=1
+
+Selection is round-robin across normalized source strings, with recognized game sources and current ranked/loved material preferred before generic `Touhou` source rows. This avoids simply taking the first IDs returned by a broad keyword search.
+
+### Source distribution
+
+- `東方風神録　～ Mountain of Faith.` — 32
+- `東方妖々夢　～ Perfect Cherry Blossom.` — 31
+- `東方紅魔郷　～ the Embodiment of Scarlet Devil.` — 30
+- `東方地霊殿　～ Subterranean Animism.` — 29
+- `東方永夜抄　～ Imperishable Night.` — 29
+- `東方花映塚　～ Phantasmagoria of Flower View.` — 28
+- `東方Project` — 27
+- `東方星蓮船　～ Undefined Fantastic Object.` — 16
+- `東方神霊廟　～ Ten Desires.` — 16
+- `東方錦上京 〜 Fossilized Wonders.` — 1
+
+### Accepted beatmapset IDs
+
+- `2280680`, `1849213`, `1919687`, `2156450`, `2185163`, `2205023`, `2120472`, `2253507`, `2454428`, `1446247`, `2328066`, `1989147`, `1945081`, `2064233`, `1927811`, `2055714`, `2257913`, `2267663`, `1873233`, `1284535`
+- `2025551`, `2301090`, `2086046`, `2011565`, `2173216`, `2303547`, `2271678`, `2198377`, `1348852`, `2102240`, `2308571`, `2266581`, `2020128`, `2235405`, `2320547`, `2412257`, `2273085`, `1461736`, `2114955`, `1960735`
+- `2480698`, `2128889`, `2288990`, `2013277`, `2463988`, `2397704`, `1499636`, `2120349`, `2049284`, `2524315`, `2240721`, `2324476`, `2013928`, `2474975`, `1382136`, `1878367`, `2138161`, `2132719`, `2389626`, `1927927`
+- `2025539`, `2258024`, `2272466`, `1889476`, `2397276`, `2275606`, `2051546`, `2011555`, `2066498`, `1961523`, `2444840`, `2084799`, `2047786`, `2115856`, `2306433`, `2462140`, `1976303`, `2074627`, `2477983`, `2528001`
+- `2321881`, `2063410`, `2193011`, `2434263`, `2023965`, `2119924`, `1241563`, `2533832`, `2473158`, `2550161`, `2111234`, `2124429`, `1267528`, `1936480`, `2346142`, `2129313`, `2299734`, `2483592`, `2557046`, `2182821`
+- `2136127`, `1360248`, `2429034`, `2148164`, `2202176`, `2236173`, `2151953`, `1992653`, `2476206`, `2217940`, `2320727`, `2177908`, `2239880`, `2237545`, `2190658`, `1437794`, `2512437`, `2350118`, `2389297`, `2254017`
+- `2302143`, `2292081`, `2211447`, `1556887`, `2076628`, `2459983`, `2274433`, `2351192`, `2453058`, `2254112`, `1565933`, `2095104`, `1849967`, `2474510`, `2499259`, `2466317`, `2490353`, `2259588`, `2128728`, `1856797`
+- `2557613`, `2521633`, `2307224`, `2489023`, `177908`, `1648038`, `2148241`, `1862313`, `1915805`, `2553532`, `328117`, `2281545`, `1762719`, `2167421`, `1914040`, `1941687`, `2052920`, `2304999`, `1772154`, `2171520`
+- `1949019`, `1999204`, `2072347`, `2314842`, `1894970`, `2176171`, `2024106`, `2051619`, `2098448`, `2011128`, `2364061`, `1909974`, `2180270`, `2039585`, `2107618`, `2024061`, `2372053`, `1915183`, `2195327`, `2057639`
+- `2529930`, `2186687`, `2087883`, `2419751`, `1927992`, `2210397`, `2066221`, `2535184`, `2293757`, `2089093`, `2445629`, `1962897`, `2271602`, `2080874`, `2549679`, `2306814`, `2524382`, `1964631`, `2313285`, `2153229`
+- `2550684`, `2376812`, `2097924`, `2524683`, `1999580`, `2318139`, `2205623`, `2586507`, `2455952`, `2101141`, `2536961`, `2023974`, `2323094`, `2469450`, `2037983`, `2337322`, `2365832`, `2069637`, `2531939`, `2132288`
+- `625519`, `2046139`, `2478777`, `2433072`, `2186014`, `2532082`, `2184864`, `1151507`, `2498268`, `2471841`, `2190615`, `2550836`, `1205704`, `2559362`, `2586381`, `2250094`, `2556827`, `1275058`, `2106026`
+
+## Negative / failure boundary
+
+### Post-review composition exclusion
+
+- `2096026` — **Knife - Story** — removed during the 2026-09-03 merge review. Although current osu! metadata says `source = 東方Project`, independent release/live documentation identifies `Story` as a **秘封倶楽部 image original song**, explicitly distinguishing it from an arrangement. That is outside this repository's composition-centered Touhou arrangement/original boundary, so generic osu! source metadata is not sufficient to publish it. Evidence: https://touhougarakuta.com/article/20_neopop_live_report01/ and https://www.suruga-ya.jp/product/detail/186144253 .
+
+Search hits that were absent but did not classify as explicit-source `verified` were not inserted. Search-stage rejection summary: `{'confidence:candidate': 2421}`.
+
+Direct API failures/mismatches (first 40, if any):
+
+- none
+
+Public-page failures/mismatches (first 40, if any):
+
+- `1368759` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1368759
+- `1550437` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1550437
+- `1588466` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1588466
+- `1635625` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1635625
+- `1771472` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1771472
+- `1840481` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1840481
+- `1892797` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1892797
+- `1909936` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1909936
+- `1913796` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1913796
+- `1921061` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1921061
+- `1928250` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1928250
+- `1941763` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1941763
+- `1990973` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1990973
+- `1999914` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/1999914
+- `2018806` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2018806
+- `2042736` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2042736
+- `2056650` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2056650
+- `2066130` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2066130
+- `2086554` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2086554
+- `2092851` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2092851
+- `2120912` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2120912
+- `2121057` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2121057
+- `2135628` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2135628
+- `2150616` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2150616
+- `2174924` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2174924
+- `2197940` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2197940
+- `2227686` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2227686
+- `2231358` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2231358
+- `2237688` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2237688
+- `2245252` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2245252
+- `2248177` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2248177
+- `2261894` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2261894
+- `2271637` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2271637
+- `2279370` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2279370
+- `2282096` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2282096
+- `2282117` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2282117
+- `2305050` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2305050
+- `2308851` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2308851
+- `2313682` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2313682
+- `2324756` — fetch:HTTP 429 from https://osu.ppy.sh/beatmapsets/2324756
+
+These rows remain outside this batch rather than being guessed or promoted from weaker signals.
+
+## Validation contract
+
+The companion workflow runs `make check`, `make build`, and `git diff --check` after the write, and asserts that catalog cardinality increases by exactly the accepted-ID count.


### PR DESCRIPTION
## Summary

Adds **239 beatmapsets absent from `main`**, growing the canonical catalog from **3,993 → 4,232** entries.

The batch started from a broad current osu! discovery pass but was narrowed repeatedly: every retained row is live-resolvable, currently ranked, absent by numeric beatmapset ID, and accepted under the repository's existing explicit-source rule. A separate pre-merge composition review then removed one false-positive scope boundary (`2096026`, Knife - Story) despite its current osu! `source = 東方Project`.

Final batch:

- **239** new beatmapsets
- **212** rows with a recognized Touhou game title as current osu! `source`
- **27** rows with the exact generic `東方Project` source, individually composition-reviewed before merge
- modes: **osu=136, taiko=52, mania=34, catch=21**
- all **239 ranked**

The exact accepted IDs, source distribution, and negative boundary are preserved in `docs/source-audit-2026-09-coverage-200plus.md`.

## Search breadth

The audit re-ran all **89 configured osu! API discovery queries**, requesting up to **8 cursor pages per query**:

- **5,272** unique beatmapsets discovered
- **2,887** absent from the base catalog
- **466** absent hits initially classifiable as explicit-source `verified`
- **2,421** weaker/candidate hits withheld

Selection was round-robin across normalized sources rather than taking the first IDs returned by generic keyword searches.

## Identity / metadata verification

Before the first write:

1. every selected ID was absent from base `main`;
2. query provenance was retained as `discovery_query:*` evidence;
3. all 466 explicit-source candidates were directly refetched through `/api/v2/beatmapsets/{id}` — **466/466 identity/source checks passed, 0 rejected**;
4. a diversified preselection was independently refetched through the public beatmapset page and canonical embedded JSON; 55 temporary HTTP 429 rows were withheld instead of guessed;
5. only public-page-confirmed rows entered the data batch.

During merge review, a fresh second live pass independently refetched the then-current 240 rows through both API v2 and public beatmapset HTML. It returned **240/240 exact API matches and 240/240 exact public-page matches** for ID / artist / title / creator / source / status / modes / last-updated. Eight pages temporarily returned 429 and all succeeded after explicit backoff; none was counted as a pass while unavailable.

## Three-pass merge review and correction

This PR was not merged on CI alone. It received three separate review passes:

### Pass 1 — semantic diff integrity

- base catalog: **3,993**
- pre-review head: **4,233**
- exactly **240** new IDs
- **0 removed** base IDs
- all **3,993 pre-existing records field-for-field unchanged**
- actual added-ID set exactly matched the audit document
- 63 tests, catalog validation, build and `git diff --check` passed

### Pass 2 — fresh live identity

All 240 pre-review rows were fetched again from both osu! API v2 and the public beatmapset page. Both paths matched catalog identity and current metadata exactly; no unresolved identity was accepted.

### Pass 3 — composition/provenance boundary

The **28 generic `東方Project` source rows** were treated as the highest-risk subset. Re-importing all configured independent sources did not provide a second configured provenance path for those rows, so their composition relationships were reviewed separately rather than trusting the generic source string.

That review found one real false positive:

- **`2096026` — Knife - Story** — current osu! metadata says `東方Project`, but independent release/live documentation identifies it as a **秘封倶楽部 image original song**, explicitly not an arrangement. This conflicts with the repository's established boundary for Touhou-associated circle/image originals, so the row was removed.

The audit document now retains `2096026` as an explicit negative boundary with the supporting source links. No equivalent scope failure was found among the remaining 27 generic-source rows.

After correction the final semantic result is **239 additions / 0 removals / 0 changes to pre-existing rows**.

## Final validation

The corrected tree has already passed the repository checks during the correction run:

- `make check` — **63 tests passed**
- `python -m touhou_osu validate` — **4,232** total (`verified=2,560`)
- `make build` — **2,589 accepted** beatmapsets
- `git diff --check` — clean
- cardinality: exactly **+239**

Temporary review/correction scripts and workflows were removed. The branch is squashed back to **one formal data commit**, and the PR diff contains only catalog shards plus the permanent audit document.

## Interaction with #31

The weekly discovery PR #31 changes only the lowest-ID shards; this batch starts in the `100,000+` ranges, so there is no changed-file overlap.