### PR TITLE
data: add 206 reviewed Touhou beatmapsets

### DIFF
--- a/data/catalog/0050000-0099999.json
+++ b/data/catalog/0050000-0099999.json
@@ -1822,6 +1822,29 @@
       "osu_last_updated": "2012-12-27T20:46:15Z"
     },
     {
+      "beatmapset_id": 69173,
+      "artist": "Liz Triangle",
+      "title": "Koisuru <3 Recipe",
+      "creator": "Holoaz",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-26T02:12:08Z"
+    },
+    {
       "beatmapset_id": 69681,
       "artist": "senya",
       "title": "Utakata, Ai no Mahoroba",

--- a/data/catalog/0300000-0399999.json
+++ b/data/catalog/0300000-0399999.json
@@ -3515,6 +3515,31 @@
       "osu_last_updated": "2015-12-07T18:02:58Z"
     },
     {
+      "beatmapset_id": 386620,
+      "artist": "ARM",
+      "title": "Rhododendron",
+      "creator": "tasuke912",
+      "source": "東方Project",
+      "status": "loved",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "external_provenance:arrangement-chronicle",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2015-12-06T11:59:14Z"
+    },
+    {
       "beatmapset_id": 388036,
       "artist": "Akiyama Uni",
       "title": "Kanpan Tasogare Shinbun",
@@ -4036,6 +4061,30 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2016-01-22T02:25:34Z"
+    },
+    {
+      "beatmapset_id": 399965,
+      "artist": "shio",
+      "title": "Qronostasis -GABBA vs. Speedcore mix-",
+      "creator": "ll-oscar",
+      "source": "東方Project",
+      "status": "loved",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "external_provenance:thbwiki",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2020-05-29T11:16:15Z"
     }
   ]
 }

--- a/data/catalog/0500000-0599999.json
+++ b/data/catalog/0500000-0599999.json
@@ -1744,6 +1744,29 @@
       "osu_last_updated": "2017-02-04T06:26:57Z"
     },
     {
+      "beatmapset_id": 556969,
+      "artist": "C.H.S",
+      "title": "Interlude - teatime",
+      "creator": "Ascendance",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2017-01-22T13:11:13Z"
+    },
+    {
       "beatmapset_id": 557175,
       "artist": "beatMARIO/COOL&CREATE",
       "title": "Night of Knights",
@@ -2367,6 +2390,29 @@
       "osu_last_updated": "2017-02-27T02:26:51Z"
     },
     {
+      "beatmapset_id": 579359,
+      "artist": "C.H.S",
+      "title": "Interlude - teatime",
+      "creator": "Gabe",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2017-04-25T03:50:56Z"
+    },
+    {
       "beatmapset_id": 579781,
       "artist": "senya",
       "title": "Mahou ga Umareta Hi",
@@ -2512,6 +2558,29 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2017-04-21T15:01:59Z"
+    },
+    {
+      "beatmapset_id": 582888,
+      "artist": "Camellia",
+      "title": "Lunatic Rough Party!! (Long Ver.)",
+      "creator": "Fantazy",
+      "source": "東方紅魔郷 ～ the Embodiment of Scarlet Devil.",
+      "status": "loved",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-04-08T01:49:35Z"
     },
     {
       "beatmapset_id": 585154,

--- a/data/catalog/1100000-1199999.json
+++ b/data/catalog/1100000-1199999.json
@@ -1191,6 +1191,29 @@
       "osu_last_updated": "2021-01-09T00:26:49Z"
     },
     {
+      "beatmapset_id": 1128939,
+      "artist": "LeaF",
+      "title": "Arianrhod",
+      "creator": "Genjuro",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "official_pack_item:FQ40"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2020-03-26T16:02:16Z"
+    },
+    {
       "beatmapset_id": 1129644,
       "artist": "Diao Ye Zong feat. Meramipop",
       "title": "Take no Hana",

--- a/data/catalog/1200000-1299999.json
+++ b/data/catalog/1200000-1299999.json
@@ -1101,6 +1101,29 @@
       "osu_last_updated": "2020-12-08T13:49:20Z"
     },
     {
+      "beatmapset_id": 1241481,
+      "artist": "D.watt (OTAKU-ELITE Recordings)",
+      "title": "Opium and Purple haze",
+      "creator": "Cynplytholowazy",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-06-27T11:58:46Z"
+    },
+    {
       "beatmapset_id": 1241561,
       "artist": "BeatMARIO",
       "title": "Night of Knights (Camellia's \"Once Upon A Night\" Remix)",
@@ -2720,6 +2743,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2020-12-02T19:35:26Z"
+    },
+    {
+      "beatmapset_id": 1277845,
+      "artist": "senya",
+      "title": "Tsuki ni Murakumo Hana Ni Kaze (PV ver.)",
+      "creator": "Benita",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2020-11-26T19:45:04Z"
     },
     {
       "beatmapset_id": 1278431,

--- a/data/catalog/1300000-1399999.json
+++ b/data/catalog/1300000-1399999.json
@@ -804,6 +804,30 @@
       "osu_last_updated": "2022-09-27T13:51:12Z"
     },
     {
+      "beatmapset_id": 1324962,
+      "artist": "ShinRa-Bansho",
+      "title": "Itazura Sensation",
+      "creator": "Spectator",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-21T12:55:58Z"
+    },
+    {
       "beatmapset_id": 1326567,
       "artist": "Nick Nitro",
       "title": "Touhou - \"Night Of Nights [Flowering Night]\" NITRO Remix",
@@ -1423,6 +1447,32 @@
       "osu_last_updated": "2021-01-17T02:56:52Z"
     },
     {
+      "beatmapset_id": 1349838,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Embraced by the Flame",
+      "creator": "Punnies",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "loved",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-04-29T19:58:20Z"
+    },
+    {
       "beatmapset_id": 1350080,
       "artist": "LeaF",
       "title": "Calamity Fortune (extended ver.)",
@@ -1831,6 +1881,30 @@
       "osu_last_updated": "2021-09-08T18:10:24Z"
     },
     {
+      "beatmapset_id": 1368759,
+      "artist": "Halozy feat. Nanahira",
+      "title": "Monosugoi Space Shuttle de Koishi ga Monosugoi Uta",
+      "creator": "Mak Kau Hijau",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-04-24T13:15:11Z"
+    },
+    {
       "beatmapset_id": 1368836,
       "artist": "BLANKFIELD",
       "title": "Witching Dream",
@@ -1876,6 +1950,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2021-02-10T09:53:33Z"
+    },
+    {
+      "beatmapset_id": 1374425,
+      "artist": "KISIDA KYODAN & THE AKEBOSI ROCKETS",
+      "title": "night birds (Cut Ver.)",
+      "creator": "Verti",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-07-27T20:52:35Z"
     },
     {
       "beatmapset_id": 1374578,
@@ -2401,6 +2498,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2022-04-15T15:29:18Z"
+    },
+    {
+      "beatmapset_id": 1397832,
+      "artist": "Yonder Voice",
+      "title": "No grave",
+      "creator": "Faputa",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-09T00:34:50Z"
     },
     {
       "beatmapset_id": 1397860,

--- a/data/catalog/1500000-1599999.json
+++ b/data/catalog/1500000-1599999.json
@@ -1148,6 +1148,32 @@
       "osu_last_updated": "2021-09-15T23:31:48Z"
     },
     {
+      "beatmapset_id": 1550437,
+      "artist": "tsunamix_underground",
+      "title": "Period. ~ Seishin no Kousoku to Jiyuu o Tsukamu Jouka",
+      "creator": "Horiiizon",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:C-CLAYS",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:上海アリス幻樂団",
+        "external_provenance:arrangement-chronicle",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-09-25T04:36:51Z"
+    },
+    {
       "beatmapset_id": 1550606,
       "artist": "SOUND HOLIC",
       "title": "Swing and Jive !",
@@ -1587,6 +1613,29 @@
       "osu_last_updated": "2021-09-11T22:44:36Z"
     },
     {
+      "beatmapset_id": 1573417,
+      "artist": "R3 Music Box",
+      "title": "Last Remote",
+      "creator": "thx for carry",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-10-18T12:01:09Z"
+    },
+    {
       "beatmapset_id": 1573459,
       "artist": "Team Shanghai Alice (Remixed by Est)",
       "title": "SAKURA",
@@ -1696,6 +1745,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1576656,
+      "artist": "Shibayan feat. 3L",
+      "title": "LOVE (signum/ii remix)",
+      "creator": "winber1",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:ShibayanRecords",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-04-28T15:43:40Z"
+    },
+    {
       "beatmapset_id": 1576749,
       "artist": "beatMARIO",
       "title": "Night of Knights (Cranky Remix)",
@@ -1762,6 +1835,29 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2021-11-09T15:00:21Z"
+    },
+    {
+      "beatmapset_id": 1579075,
+      "artist": "SOUND HOLIC feat. YURiCa",
+      "title": "Septuor de ecarlate",
+      "creator": "-Kemsyt",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-03-15T15:04:02Z"
     },
     {
       "beatmapset_id": 1579161,
@@ -1876,6 +1972,30 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1588466,
+      "artist": "Diao Ye Zong feat. Ranko",
+      "title": "Tomo ni Aruku Sono Kokoro",
+      "creator": "paz08",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Diao ye zong",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-11-01T20:20:48Z"
     },
     {
       "beatmapset_id": 1589006,

--- a/data/catalog/1600000-1699999.json
+++ b/data/catalog/1600000-1699999.json
@@ -2,6 +2,30 @@
   "schema_version": 1,
   "entries": [
     {
+      "beatmapset_id": 1601650,
+      "artist": "EastNewSound",
+      "title": "Soleil",
+      "creator": "__Ag",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-29T04:01:32Z"
+    },
+    {
       "beatmapset_id": 1603754,
       "artist": "Shibayan feat. nachi",
       "title": "Fuwafuwa Doremy",
@@ -362,6 +386,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-07-06T14:56:14Z"
+    },
+    {
+      "beatmapset_id": 1618365,
+      "artist": "SEPHID feat. darkxixin",
+      "title": "Fu Xiang Di Xin De Luo Ri Liu Hao ~ Little Raven",
+      "creator": "Jemzuu",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-09-01T12:01:52Z"
     },
     {
       "beatmapset_id": 1618758,
@@ -799,6 +846,32 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1635625,
+      "artist": "SOUND HOLIC",
+      "title": "PRESERVED VAMPIRE",
+      "creator": "Natsu",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "external_provenance:official-circle",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-27T19:07:10Z"
+    },
+    {
       "beatmapset_id": 1636363,
       "artist": "FELT",
       "title": "Sky Gate",
@@ -964,6 +1037,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1641141,
+      "artist": "Demetori",
+      "title": "Naki Oujo no Tame no Septette ~ Ascending Into Naught",
+      "creator": "Sanch-KK",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-07-06T14:48:25Z"
+    },
+    {
       "beatmapset_id": 1641533,
       "artist": "Down",
       "title": "Luscent",
@@ -1088,6 +1185,32 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2022-01-25T16:10:08Z"
+    },
+    {
+      "beatmapset_id": 1644488,
+      "artist": "A-One feat. Shihori",
+      "title": "Magic Girl !!",
+      "creator": "Greaper",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "external_provenance:official-pack+thbwiki",
+        "official_pack_item:FQ66",
+        "official_pack_item:R309"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2021-12-16T22:52:20Z"
     },
     {
       "beatmapset_id": 1644658,
@@ -1245,6 +1368,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2021-12-11T14:41:36Z"
+    },
+    {
+      "beatmapset_id": 1649093,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Without the end",
+      "creator": "soirT",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-06-17T13:27:44Z"
     },
     {
       "beatmapset_id": 1650227,

--- a/data/catalog/1700000-1799999.json
+++ b/data/catalog/1700000-1799999.json
@@ -177,6 +177,30 @@
       "osu_last_updated": "2025-05-29T08:09:49Z"
     },
     {
+      "beatmapset_id": 1704340,
+      "artist": "A-One feat. Shihori",
+      "title": "Magic Girl !!",
+      "creator": "Chromoxx",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-03-18T14:18:53Z"
+    },
+    {
       "beatmapset_id": 1705564,
       "artist": "SOUND HOLIC",
       "title": "Apollo 13 (-Deepdive-) [Last Word [\\_underjoy]]",
@@ -568,6 +592,55 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1715998,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Without the end",
+      "creator": "bigh",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-03-23T17:42:59Z"
+    },
+    {
+      "beatmapset_id": 1716009,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Under the scarlet sky pt,1 inst",
+      "creator": "GIGACHAD",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-03-23T23:47:06Z"
     },
     {
       "beatmapset_id": 1716100,
@@ -1336,6 +1409,30 @@
       "osu_last_updated": "2023-05-09T18:24:58Z"
     },
     {
+      "beatmapset_id": 1752523,
+      "artist": "LiLA'c Records",
+      "title": "Maze of Vapor (Brutal Core mix)",
+      "creator": "-Kemsyt",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-11-30T19:46:22Z"
+    },
+    {
       "beatmapset_id": 1753646,
       "artist": "beatMARIO",
       "title": "Night of Nights",
@@ -1540,6 +1637,29 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1763702,
+      "artist": "Unlucky Morpheus",
+      "title": "DRAGON FORCE",
+      "creator": "Maeda",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-07-06T15:58:23Z"
+    },
+    {
       "beatmapset_id": 1765192,
       "artist": "Down",
       "title": "Duo Cup",
@@ -1558,6 +1678,29 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1765375,
+      "artist": "Foreground Eclipse",
+      "title": "Last Liar Standing",
+      "creator": "Sanch-KK",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-19T23:51:20Z"
     },
     {
       "beatmapset_id": 1767068,
@@ -1860,6 +2003,31 @@
       "osu_last_updated": "2022-08-12T18:49:10Z"
     },
     {
+      "beatmapset_id": 1780135,
+      "artist": "UNDEAD CORPORATION",
+      "title": "The Empress",
+      "creator": "Daycore",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-03T20:16:39Z"
+    },
+    {
       "beatmapset_id": 1780259,
       "artist": "Akatsuki Records",
       "title": "HANIPAGANDA",
@@ -1963,6 +2131,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1784332,
+      "artist": "REEYA",
+      "title": "Fortuna",
+      "creator": "Eyenine",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-06-27T02:28:20Z"
     },
     {
       "beatmapset_id": 1785945,

--- a/data/catalog/1800000-1899999.json
+++ b/data/catalog/1800000-1899999.json
@@ -202,6 +202,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1811874,
+      "artist": "Kanpyohgo",
+      "title": "Reichi no Taiyou Shinkou -Nuclear Fusion- Hardcore.edt",
+      "creator": "JBHyperion",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-10-21T18:24:28Z"
+    },
+    {
       "beatmapset_id": 1813411,
       "artist": "beatMARIO",
       "title": "Night of knights (Cranky Remix)",
@@ -361,6 +385,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2022-09-09T05:33:34Z"
+    },
+    {
+      "beatmapset_id": 1817787,
+      "artist": "SOUND HOLIC feat. Nana Takahashi",
+      "title": "Chinmoku ~Cercueil no Shoujo~",
+      "creator": "Schopfer",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-09-23T14:45:10Z"
     },
     {
       "beatmapset_id": 1817922,
@@ -662,6 +710,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 1832066,
+      "artist": "Kanpyohgo",
+      "title": "Shoujo Satori -3rd.eye- Trance.edt",
+      "creator": "Annabel",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-07T06:02:42Z"
+    },
+    {
       "beatmapset_id": 1833640,
       "artist": "BUTAOTOME",
       "title": "In the Black",
@@ -815,6 +888,31 @@
       "osu_last_updated": "2022-11-26T14:57:08Z"
     },
     {
+      "beatmapset_id": 1837942,
+      "artist": "A-One",
+      "title": "Bloody Knife",
+      "creator": "Akonine",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-10-07T13:02:49Z"
+    },
+    {
       "beatmapset_id": 1837962,
       "artist": "Down",
       "title": "Halfslashed",
@@ -881,6 +979,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2022-10-25T11:48:29Z"
+    },
+    {
+      "beatmapset_id": 1840481,
+      "artist": "A-One",
+      "title": "Wanna Be My Dream",
+      "creator": "Chromoxx",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-09-11T05:55:52Z"
     },
     {
       "beatmapset_id": 1840749,
@@ -1168,6 +1291,30 @@
       "osu_last_updated": "2025-07-28T11:35:19Z"
     },
     {
+      "beatmapset_id": 1852057,
+      "artist": "Innocent Key",
+      "title": "Toho-Assisted-Speedrun!!!",
+      "creator": "FAMoss",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-11-20T09:07:11Z"
+    },
+    {
       "beatmapset_id": 1852062,
       "artist": "Sunasya Asuka",
       "title": "Yozakura Kaidou (To2) [Blossom Night]",
@@ -1279,6 +1426,30 @@
       "osu_last_updated": "2025-10-19T17:04:59Z"
     },
     {
+      "beatmapset_id": 1857047,
+      "artist": "LEMiao feat. YooSanHyakurei",
+      "title": "Setsugen Tir na nOg",
+      "creator": "wiken",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-05-04T23:51:25Z"
+    },
+    {
       "beatmapset_id": 1857465,
       "artist": "Conagusuri",
       "title": "Hina Choco Dark Matter",
@@ -1359,6 +1530,29 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1861782,
+      "artist": "Chata",
+      "title": "Gusha",
+      "creator": "Raijodo",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-11-08T19:05:48Z"
     },
     {
       "beatmapset_id": 1862313,
@@ -1805,6 +1999,30 @@
       "osu_last_updated": "2023-09-09T00:42:38Z"
     },
     {
+      "beatmapset_id": 1878008,
+      "artist": "Tatsh feat. Oda Yu",
+      "title": "Heartfelt Universe",
+      "creator": "ayel",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-23T17:35:21Z"
+    },
+    {
       "beatmapset_id": 1878367,
       "artist": "Batory",
       "title": "Touhou Koumakyou Zenkyoku Arrange Medley",
@@ -2184,6 +2402,31 @@
       "osu_last_updated": "2023-02-05T10:27:47Z"
     },
     {
+      "beatmapset_id": 1892797,
+      "artist": "Demetori",
+      "title": "Kourou ~ Eastern Dream",
+      "creator": "big snag",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-19T03:57:26Z"
+    },
+    {
       "beatmapset_id": 1893333,
       "artist": "BeatMARIO",
       "title": "Night of Knights (USAO Remix)",
@@ -2274,6 +2517,31 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2023-09-24T03:42:35Z"
+    },
+    {
+      "beatmapset_id": 1896626,
+      "artist": "Discord Registers",
+      "title": "Kiri Kakaru Meiya ~Foggy Night~",
+      "creator": "M4xWasHere",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-10T09:54:21Z"
     },
     {
       "beatmapset_id": 1898039,

--- a/data/catalog/1900000-1999999.json
+++ b/data/catalog/1900000-1999999.json
@@ -64,6 +64,31 @@
       "osu_last_updated": "2023-02-18T13:12:38Z"
     },
     {
+      "beatmapset_id": 1901650,
+      "artist": "Supire",
+      "title": "Borderline Of The Moon",
+      "creator": "Ideal",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2022-12-29T18:00:32Z"
+    },
+    {
       "beatmapset_id": 1901788,
       "artist": "beatMARIO",
       "title": "Night Of Knights",
@@ -264,6 +289,32 @@
       "osu_last_updated": "2022-12-28T21:41:15Z"
     },
     {
+      "beatmapset_id": 1909936,
+      "artist": "IOSYS",
+      "title": "Kanbu de Tomatte Sugu Tokeru ~ Kyouki no Udongein",
+      "creator": "shizehao",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-01-24T08:01:47Z"
+    },
+    {
       "beatmapset_id": 1909974,
       "artist": "Masayoshi Minoshima feat. mikicco",
       "title": "Wall of Flowers",
@@ -335,6 +386,30 @@
       "osu_last_updated": "2024-10-24T07:38:13Z"
     },
     {
+      "beatmapset_id": 1913078,
+      "artist": "SYNC.ART'S feat. Rill Practica",
+      "title": "tod und feuer",
+      "creator": "Patchouli-R",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-02-19T02:08:40Z"
+    },
+    {
       "beatmapset_id": 1913530,
       "artist": "beatMARIO",
       "title": "Night of Knights",
@@ -386,6 +461,33 @@
       "osu_last_updated": "2023-01-16T18:06:50Z"
     },
     {
+      "beatmapset_id": 1913796,
+      "artist": "ZUN",
+      "title": "Voyage 1970",
+      "creator": "Shurelia",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-03-03T14:17:24Z"
+    },
+    {
       "beatmapset_id": 1914040,
       "artist": "Masayoshi Minoshima feat. nomico",
       "title": "Dreaming",
@@ -433,6 +535,30 @@
       "osu_last_updated": "2023-12-22T17:34:32Z"
     },
     {
+      "beatmapset_id": 1914658,
+      "artist": "Demetori",
+      "title": "Sennen Gensokyo ~ Point Of Know Return",
+      "creator": "Camo",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-03-01T20:30:11Z"
+    },
+    {
       "beatmapset_id": 1915183,
       "artist": "Kanpyohgo",
       "title": "Shoujo Satori -3rd.eye- Trance.edt",
@@ -477,6 +603,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-07-20T13:59:27Z"
+    },
+    {
+      "beatmapset_id": 1915327,
+      "artist": "8686m",
+      "title": "canon",
+      "creator": "guden",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-15T03:39:01Z"
     },
     {
       "beatmapset_id": 1915805,
@@ -665,6 +814,56 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-02-21T17:27:35Z"
+    },
+    {
+      "beatmapset_id": 1921061,
+      "artist": "cYsmix",
+      "title": "Tear Rain feat. Emmy",
+      "creator": "H4chyk0",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Adust Rain",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-19T21:51:45Z"
+    },
+    {
+      "beatmapset_id": 1921815,
+      "artist": "Riverside",
+      "title": "Gensou no Ruminaria",
+      "creator": "Xzzj",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-05-06T16:14:01Z"
     },
     {
       "beatmapset_id": 1922251,
@@ -904,6 +1103,32 @@
       "osu_last_updated": "2024-02-20T16:10:14Z"
     },
     {
+      "beatmapset_id": 1928250,
+      "artist": "Shibayan feat. Tsubaki Ichimatsu",
+      "title": "GAZE IT",
+      "creator": "tokiko",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:ShibayanRecords",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:上海アリス幻樂団",
+        "external_provenance:official-circle",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-03-12T06:22:33Z"
+    },
+    {
       "beatmapset_id": 1928690,
       "artist": "beatMARIO",
       "title": "Night of Knights (REDALiCE Remix)",
@@ -929,6 +1154,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-01-25T01:02:13Z"
+    },
+    {
+      "beatmapset_id": 1929270,
+      "artist": "EastNewSound",
+      "title": "Nijiiro Kekkai, Gekkyou no Goku",
+      "creator": "__Ag",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-08T10:07:27Z"
     },
     {
       "beatmapset_id": 1929301,
@@ -999,6 +1248,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2023-05-15T20:06:38Z"
+    },
+    {
+      "beatmapset_id": 1931429,
+      "artist": "Yuuhei Satellite",
+      "title": "Yuudachi, Kimi to Kakurega",
+      "creator": "Patchouli-R",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-09T03:24:50Z"
     },
     {
       "beatmapset_id": 1931793,
@@ -1207,6 +1481,79 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2023-05-01T19:09:05Z"
+    },
+    {
+      "beatmapset_id": 1941763,
+      "artist": "Rolling Contact",
+      "title": "Fly Anima",
+      "creator": "Sanch-KK",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-09T21:01:20Z"
+    },
+    {
+      "beatmapset_id": 1942061,
+      "artist": "Halozy feat. Nanahira",
+      "title": "Monosugoi Live de Cirno ga Sokohakatonaku Monosugoi Uta",
+      "creator": "Xzzj",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-28T17:57:34Z"
+    },
+    {
+      "beatmapset_id": 1942214,
+      "artist": "GET IN THE RING",
+      "title": "Midnight Syndrome",
+      "creator": "Antti",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "external_provenance:thbwiki",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-02-26T09:17:32Z"
     },
     {
       "beatmapset_id": 1942555,
@@ -1440,6 +1787,30 @@
       "osu_last_updated": "2023-06-13T18:16:24Z"
     },
     {
+      "beatmapset_id": 1953513,
+      "artist": "SEPHID feat. darkxixin",
+      "title": "Fu Xiang Di Xin De Luo Ri Liu Hao ~ Little Raven",
+      "creator": "FLeVI",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-09-03T12:05:40Z"
+    },
+    {
       "beatmapset_id": 1953606,
       "artist": "ZUN",
       "title": "Border of Life",
@@ -1527,6 +1898,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1958464,
+      "artist": "moro",
+      "title": "Speed Performance",
+      "creator": "Genjuro",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-08T07:55:42Z"
     },
     {
       "beatmapset_id": 1958919,
@@ -1809,6 +2203,30 @@
       "osu_last_updated": "2024-07-05T14:23:02Z"
     },
     {
+      "beatmapset_id": 1969255,
+      "artist": "moro",
+      "title": "Deaf-mutes",
+      "creator": "Whulf",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-04T18:20:35Z"
+    },
+    {
       "beatmapset_id": 1969718,
       "artist": "Halozy",
       "title": "Koi no Stadium",
@@ -1849,6 +2267,53 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1971670,
+      "artist": "Takamachi Walk",
+      "title": "Phantom Moon",
+      "creator": "l43yrnt",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-05-25T15:54:40Z"
+    },
+    {
+      "beatmapset_id": 1972745,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Yogoto no Yami no Okusoko de",
+      "creator": "mati-bmp",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-05T01:25:18Z"
     },
     {
       "beatmapset_id": 1974745,
@@ -2060,6 +2525,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 1984348,
+      "artist": "S&S Munitions (Sephid & system [S])",
+      "title": "OVERPROTECTION",
+      "creator": "kageminori",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-07T12:27:11Z"
     },
     {
       "beatmapset_id": 1985153,
@@ -2393,6 +2882,33 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-05-09T04:41:53Z"
+    },
+    {
+      "beatmapset_id": 1990973,
+      "artist": "IOSYS",
+      "title": "Cirno's Perfect Math Class (Nika Lenina Russian Version)",
+      "creator": "dopaminos",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-17T09:27:09Z"
     },
     {
       "beatmapset_id": 1991141,
@@ -3072,6 +3588,32 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2023-06-04T05:52:30Z"
+    },
+    {
+      "beatmapset_id": 1999914,
+      "artist": "A-One feat. Shihori",
+      "title": "Magic Girl !!",
+      "creator": "HyperPigeon",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-30T13:40:48Z"
     },
     {
       "beatmapset_id": 1999921,

--- a/data/catalog/2000000-2099999.json
+++ b/data/catalog/2000000-2099999.json
@@ -343,6 +343,55 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2006619,
+      "artist": "Shibayan feat. Mei Ayakura",
+      "title": "R.I.N.",
+      "creator": "228",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-09-15T22:06:10Z"
+    },
+    {
+      "beatmapset_id": 2006943,
+      "artist": "Yonder Voice",
+      "title": "Sougetsu no Zangeshi ~ Universal Nemesis",
+      "creator": "Jayblue",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-09T10:24:30Z"
+    },
+    {
       "beatmapset_id": 2006946,
       "artist": "Akatsuki Records",
       "title": "HANIPAGANDA (YuEast 2018) [HAHAHA]",
@@ -799,6 +848,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2012401,
+      "artist": "Hanatan",
+      "title": "Paranoia",
+      "creator": "Xzzj",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-09-09T05:23:54Z"
+    },
+    {
       "beatmapset_id": 2012534,
       "artist": "Demetori",
       "title": "Faith is for the Transient People ~ Jehovah's YaHVeH (Alptraum) [SANAEchor 1.1x (242bpm)]",
@@ -953,6 +1027,29 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2014469,
+      "artist": "Down",
+      "title": "nanoya",
+      "creator": "nanoya",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-07-11T18:28:05Z"
+    },
+    {
       "beatmapset_id": 2014755,
       "artist": "Sakaue Nachi",
       "title": "Crazy Hot ([GB]Reisen) [Nixo's Work in progress (170bpm)]",
@@ -1035,6 +1132,30 @@
       "osu_last_updated": "2024-09-11T16:42:27Z"
     },
     {
+      "beatmapset_id": 2018806,
+      "artist": "Down",
+      "title": "Lince Cosmico",
+      "creator": "Pisapou",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:ZUN",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-11-18T14:19:45Z"
+    },
+    {
       "beatmapset_id": 2019552,
       "artist": "Chata",
       "title": "Wan",
@@ -1104,6 +1225,30 @@
       "osu_last_updated": "2025-04-25T12:54:52Z"
     },
     {
+      "beatmapset_id": 2020167,
+      "artist": "Poplica* feat. Mei Ayakura",
+      "title": "Puzzle Maker (Cut Ver.)",
+      "creator": "Nekoharu",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-13T10:17:42Z"
+    },
+    {
       "beatmapset_id": 2020285,
       "artist": "AUTUMN+GHOST feat. Akira Complex",
       "title": "PURE FURY",
@@ -1168,6 +1313,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2022219,
+      "artist": "Dark PHOENiX",
+      "title": "Yuuga ni Sakase, Sumizome no Sakura",
+      "creator": "Muziyami",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-08T15:42:57Z"
     },
     {
       "beatmapset_id": 2023038,
@@ -1540,6 +1708,53 @@
       "osu_last_updated": "2023-08-02T15:21:49Z"
     },
     {
+      "beatmapset_id": 2030543,
+      "artist": "happy30",
+      "title": "What I feel for you",
+      "creator": "Zekk",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-03T18:43:04Z"
+    },
+    {
+      "beatmapset_id": 2030733,
+      "artist": "Frost Fragment",
+      "title": "Ha no Gotoku",
+      "creator": "Syph",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-14T07:34:22Z"
+    },
+    {
       "beatmapset_id": 2031364,
       "artist": "Masayoshi Minoshima",
       "title": "Scolded By The Princess feat. Aki Misawa",
@@ -1579,6 +1794,76 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2033193,
+      "artist": "Down",
+      "title": "nanoya",
+      "creator": "Hivie",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-18T19:32:48Z"
+    },
+    {
+      "beatmapset_id": 2034075,
+      "artist": "Kikuo",
+      "title": "Oboreru Uchuu Neko",
+      "creator": "Alchyr",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-11-28T23:01:49Z"
+    },
+    {
+      "beatmapset_id": 2035737,
+      "artist": "ShinRa-Bansho",
+      "title": "Itazura Sensation",
+      "creator": "Xzzj",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-11-23T14:12:27Z"
     },
     {
       "beatmapset_id": 2037678,
@@ -1646,6 +1931,29 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2023-09-02T17:34:01Z"
+    },
+    {
+      "beatmapset_id": 2039084,
+      "artist": "Silver Forest",
+      "title": "Sora ni Mae, Sumizome no Sakura (Cut Ver.)",
+      "creator": "-Ady",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-07T18:04:01Z"
     },
     {
       "beatmapset_id": 2039585,
@@ -1755,6 +2063,33 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-11-06T08:14:08Z"
+    },
+    {
+      "beatmapset_id": 2042736,
+      "artist": "ROSIVO feat. Sakaue Nachi",
+      "title": "Eternal Dream",
+      "creator": "TormentVoid",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:Syrufit",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-08-24T14:26:24Z"
     },
     {
       "beatmapset_id": 2043284,
@@ -2059,6 +2394,31 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2023-08-21T15:03:02Z"
+    },
+    {
+      "beatmapset_id": 2048946,
+      "artist": "HAGISOPH",
+      "title": "Beyond the Millennium",
+      "creator": "Karliah",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-03-24T15:21:22Z"
     },
     {
       "beatmapset_id": 2048957,
@@ -2579,6 +2939,55 @@
       "osu_last_updated": "2024-09-10T02:28:23Z"
     },
     {
+      "beatmapset_id": 2056468,
+      "artist": "Shoujo Fractal",
+      "title": "Samayoi no Mei",
+      "creator": "PixelGlory",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-03T01:00:43Z"
+    },
+    {
+      "beatmapset_id": 2056650,
+      "artist": "ShinRa-Bansho",
+      "title": "Mugen Shitto Gekijou \"666\"",
+      "creator": "[TCD] Murasss",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-04T04:49:09Z"
+    },
+    {
       "beatmapset_id": 2057639,
       "artist": "Halozy",
       "title": "Suna no Hoshi (Blue Twinkle Trance Remix / Version 2.0)",
@@ -2622,6 +3031,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2060837,
+      "artist": "Para Dot.",
+      "title": "Hyper banquet",
+      "creator": "Annabel",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-25T23:56:31Z"
     },
     {
       "beatmapset_id": 2061596,
@@ -2719,6 +3152,30 @@
       "osu_last_updated": "2024-09-17T12:04:20Z"
     },
     {
+      "beatmapset_id": 2064066,
+      "artist": "8686m",
+      "title": "TAKE TOO, TAKE TWO",
+      "creator": "Disguise",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-03-04T17:26:48Z"
+    },
+    {
       "beatmapset_id": 2064233,
       "artist": "Demetori",
       "title": "Natsukashiki Touhou no Chi ~ Sic World",
@@ -2745,6 +3202,29 @@
       "osu_last_updated": "2023-12-30T03:52:32Z"
     },
     {
+      "beatmapset_id": 2065149,
+      "artist": "BUTAOTOME",
+      "title": "Kasanaru Kage",
+      "creator": "nanoya",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-07T21:33:03Z"
+    },
+    {
       "beatmapset_id": 2065860,
       "artist": "Aoi Xia",
       "title": "Lost Blue",
@@ -2764,6 +3244,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2066130,
+      "artist": "TatshMusicCircle",
+      "title": "Yoiyami no Tsuki ni Dakarete feat. Ayane",
+      "creator": "zekk",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-25T17:30:40Z"
     },
     {
       "beatmapset_id": 2066206,
@@ -2962,6 +3466,30 @@
       "osu_last_updated": "2024-04-29T09:59:32Z"
     },
     {
+      "beatmapset_id": 2071645,
+      "artist": "katikatiyama",
+      "title": "Koi no Uta",
+      "creator": "Jayblue",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-05T17:19:38Z"
+    },
+    {
       "beatmapset_id": 2072347,
       "artist": "Unlucky Morpheus",
       "title": "FAITH",
@@ -2983,6 +3511,55 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2024-01-20T14:13:27Z"
+    },
+    {
+      "beatmapset_id": 2072440,
+      "artist": "ALiCE'S EMOTiON feat. 3L",
+      "title": "Sakura Hana Getsusou",
+      "creator": "Xzzj",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-30T19:58:22Z"
+    },
+    {
+      "beatmapset_id": 2072915,
+      "artist": "DiGiTAL WiNG",
+      "title": "Paranoia (DiGiTAL WiNG 2018 LIVE MIX)",
+      "creator": "228",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-10-22T11:48:56Z"
     },
     {
       "beatmapset_id": 2073247,
@@ -3236,6 +3813,30 @@
       "osu_last_updated": "2025-07-10T14:49:59Z"
     },
     {
+      "beatmapset_id": 2080690,
+      "artist": "zts",
+      "title": "iconoclasm",
+      "creator": "Ratarok",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-09T21:03:10Z"
+    },
+    {
       "beatmapset_id": 2080874,
       "artist": "IOSYS",
       "title": "Saint Marisa no Okurimono",
@@ -3285,6 +3886,53 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-02-10T12:20:06Z"
+    },
+    {
+      "beatmapset_id": 2080925,
+      "artist": "556t",
+      "title": "change",
+      "creator": "fllecc",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-26T20:28:27Z"
+    },
+    {
+      "beatmapset_id": 2082657,
+      "artist": "Unlucky Morpheus",
+      "title": "Sono Tamashii ni Yasuragi o ~ Dignity of Spirit",
+      "creator": "gaston_2199",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-11-10T23:40:23Z"
     },
     {
       "beatmapset_id": 2084159,
@@ -3433,6 +4081,55 @@
       "osu_last_updated": "2023-11-12T13:50:53Z"
     },
     {
+      "beatmapset_id": 2086554,
+      "artist": "ShinRa-Bansho",
+      "title": "Fluorite",
+      "creator": "Matsuyuki Ame",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-03-15T04:52:09Z"
+    },
+    {
+      "beatmapset_id": 2086616,
+      "artist": "Zutlo",
+      "title": "Cirno Car",
+      "creator": "cirnoulja boy",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-13T21:30:49Z"
+    },
+    {
       "beatmapset_id": 2087326,
       "artist": "REDALiCE",
       "title": "taboo tears you up",
@@ -3475,6 +4172,30 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2023-12-08T16:48:17Z"
+    },
+    {
+      "beatmapset_id": 2088280,
+      "artist": "Kraster",
+      "title": "Space Rainbow*",
+      "creator": "Luscent",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Adust Rain",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-13T16:25:10Z"
     },
     {
       "beatmapset_id": 2088431,
@@ -3593,6 +4314,30 @@
       "osu_last_updated": "2024-06-01T21:09:38Z"
     },
     {
+      "beatmapset_id": 2089306,
+      "artist": "BUTAOTOME",
+      "title": "Utakata",
+      "creator": "Ratarok",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2023-12-18T22:52:01Z"
+    },
+    {
       "beatmapset_id": 2091456,
       "artist": "Akatsuki Records",
       "title": "S.A.R.I.E.L.",
@@ -3614,6 +4359,32 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2023-12-13T14:09:03Z"
+    },
+    {
+      "beatmapset_id": 2092851,
+      "artist": "Unlucky Morpheus x UNDEAD CORPORATION",
+      "title": "Miracles Inst ver",
+      "creator": "M4xWasHere",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-02-29T12:11:38Z"
     },
     {
       "beatmapset_id": 2093561,

--- a/data/catalog/2100000-2199999.json
+++ b/data/catalog/2100000-2199999.json
@@ -716,6 +716,82 @@
       "osu_last_updated": "2024-06-02T11:11:38Z"
     },
     {
+      "beatmapset_id": 2120912,
+      "artist": "tsunamix",
+      "title": "stella maris",
+      "creator": "Luscent",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "external_provenance:arrangement-chronicle",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-21T04:10:51Z"
+    },
+    {
+      "beatmapset_id": 2120920,
+      "artist": "Dark PHOENiX",
+      "title": "Misshitsu ni Hanataba o (Locked Girl)",
+      "creator": "Shurelia",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-02T21:34:03Z"
+    },
+    {
+      "beatmapset_id": 2121057,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Death is just the beginning",
+      "creator": "chromb",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-01-18T21:48:03Z"
+    },
+    {
       "beatmapset_id": 2121209,
       "artist": "Para Dot.",
       "title": "Azure Fragments",
@@ -756,6 +832,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-08-14T17:00:25Z"
+    },
+    {
+      "beatmapset_id": 2122307,
+      "artist": "Thousand Leaves",
+      "title": "The Gathering",
+      "creator": "ReaL motion",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-02-08T09:14:05Z"
     },
     {
       "beatmapset_id": 2123533,
@@ -1207,6 +1306,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2135628,
+      "artist": "Xi",
+      "title": "Rokujuu-nen Me no Shinsoku Saiban ~ Rapidity is a justice",
+      "creator": "-Aku",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-03-04T16:25:10Z"
+    },
+    {
       "beatmapset_id": 2136000,
       "artist": "paradot",
       "title": "{touhou Full Flavor / Remix} night of nights",
@@ -1259,6 +1382,30 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2024-02-18T14:22:30Z"
+    },
+    {
+      "beatmapset_id": 2136154,
+      "artist": "Sharlo",
+      "title": "Eisou Youga ~Meikyou Shisui~",
+      "creator": "My Angel Marisa",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-23T13:39:44Z"
     },
     {
       "beatmapset_id": 2136607,
@@ -1511,6 +1658,30 @@
       "osu_last_updated": "2024-04-24T09:31:10Z"
     },
     {
+      "beatmapset_id": 2141740,
+      "artist": "SOUND HOLIC feat. Arima Misaki",
+      "title": "Tokimeki*Reitou Pack",
+      "creator": "Xzzj",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "official_pack_item:R334"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-08-10T12:02:19Z"
+    },
+    {
       "beatmapset_id": 2141849,
       "artist": "senya",
       "title": "Kegarenaki Euphoria",
@@ -1597,6 +1768,31 @@
       "osu_last_updated": "2024-10-04T16:23:34Z"
     },
     {
+      "beatmapset_id": 2143839,
+      "artist": "bunny rhyTHm",
+      "title": "Genfoedsel",
+      "creator": "kartofle",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-04T14:08:23Z"
+    },
+    {
       "beatmapset_id": 2144024,
       "artist": "Sephid",
       "title": "Critical Cannonball (Extended ver.)",
@@ -1617,6 +1813,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-07-30T16:58:20Z"
+    },
+    {
+      "beatmapset_id": 2144555,
+      "artist": "FELT",
+      "title": "New World",
+      "creator": "-Aku",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-03-24T14:40:39Z"
     },
     {
       "beatmapset_id": 2146723,
@@ -1820,6 +2039,79 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-09-05T00:42:55Z"
+    },
+    {
+      "beatmapset_id": 2149949,
+      "artist": "GET IN THE RING",
+      "title": "Midnight Syndrome",
+      "creator": "gaston_2199",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "external_provenance:thbwiki",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-10-13T21:30:20Z"
+    },
+    {
+      "beatmapset_id": 2150144,
+      "artist": "Para Dot.",
+      "title": "Ultimate taste",
+      "creator": "Kukkai",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-10T15:23:43Z"
+    },
+    {
+      "beatmapset_id": 2150616,
+      "artist": "IOSYS feat. Nanahira",
+      "title": "Shinchoku Dou Desu ka?",
+      "creator": "My Angel RangE",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-09T09:51:04Z"
     },
     {
       "beatmapset_id": 2151146,
@@ -2028,6 +2320,30 @@
       "osu_last_updated": "2024-12-07T15:09:33Z"
     },
     {
+      "beatmapset_id": 2155937,
+      "artist": "Para Dot.",
+      "title": "Peerless taste",
+      "creator": "Jayblue",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-29T07:27:16Z"
+    },
+    {
       "beatmapset_id": 2156156,
       "artist": "ZUN",
       "title": "Night of Nights (RichaadEB)",
@@ -2083,6 +2399,55 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2024-10-27T12:01:01Z"
+    },
+    {
+      "beatmapset_id": 2159203,
+      "artist": "Minstrel",
+      "title": "Cinderella Cage ~Falling in Love Again~",
+      "creator": "MicSup08",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:上海アリス幻樂団",
+        "official_pack_item:R340"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-05T16:35:30Z"
+    },
+    {
+      "beatmapset_id": 2159661,
+      "artist": "Hatsunetsumiko's",
+      "title": "Horizon",
+      "creator": "Narcissu",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-04-07T08:11:50Z"
     },
     {
       "beatmapset_id": 2161238,
@@ -2170,6 +2535,30 @@
       "osu_last_updated": "2024-07-18T15:44:22Z"
     },
     {
+      "beatmapset_id": 2166782,
+      "artist": "Takamachi Walk",
+      "title": "hollow hope",
+      "creator": "Hinsvar",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-17T16:14:36Z"
+    },
+    {
       "beatmapset_id": 2167421,
       "artist": "Demetori",
       "title": "Necrofantasia ~ Remix",
@@ -2192,6 +2581,30 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2024-06-30T15:51:13Z"
+    },
+    {
+      "beatmapset_id": 2170949,
+      "artist": "FELT",
+      "title": "Lost in the Abyss",
+      "creator": "Lafayla",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-02T12:29:04Z"
     },
     {
       "beatmapset_id": 2171371,
@@ -2284,6 +2697,31 @@
       "osu_last_updated": "2024-07-17T19:55:58Z"
     },
     {
+      "beatmapset_id": 2174924,
+      "artist": "RUON feat. Meramipop",
+      "title": "Secret Desire - Dyes Remix -",
+      "creator": "Vert",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-11T15:16:36Z"
+    },
+    {
       "beatmapset_id": 2175777,
       "artist": "Halozy",
       "title": "K.O.K.O.R.O & S.A.T.O.R.A.R.E",
@@ -2327,6 +2765,31 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2024-07-24T21:04:51Z"
+    },
+    {
+      "beatmapset_id": 2176852,
+      "artist": "IOSYS",
+      "title": "Heartful Nekoromancer (Edit ver.)",
+      "creator": "Luscent",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-05-08T04:36:20Z"
     },
     {
       "beatmapset_id": 2176951,
@@ -2925,6 +3388,33 @@
       "osu_last_updated": "2026-04-10T09:07:01Z"
     },
     {
+      "beatmapset_id": 2192796,
+      "artist": "sawawa",
+      "title": "Koishi Circulation (Cut Ver.)",
+      "creator": "My Angel Nilou",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-03T18:23:03Z"
+    },
+    {
       "beatmapset_id": 2193011,
       "artist": "Yellow Zebra",
       "title": "Believe heart!",
@@ -3018,6 +3508,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-07-02T11:45:25Z"
+    },
+    {
+      "beatmapset_id": 2194940,
+      "artist": "Para Dot.",
+      "title": "Ultimate taste",
+      "creator": "Joltzzz",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-12-01T00:26:35Z"
     },
     {
       "beatmapset_id": 2195132,
@@ -3124,6 +3638,79 @@
       "confidence": "probable",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2025-05-11T11:43:14Z"
+    },
+    {
+      "beatmapset_id": 2197609,
+      "artist": "Yuuna Kamishiro",
+      "title": "Shrill False",
+      "creator": "Genjuro",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-06-23T20:47:14Z"
+    },
+    {
+      "beatmapset_id": 2197940,
+      "artist": "Down",
+      "title": "Ekoro",
+      "creator": "_gt",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "mania",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-08-07T15:58:01Z"
+    },
+    {
+      "beatmapset_id": 2198080,
+      "artist": "Xenoglossy",
+      "title": "Suigetsu Kyouka Koubou Issen",
+      "creator": "Camo",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:Team Shanghai Alice",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-08-22T22:25:43Z"
     },
     {
       "beatmapset_id": 2198377,

--- a/data/catalog/2200000-2299999.json
+++ b/data/catalog/2200000-2299999.json
@@ -413,6 +413,30 @@
       "osu_last_updated": "2024-07-23T06:33:43Z"
     },
     {
+      "beatmapset_id": 2217257,
+      "artist": "GARYWAVE vs. Sakimura Ryuu",
+      "title": "FUCKIN' EIENTEI",
+      "creator": "Genjuro",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-07-28T09:55:36Z"
+    },
+    {
       "beatmapset_id": 2217940,
       "artist": "UNDEAD CORPORATION",
       "title": "Everything will freeze",
@@ -488,6 +512,29 @@
       "osu_last_updated": "2024-09-23T20:49:36Z"
     },
     {
+      "beatmapset_id": 2220709,
+      "artist": "UNKNOWN HEROINE -NUE-",
+      "title": "ELEMENTAL SANCTUARY",
+      "creator": "Genjuro",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "official_pack_item:R332"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-08-14T16:25:07Z"
+    },
+    {
       "beatmapset_id": 2221758,
       "artist": "Syrufit / Poplica* feat. Mei Ayakura",
       "title": "Threat of rain",
@@ -530,6 +577,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-12-19T00:21:34Z"
+    },
+    {
+      "beatmapset_id": 2223022,
+      "artist": "cYsmix",
+      "title": "Tear Rain feat. Emmy",
+      "creator": "LeCandy",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Adust Rain",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-08-25T12:33:41Z"
     },
     {
       "beatmapset_id": 2223639,
@@ -622,6 +694,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2226125,
+      "artist": "EastNewSound feat. nayuta",
+      "title": "Nijiiro Kekkai, Gekkyou no Goku",
+      "creator": "Seiran-",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-08-30T10:03:12Z"
+    },
+    {
       "beatmapset_id": 2226658,
       "artist": "U2",
       "title": "Saigetsu (Koko & Satsuki ga Tenkomori's Sagyou Bougai Remix)",
@@ -665,6 +761,31 @@
       "osu_last_updated": "2025-08-23T20:30:41Z"
     },
     {
+      "beatmapset_id": 2227686,
+      "artist": "Halozy",
+      "title": "Crystal Snow",
+      "creator": "itay",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-09-10T10:58:38Z"
+    },
+    {
       "beatmapset_id": 2229728,
       "artist": "RD-Sounds feat. Meramipop / nayuta",
       "title": "Shiten",
@@ -686,6 +807,32 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-08-15T13:35:55Z"
+    },
+    {
+      "beatmapset_id": 2231358,
+      "artist": "ZUN",
+      "title": "Ryokugan no Jealousy",
+      "creator": "iRedi",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-04T02:31:20Z"
     },
     {
       "beatmapset_id": 2234458,
@@ -829,6 +976,30 @@
       "osu_last_updated": "2025-04-19T06:57:51Z"
     },
     {
+      "beatmapset_id": 2239310,
+      "artist": "UNDEAD CORPORATION",
+      "title": "The Empress",
+      "creator": "Daletto",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-14T12:36:05Z"
+    },
+    {
       "beatmapset_id": 2239541,
       "artist": "TAMAONSEN",
       "title": "Gensou Kappa Koushinkyoku feat. ytr",
@@ -919,6 +1090,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-10-16T20:11:37Z"
+    },
+    {
+      "beatmapset_id": 2241785,
+      "artist": "SOUND HOLIC feat. Nana Takahashi",
+      "title": "Finale",
+      "creator": "Peaceful",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-17T14:26:49Z"
     },
     {
       "beatmapset_id": 2243304,
@@ -1030,6 +1226,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2024-10-06T12:40:30Z"
+    },
+    {
+      "beatmapset_id": 2248177,
+      "artist": "ShinRa-Bansho",
+      "title": "Ame, Tokidoki, Karankoron",
+      "creator": "Tatara Kogasa",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinra-Bansho",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-19T14:31:06Z"
     },
     {
       "beatmapset_id": 2248838,
@@ -1248,6 +1468,80 @@
       "osu_last_updated": "2025-04-12T11:55:52Z"
     },
     {
+      "beatmapset_id": 2254348,
+      "artist": "Demetori",
+      "title": "Sennen Gensokyo ~ Point Of Know Return",
+      "creator": "Genjuro",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-25T06:10:35Z"
+    },
+    {
+      "beatmapset_id": 2254629,
+      "artist": "ZYTOKINE feat. YURiCa/Hanatan",
+      "title": "Shuumatsu Kikou no Schadenfreude",
+      "creator": "kartofle",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-29T15:57:12Z"
+    },
+    {
+      "beatmapset_id": 2254847,
+      "artist": "Xenoglossy",
+      "title": "RECALL A TRAUMATIC EXPERIENCE (2012 VER.)",
+      "creator": "IllusionB",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-02-23T00:21:33Z"
+    },
+    {
       "beatmapset_id": 2255745,
       "artist": "Beat Mario",
       "title": "Night of Knights / Knight of Nights",
@@ -1296,6 +1590,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2025-08-27T13:36:46Z"
+    },
+    {
+      "beatmapset_id": 2256857,
+      "artist": "IOSYS",
+      "title": "Scarlet Keisatsu no Ghetto Patrol 24-ji (Short Ver.)",
+      "creator": "Bloxi",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-17T04:41:12Z"
     },
     {
       "beatmapset_id": 2257821,
@@ -1507,6 +1826,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2261894,
+      "artist": "Halozy",
+      "title": "Aqua Trytone / Kanshou no Matenrou",
+      "creator": "cosilgam",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-13T17:47:34Z"
+    },
+    {
       "beatmapset_id": 2264599,
       "artist": "Para Dot.",
       "title": "Night of Knights (Para Dot. Remix)",
@@ -1534,6 +1877,31 @@
       "osu_last_updated": "2025-01-07T04:51:52Z"
     },
     {
+      "beatmapset_id": 2266294,
+      "artist": "Diabolic Phantasma",
+      "title": "Liberation",
+      "creator": "Camo",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-13T21:45:38Z"
+    },
+    {
       "beatmapset_id": 2266581,
       "artist": "Syrufit feat. Mei Ayakura",
       "title": "Tsukikage Shoujo (Poplica* Remix)",
@@ -1558,6 +1926,31 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2025-01-30T09:43:00Z"
+    },
+    {
+      "beatmapset_id": 2266612,
+      "artist": "SYNC.ART'S feat. YuNa",
+      "title": "Dogma Kagura ~Shingetsu no Kouyasai~",
+      "creator": "BeautifulKisa",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-15T04:00:12Z"
     },
     {
       "beatmapset_id": 2267353,
@@ -1676,6 +2069,30 @@
       "osu_last_updated": "2024-10-23T13:00:12Z"
     },
     {
+      "beatmapset_id": 2270937,
+      "artist": "mirin*, China",
+      "title": "Sweets*Hearts",
+      "creator": "App",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-07T19:10:33Z"
+    },
+    {
       "beatmapset_id": 2271602,
       "artist": "senya",
       "title": "Sakuretsu Irony",
@@ -1698,6 +2115,33 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2024-11-04T09:06:50Z"
+    },
+    {
+      "beatmapset_id": 2271637,
+      "artist": "IOSYS",
+      "title": "Accept Bloody Fate",
+      "creator": "NeKroMan4ik",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-07-20T13:11:51Z"
     },
     {
       "beatmapset_id": 2271653,
@@ -2046,6 +2490,29 @@
       "osu_last_updated": "2025-11-03T09:06:30Z"
     },
     {
+      "beatmapset_id": 2278914,
+      "artist": "Poplica* feat. Mei Ayakura",
+      "title": "Crossoverthere",
+      "creator": "Wither",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-02T08:29:50Z"
+    },
+    {
       "beatmapset_id": 2279360,
       "artist": "marasy",
       "title": "Re\\:Unknown X (cherrychou) [Lunatic (edit)]",
@@ -2065,6 +2532,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2279370,
+      "artist": "IOSYS",
+      "title": "Judgement Star",
+      "creator": "NeKroMan4ik",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-12-16T09:04:41Z"
     },
     {
       "beatmapset_id": 2280202,
@@ -2282,6 +2774,55 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2282096,
+      "artist": "Halozy",
+      "title": "Don't let you down",
+      "creator": "ler1211",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2024-11-24T03:50:25Z"
+    },
+    {
+      "beatmapset_id": 2282117,
+      "artist": "Sawawa",
+      "title": "Cosmic Drive",
+      "creator": "k0alcj",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-23T16:51:14Z"
+    },
+    {
       "beatmapset_id": 2282492,
       "artist": "SOUND HOLIC feat. Meramipop",
       "title": "Koiiro no Yume",
@@ -2435,6 +2976,34 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2024-11-26T07:50:53Z"
+    },
+    {
+      "beatmapset_id": 2285652,
+      "artist": "Alejqndro",
+      "title": "Hartmann no Youkai Shoujo (Synthwave Remix)",
+      "creator": "-Doge-",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-06-29T06:25:30Z"
     },
     {
       "beatmapset_id": 2285768,

--- a/data/catalog/2300000-2399999.json
+++ b/data/catalog/2300000-2399999.json
@@ -235,6 +235,81 @@
       "osu_last_updated": "2025-08-01T10:59:45Z"
     },
     {
+      "beatmapset_id": 2305050,
+      "artist": "Halozy feat. Nanahira",
+      "title": "Monosugoi Ikioi de Keine ga Monosugoi Uta (Cut Ver.)",
+      "creator": "Remilie",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-19T19:38:33Z"
+    },
+    {
+      "beatmapset_id": 2305505,
+      "artist": "Shibayan feat. nachi",
+      "title": "Kenja no Kyokuhoku (Nhato Remix)",
+      "creator": "nanoya",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:ShibayanRecords",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-08T22:15:03Z"
+    },
+    {
+      "beatmapset_id": 2305788,
+      "artist": "LeaF",
+      "title": "Wizdomiot (Extended Ver.)",
+      "creator": "Cestorie",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-21T19:20:50Z"
+    },
+    {
       "beatmapset_id": 2306433,
       "artist": "Rin",
       "title": "Daishibyo set 10 ~ Oomiwa Shinwaden",
@@ -376,6 +451,32 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2025-03-12T15:53:22Z"
+    },
+    {
+      "beatmapset_id": 2308851,
+      "artist": "Halozy",
+      "title": "K.O.K.O.R.O & S.A.T.O.R.A.R.E",
+      "creator": "karupa",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-01-25T12:40:54Z"
     },
     {
       "beatmapset_id": 2309829,
@@ -570,6 +671,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-03-23T13:05:22Z"
+    },
+    {
+      "beatmapset_id": 2313682,
+      "artist": "Akatsuki Records",
+      "title": "Konnichiwa?",
+      "creator": "Nyanaro",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Alstroemeria Records",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-14T17:35:21Z"
     },
     {
       "beatmapset_id": 2314105,
@@ -851,6 +977,30 @@
       "osu_last_updated": "2025-02-09T18:52:21Z"
     },
     {
+      "beatmapset_id": 2315649,
+      "artist": "Liz Triangle",
+      "title": "Hakugin no Yaiba",
+      "creator": "Kokoro223_",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-02-08T03:30:39Z"
+    },
+    {
       "beatmapset_id": 2315856,
       "artist": "EastNewSound feat. nayuta",
       "title": "Nijiiro Kekkai, Gekkyou no Goku",
@@ -870,6 +1020,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2025-03-30T03:51:36Z"
+    },
+    {
+      "beatmapset_id": 2316692,
+      "artist": "Xyris",
+      "title": "Dystopian Exodus of the Magical Girls",
+      "creator": "Linkff001",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-09-24T08:04:14Z"
     },
     {
       "beatmapset_id": 2317217,
@@ -892,6 +1066,32 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-03-21T11:41:32Z"
+    },
+    {
+      "beatmapset_id": 2317462,
+      "artist": "Innocent Key",
+      "title": "Love-chu * CHIREIDEN",
+      "creator": "Nyanaro",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-23T21:11:33Z"
     },
     {
       "beatmapset_id": 2318139,
@@ -944,6 +1144,30 @@
       "osu_last_updated": "2025-05-15T15:26:30Z"
     },
     {
+      "beatmapset_id": 2320572,
+      "artist": "TUMENECO feat. yukina & Mii",
+      "title": "Itsuka Kimi to Mukaeru Yoake",
+      "creator": "dahkjdas",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "external_provenance:retailer-tracklist+thbwiki",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-03-23T02:10:36Z"
+    },
+    {
       "beatmapset_id": 2320727,
       "artist": "Demetori",
       "title": "Kamisabita Kosenjou ~ Suwa Foughten Field",
@@ -993,6 +1217,54 @@
       "osu_last_updated": "2025-05-06T13:13:12Z"
     },
     {
+      "beatmapset_id": 2322334,
+      "artist": "Unlucky Morpheus",
+      "title": "Sono Tamashii ni Yasuragi o ~ Dignity of Spirit",
+      "creator": "My Angel Chen",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-11-13T04:15:14Z"
+    },
+    {
+      "beatmapset_id": 2322699,
+      "artist": "minimum electric design",
+      "title": "miscalc",
+      "creator": "Ideal",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "external_provenance:arrangement-chronicle",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-02-18T23:34:39Z"
+    },
+    {
       "beatmapset_id": 2323094,
       "artist": "Silver Forest",
       "title": "Phantasm Brigade",
@@ -1040,6 +1312,33 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2025-04-03T11:50:58Z"
+    },
+    {
+      "beatmapset_id": 2324756,
+      "artist": "ZUN",
+      "title": "Last Remote",
+      "creator": "Nyanaro",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:ZUN",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-06-13T21:42:13Z"
     },
     {
       "beatmapset_id": 2325579,
@@ -1536,6 +1835,32 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2331469,
+      "artist": "Halozy feat. Tsubaki",
+      "title": "Kyun Kyun Tamaran Inaba-tan.",
+      "creator": "sho_o",
+      "source": "東方永夜抄　～ Imperishable Night.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Imperishable Night",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方永夜抄",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-04-25T13:21:05Z"
+    },
+    {
       "beatmapset_id": 2333219,
       "artist": "Shinigiwa Satellite feat. Meramipop",
       "title": "Omoikane Injection",
@@ -1898,6 +2223,30 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2025-03-09T18:08:59Z"
+    },
+    {
+      "beatmapset_id": 2336986,
+      "artist": "S.S.H. & Aether",
+      "title": "Locked Girl ~ Shoujo Misshitsu",
+      "creator": "Shurelia",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-16T06:48:53Z"
     },
     {
       "beatmapset_id": 2337108,
@@ -2666,6 +3015,31 @@
       "osu_last_updated": "2025-06-10T11:41:07Z"
     },
     {
+      "beatmapset_id": 2345463,
+      "artist": "Kurokotei",
+      "title": "Galaxy Collapse",
+      "creator": "XRedyRatyX",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-04-23T18:09:32Z"
+    },
+    {
       "beatmapset_id": 2345936,
       "artist": "Rolling Contact",
       "title": "Snow, White, Echo",
@@ -3269,6 +3643,31 @@
       "osu_last_updated": "2026-01-12T09:55:24Z"
     },
     {
+      "beatmapset_id": 2352149,
+      "artist": "UNDEAD CORPORATION",
+      "title": "MEGALOMANIA",
+      "creator": "Vaqu",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-10T14:12:25Z"
+    },
+    {
       "beatmapset_id": 2352527,
       "artist": "Akiyama Uni",
       "title": "Touhou Hisouten (Game Ver.)",
@@ -3338,6 +3737,30 @@
       "osu_last_updated": "2025-06-25T22:24:08Z"
     },
     {
+      "beatmapset_id": 2354377,
+      "artist": "Takamachi Walk",
+      "title": "hollow hope",
+      "creator": "hz404",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-05T08:30:58Z"
+    },
+    {
       "beatmapset_id": 2354680,
       "artist": "ZUN",
       "title": "Meiji Juushichi-nen no Shanghai Alice",
@@ -3398,6 +3821,31 @@
       "confidence": "probable",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-01-13T23:00:54Z"
+    },
+    {
+      "beatmapset_id": 2358120,
+      "artist": "Hexacube",
+      "title": "LOVE EYE",
+      "creator": "Briesmas",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-31T01:49:33Z"
     },
     {
       "beatmapset_id": 2359033,
@@ -3505,6 +3953,30 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2362559,
+      "artist": "camel ytpmv",
+      "title": "Camelmiru Camel",
+      "creator": "Broadsword",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-06-10T09:49:34Z"
+    },
+    {
       "beatmapset_id": 2364061,
       "artist": "UNDEAD CORPORATION",
       "title": "MEGALOMANIA",
@@ -3528,6 +4000,55 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2025-05-05T02:49:12Z"
+    },
+    {
+      "beatmapset_id": 2364934,
+      "artist": "beatMARIO",
+      "title": "Cirno's Perfect Math Academy",
+      "creator": "iRedi",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:COOL&CREATE",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-05-15T12:03:00Z"
+    },
+    {
+      "beatmapset_id": 2365171,
+      "artist": "Unlucky Morpheus",
+      "title": "BPM210 no Shanghai Alice (Instrumental)",
+      "creator": "Erowdi",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-10-26T19:16:49Z"
     },
     {
       "beatmapset_id": 2365832,
@@ -4304,6 +4825,30 @@
       "osu_last_updated": "2025-08-10T19:41:09Z"
     },
     {
+      "beatmapset_id": 2389260,
+      "artist": "Acro",
+      "title": "Yume",
+      "creator": "Gera",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方神霊廟",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-25T04:22:26Z"
+    },
+    {
       "beatmapset_id": 2389297,
       "artist": "Rin",
       "title": "Moriya set 11 ReEdit ~ Onbashira no Hakaba",
@@ -4454,6 +4999,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2392966,
+      "artist": "AU",
+      "title": "Owens",
+      "creator": "Kukkai",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-04-26T10:32:11Z"
     },
     {
       "beatmapset_id": 2393429,
@@ -4615,6 +5183,30 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2026-03-01T16:26:46Z"
+    },
+    {
+      "beatmapset_id": 2398086,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Under the scarlet sky pt. 2",
+      "creator": "Hydria",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-09-22T15:48:53Z"
     },
     {
       "beatmapset_id": 2399201,

--- a/data/catalog/2400000-2499999.json
+++ b/data/catalog/2400000-2499999.json
@@ -104,6 +104,31 @@
       "osu_last_updated": "2025-07-21T12:10:21Z"
     },
     {
+      "beatmapset_id": 2407462,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Under the scarlet sky pt. 2",
+      "creator": "bighzonda",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-09-12T16:00:56Z"
+    },
+    {
       "beatmapset_id": 2409273,
       "artist": "ArmpitMaiden",
       "title": "On the Edge of Paradise",
@@ -144,6 +169,57 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-03-29T11:03:22Z"
+    },
+    {
+      "beatmapset_id": 2410016,
+      "artist": "Halozy feat. Nanahira",
+      "title": "Monosugoi Satori Gear de Reimu ga Monosugoi Uta",
+      "creator": "Kukkai",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "catch"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-11-14T04:36:34Z"
+    },
+    {
+      "beatmapset_id": 2410294,
+      "artist": "Para Dot.",
+      "title": "Hyper banquet",
+      "creator": "yakisode",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-09-08T20:45:20Z"
     },
     {
       "beatmapset_id": 2410417,
@@ -401,6 +477,31 @@
       "osu_last_updated": "2025-08-05T20:02:38Z"
     },
     {
+      "beatmapset_id": 2414966,
+      "artist": "EastNewSound feat. nayuta",
+      "title": "Nijiiro Kekkai, Gekkyou no Goku",
+      "creator": "k0alcj",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-08-25T02:55:45Z"
+    },
+    {
       "beatmapset_id": 2415151,
       "artist": "Takamachi Walk",
       "title": "Forget Me",
@@ -421,6 +522,57 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-07-05T02:59:34Z"
+    },
+    {
+      "beatmapset_id": 2415448,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Karakurenai feat. Ranko",
+      "creator": "Cris-",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-05T22:43:30Z"
+    },
+    {
+      "beatmapset_id": 2416218,
+      "artist": "Halozy",
+      "title": "S.A.T.O.R.A.R.E",
+      "creator": "Eriha",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-10-10T11:15:36Z"
     },
     {
       "beatmapset_id": 2416620,
@@ -500,6 +652,31 @@
       "osu_last_updated": "2025-10-10T01:18:16Z"
     },
     {
+      "beatmapset_id": 2417668,
+      "artist": "senya",
+      "title": "Kachou Fuugetsu",
+      "creator": "LostF4te",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-09-13T03:11:54Z"
+    },
+    {
       "beatmapset_id": 2418189,
       "artist": "K.V. Kaoruko",
       "title": "U.N. Owen was Her Majesty?",
@@ -541,6 +718,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-01-08T15:00:12Z"
+    },
+    {
+      "beatmapset_id": 2418853,
+      "artist": "Dark PHOENiX",
+      "title": "Ryokugan no Jealousy",
+      "creator": "Okoayu",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-12-17T10:59:37Z"
     },
     {
       "beatmapset_id": 2418954,
@@ -635,6 +837,29 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-02-09T14:01:10Z"
+    },
+    {
+      "beatmapset_id": 2424250,
+      "artist": "Yuzutyie",
+      "title": "N.N. Teki Vocaloid wa Byouki Nano ka? Saishuu Kichiku Vocaloidre-N",
+      "creator": "AJT",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-12-06T21:13:49Z"
     },
     {
       "beatmapset_id": 2425144,
@@ -984,6 +1209,32 @@
       "osu_last_updated": "2025-10-19T13:51:15Z"
     },
     {
+      "beatmapset_id": 2441875,
+      "artist": "Halozy",
+      "title": "Masshiro na Yuki",
+      "creator": "AelSan",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-10-24T06:24:55Z"
+    },
+    {
       "beatmapset_id": 2442680,
       "artist": "Demetori",
       "title": "Pure Furies ~ Vengeance is Mine",
@@ -1305,6 +1556,31 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2455224,
+      "artist": "R-note",
+      "title": "Desire Shooting",
+      "creator": "Luscent",
+      "source": "東方神霊廟　～ Ten Desires.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Ten Desires",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方神霊廟",
+        "discovery_query:東方",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-12-07T13:07:50Z"
+    },
+    {
       "beatmapset_id": 2455952,
       "artist": "komasy",
       "title": "the primal scene of hyperflip the girl saw",
@@ -1347,6 +1623,31 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-08-02T00:46:39Z"
+    },
+    {
+      "beatmapset_id": 2458692,
+      "artist": "D.watt (OTAKU-ELITE Recordings)",
+      "title": "Opium and Purple haze",
+      "creator": "Feraligatr",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:IOSYS",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2025-12-04T02:48:55Z"
     },
     {
       "beatmapset_id": 2459936,
@@ -1470,6 +1771,30 @@
       "osu_last_updated": "2026-03-06T09:06:53Z"
     },
     {
+      "beatmapset_id": 2465439,
+      "artist": "EastNewSound feat. nayuta",
+      "title": "Nijiiro Kekkai, Gekkyou no Goku",
+      "creator": "yakisode",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-12T06:19:42Z"
+    },
+    {
       "beatmapset_id": 2466317,
       "artist": "Liz Triangle",
       "title": "Renge Hanabi",
@@ -1559,6 +1884,30 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2026-02-16T04:41:13Z"
+    },
+    {
+      "beatmapset_id": 2472186,
+      "artist": "ryu5150",
+      "title": "Battle Warrior!!",
+      "creator": "reisen91937",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "external_provenance:official-circle",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-24T00:28:00Z"
     },
     {
       "beatmapset_id": 2473158,
@@ -1835,6 +2184,33 @@
       "osu_last_updated": "2026-01-13T05:54:19Z"
     },
     {
+      "beatmapset_id": 2483766,
+      "artist": "Halozy",
+      "title": "Heart of Night",
+      "creator": "big snag",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Phantasmagoria of Dim.Dream",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-09T14:51:23Z"
+    },
+    {
       "beatmapset_id": 2484594,
       "artist": "beatMARIO",
       "title": "Night of Knights (Cranky Remix)",
@@ -1927,6 +2303,29 @@
       "osu_last_updated": null
     },
     {
+      "beatmapset_id": 2489824,
+      "artist": "Tsukasa Yatoki",
+      "title": "Heaven's Race Guitar Style",
+      "creator": "ulko",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-01T02:22:40Z"
+    },
+    {
       "beatmapset_id": 2490353,
       "artist": "senya",
       "title": "Iro wa Jou e to Izanau",
@@ -1991,6 +2390,55 @@
       "confidence": "candidate",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2497259,
+      "artist": "senya",
+      "title": "Iro wa Nioedo Chirinuru o",
+      "creator": "patchy",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-18T15:34:18Z"
+    },
+    {
+      "beatmapset_id": 2497564,
+      "artist": "Rolling Contact",
+      "title": "Red Anthem -separate-",
+      "creator": "Sanch-KK",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-01-24T12:41:27Z"
     },
     {
       "beatmapset_id": 2498021,

--- a/data/catalog/2500000-2599999.json
+++ b/data/catalog/2500000-2599999.json
@@ -2,6 +2,57 @@
   "schema_version": 1,
   "entries": [
     {
+      "beatmapset_id": 2500223,
+      "artist": "SuganoMusic",
+      "title": "Imademo...",
+      "creator": "Luscent",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:東方",
+        "discovery_query:東方Project",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-06T11:30:14Z"
+    },
+    {
+      "beatmapset_id": 2503577,
+      "artist": "Down",
+      "title": "Luscent",
+      "creator": "Irone OSU",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "catch",
+        "mania",
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-02-23T02:39:29Z"
+    },
+    {
       "beatmapset_id": 2503873,
       "artist": "Diao Ye Zong feat. Meramipop",
       "title": "Kaeruhime",
@@ -88,6 +139,54 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": null
+    },
+    {
+      "beatmapset_id": 2508608,
+      "artist": "senya",
+      "title": "Mujaki sae no Uwagaki",
+      "creator": "Satellite",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-19T14:52:38Z"
+    },
+    {
+      "beatmapset_id": 2509002,
+      "artist": "Unlucky Morpheus",
+      "title": "DRAGON FORCE",
+      "creator": "6_9",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-07-11T18:04:08Z"
     },
     {
       "beatmapset_id": 2509245,
@@ -277,6 +376,30 @@
       "osu_last_updated": "2026-02-27T16:08:01Z"
     },
     {
+      "beatmapset_id": 2516975,
+      "artist": "maritumix",
+      "title": "514",
+      "creator": "[GB]Cinelia",
+      "source": "東方地霊殿　～ Subterranean Animism.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Subterranean Animism",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方地霊殿",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-15T05:47:00Z"
+    },
+    {
       "beatmapset_id": 2516983,
       "artist": "Snowman",
       "title": "Braggartcrow's dance",
@@ -381,6 +504,29 @@
       "osu_last_updated": "2026-05-24T13:41:37Z"
     },
     {
+      "beatmapset_id": 2522131,
+      "artist": "8686m",
+      "title": "tangent",
+      "creator": "zglock",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-23T03:17:19Z"
+    },
+    {
       "beatmapset_id": 2523604,
       "artist": "beatMARIO",
       "title": "Night of Nights (Flowering nights remix)",
@@ -483,6 +629,31 @@
       "osu_last_updated": "2026-04-29T15:23:45Z"
     },
     {
+      "beatmapset_id": 2524492,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Iki wa Yoi Yoi",
+      "creator": "Smoke",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "discovery_query:Team Shanghai Alice",
+        "discovery_query:UNDEAD CORPORATION",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-23T20:01:41Z"
+    },
+    {
       "beatmapset_id": 2524653,
       "artist": "beatMARIO",
       "title": "Night of Knights",
@@ -557,6 +728,54 @@
       "confidence": "verified",
       "last_checked": "2026-08-21",
       "osu_last_updated": "2026-04-20T09:20:43Z"
+    },
+    {
+      "beatmapset_id": 2525930,
+      "artist": "Demetori",
+      "title": "Necrofantasia ~ Remix",
+      "creator": "Greenshell",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-04-05T16:46:41Z"
+    },
+    {
+      "beatmapset_id": 2525946,
+      "artist": "Shibayan feat. nachi",
+      "title": "Que ela vem",
+      "creator": "velamy",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:ShibayanRecords",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-03-29T15:31:48Z"
     },
     {
       "beatmapset_id": 2526938,
@@ -711,6 +930,32 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2026-04-03T14:58:32Z"
+    },
+    {
+      "beatmapset_id": 2530670,
+      "artist": "tsunamix",
+      "title": "stella maris",
+      "creator": "Cafe_deCoral",
+      "source": "東方Project",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=東方",
+        "discovery_query:source=東方Project",
+        "discovery_query:上海アリス幻樂団",
+        "discovery_query:東方Project",
+        "external_provenance:arrangement-chronicle",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-20T00:50:50Z"
     },
     {
       "beatmapset_id": 2530780,
@@ -889,6 +1134,30 @@
       "osu_last_updated": "2026-04-05T12:02:34Z"
     },
     {
+      "beatmapset_id": 2534821,
+      "artist": "A-One feat. Shihori",
+      "title": "Magic Girl !!",
+      "creator": "SimpForTakagi",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:A-One",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-04-13T22:59:36Z"
+    },
+    {
       "beatmapset_id": 2535184,
       "artist": "Halozy",
       "title": "143",
@@ -987,6 +1256,31 @@
       "confidence": "verified",
       "last_checked": "2026-09-03",
       "osu_last_updated": "2026-05-16T22:18:03Z"
+    },
+    {
+      "beatmapset_id": 2538196,
+      "artist": "senya",
+      "title": "Yowamushi Vampire",
+      "creator": "Satellite",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Shinigiwa Satellite",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-24T03:13:40Z"
     },
     {
       "beatmapset_id": 2539015,
@@ -1211,6 +1505,29 @@
       "osu_last_updated": "2026-08-08T10:18:59Z"
     },
     {
+      "beatmapset_id": 2551839,
+      "artist": "FELT",
+      "title": "Sky Gate",
+      "creator": "Sutherland",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-05-24T12:20:18Z"
+    },
+    {
       "beatmapset_id": 2553057,
       "artist": "Richaadeb",
       "title": "Night of Nights",
@@ -1286,6 +1603,31 @@
       "osu_last_updated": "2026-07-15T05:05:44Z"
     },
     {
+      "beatmapset_id": 2555232,
+      "artist": "UNDEAD CORPORATION",
+      "title": "Under the scarlet sky pt,1 inst",
+      "creator": "Frutiger_",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:UNDEAD CORPORATION",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-07-01T12:34:21Z"
+    },
+    {
       "beatmapset_id": 2556827,
       "artist": "Unlucky Morpheus",
       "title": "Kamigami ga Koishita Gensoukyou",
@@ -1358,6 +1700,54 @@
       "osu_last_updated": "2026-07-10T03:59:40Z"
     },
     {
+      "beatmapset_id": 2559045,
+      "artist": "FELT",
+      "title": "Crumbling",
+      "creator": "espii",
+      "source": "東方星蓮船　～ Undefined Fantastic Object.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Undefined Fantastic Object",
+        "discovery_query:source=東方星蓮船",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-14T21:53:18Z"
+    },
+    {
+      "beatmapset_id": 2559071,
+      "artist": "ryu5150",
+      "title": "Mighty Red",
+      "creator": "reisen91937",
+      "source": "東方紅魔郷　～ the Embodiment of Scarlet Devil.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Embodiment of Scarlet Devil",
+        "discovery_query:source=東方紅魔郷",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-06-05T03:41:14Z"
+    },
+    {
       "beatmapset_id": 2559362,
       "artist": "Halozy",
       "title": "Sakura Saku Utopia",
@@ -1426,6 +1816,54 @@
       "confidence": "verified",
       "last_checked": "2026-08-15",
       "osu_last_updated": "2026-07-31T21:51:31Z"
+    },
+    {
+      "beatmapset_id": 2564142,
+      "artist": "Demetori",
+      "title": "Shinkou wa Hakanaki Ningen no Tame ni ~ Jehovah's YaHVeH",
+      "creator": "reisen91937",
+      "source": "東方風神録　～ Mountain of Faith.",
+      "status": "ranked",
+      "modes": [
+        "taiko"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Mountain of Faith",
+        "discovery_query:source=東方風神録",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-07-09T03:56:04Z"
+    },
+    {
+      "beatmapset_id": 2564859,
+      "artist": "Halozy",
+      "title": "Crystal Snow",
+      "creator": "risui",
+      "source": "東方妖々夢　～ Perfect Cherry Blossom.",
+      "status": "ranked",
+      "modes": [
+        "osu"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:Halozy",
+        "discovery_query:source=Perfect Cherry Blossom",
+        "discovery_query:source=東方妖々夢",
+        "discovery_query:上海アリス幻樂団",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-08-04T17:43:22Z"
     },
     {
       "beatmapset_id": 2567202,

--- a/data/catalog/2600000-2699999.json
+++ b/data/catalog/2600000-2699999.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "entries": [
+    {
+      "beatmapset_id": 2608197,
+      "artist": "t+pazolite",
+      "title": "Luv*Lab*Poison 22ate!",
+      "creator": "Furryswan",
+      "source": "東方花映塚　～ Phantasmagoria of Flower View.",
+      "status": "ranked",
+      "modes": [
+        "mania"
+      ],
+      "touhou_kind": "unknown",
+      "origin_games": [],
+      "original_themes": [],
+      "evidence": [
+        "audit:wave2-reviewed-2026-09",
+        "discovery_query:source=Phantasmagoria of Flower View",
+        "discovery_query:source=東方花映塚",
+        "osu_source"
+      ],
+      "confidence": "verified",
+      "last_checked": "2026-09-03",
+      "osu_last_updated": "2026-08-24T14:14:26Z"
+    }
+  ]
+}

--- a/docs/source-audit-2026-09-wave2-reviewed.md
+++ b/docs/source-audit-2026-09-wave2-reviewed.md
@@ -1,0 +1,121 @@
+# Touhou coverage wave 2 — reviewed 206-set expansion (2026-09)
+
+## Scope and trust boundary
+
+This pass starts from the post-PR-#32 canonical `main` and deliberately separates two evidence classes. It never treats a generic `Touhou` / `東方Project` osu! source string as sufficient on its own, because the merge review of PR #32 proved that class can contain Touhou-associated image originals rather than arrangements.
+
+- base catalog: **4232**
+- Class A (specific official game source + >=2 discovery queries + current Touhou/ZUN tag signal + API/page exact): **193**
+- Class B (quarantined metadata class + manually frozen independent composition provenance + API/page exact): **13**
+- total new beatmapsets: **206**
+- final catalog: **4438**
+
+## Discovery and verification
+
+- configured discovery queries: **89**
+- cursor pages/query: up to **12**
+- unique beatmapsets discovered: **6078**
+- absent from the post-#32 catalog: **3343**
+- live API exact verification: **206/206**
+- separate public-page canonical JSON verification: **206/206**
+- configured live source reports re-imported: **43** (6977 records)
+- selected rows with additional configured-source overlap: **5**
+
+All selected IDs were absent before writeback. The writer asserts every pre-existing catalog record remains field-for-field identical and uses `Catalog.save()` only after all live gates have passed.
+
+## Final distribution
+
+- statuses: `{'ranked': 202, 'loved': 4}`
+- modes: `{'osu': 95, 'taiko': 58, 'catch': 19, 'mania': 37}`
+- discovery-query corroboration: `{2: 48, 3: 77, 4: 57, 5: 16, 6: 7, 7: 1}`
+
+### Source strings
+
+- `東方紅魔郷　～ the Embodiment of Scarlet Devil.` — 83
+- `東方地霊殿　～ Subterranean Animism.` — 42
+- `東方妖々夢　～ Perfect Cherry Blossom.` — 22
+- `東方永夜抄　～ Imperishable Night.` — 21
+- `東方Project` — 12
+- `東方花映塚　～ Phantasmagoria of Flower View.` — 10
+- `東方神霊廟　～ Ten Desires.` — 6
+- `東方星蓮船　～ Undefined Fantastic Object.` — 5
+- `東方風神録　～ Mountain of Faith.` — 4
+- `東方紅魔郷 ～ the Embodiment of Scarlet Devil.` — 1
+
+## Class B — manually reviewed independent composition provenance
+
+These rows are the only quarantined-source candidates promoted in this wave. Each was manually checked against a track/release source that explicitly names the underlying Touhou original(s). TouhouDB alone is not accepted as a final arbiter: it misclassifies the already-reviewed `Knife - Story` boundary, so the final B allowlist uses stronger release/track evidence.
+
+| Beatmapset | Track | Independent relation | Source |
+| ---: | --- | --- | --- |
+| `386620` | ARM — Rhododendron | 月まで届け、不死の煙 | https://touhou.arrangement-chronicle.com/original_song/%E6%9D%B1%E6%96%B9%E6%B0%B8%E5%A4%9C%E6%8A%84/%E6%9C%88%E3%81%BE%E3%81%A7%E5%B1%8A%E3%81%91%E3%80%81%E4%B8%8D%E6%AD%BB%E3%81%AE%E7%85%99 |
+| `399965` | shio — Qronostasis -GABBA vs. Speedcore mix- | 天空のグリニッジ; THBWiki track 3450769: arrange=shio, ogmusic=天空のグリニッジ | https://thwiki.cc/album.php |
+| `1550437` | tsunamix_underground — Period. ~ Seishin no Kousoku to Jiyuu o Tsukamu Jouka | 天空のグリニッジ | https://touhou.arrangement-chronicle.com/original_song/%E5%A4%A7%E7%A9%BA%E9%AD%94%E8%A1%93/%E5%A4%A9%E7%A9%BA%E3%81%AE%E3%82%B0%E3%83%AA%E3%83%8B%E3%83%83%E3%82%B8 |
+| `1635625` | SOUND HOLIC — PRESERVED VAMPIRE | 月時計 ～ ルナ・ダイアル; フラワリングナイト | https://sound-holic.booth.pm/items/3530545 |
+| `1644488` | A-One feat. Shihori — Magic Girl !! | 魔法少女達の百年祭 | https://thwiki.cc/index.php?setlang=en&title=%E6%AD%8C%E8%AF%8D%3AMagic_Girl_%21%21 |
+| `1928250` | Shibayan feat. Tsubaki Ichimatsu — GAZE IT | 天空のグリニッジ | https://booth.pm/en/items/1663468 |
+| `1942214` | GET IN THE RING — Midnight Syndrome | 燕石博物誌が連れてきた闇; バー・オールドアダム; アウトサイダーカクテル; 旧世界の冒険酒場 | https://thwiki.cc/index.php?setlang=en&title=%E6%AD%8C%E8%AF%8D%3AMidnight_Syndrome |
+| `2120912` | tsunamix — stella maris | ネクロファンタジア; 夜が降りてくる ～ Evening Star | https://touhou.arrangement-chronicle.com/circle/AGGRESSIVE%20BEAT%20CIRCLE/album/AGGRESSIVE%20GENERATION |
+| `2149949` | GET IN THE RING — Midnight Syndrome | 燕石博物誌が連れてきた闇; バー・オールドアダム; アウトサイダーカクテル; 旧世界の冒険酒場 | https://thwiki.cc/index.php?setlang=en&title=%E6%AD%8C%E8%AF%8D%3AMidnight_Syndrome |
+| `2320572` | TUMENECO feat. yukina & Mii — Itsuka Kimi to Mukaeru Yoake | 日本中の不思議を集めて | https://www.melonbooks.co.jp/detail/detail.php?product_id=2411052 |
+| `2322699` | minimum electric design — miscalc | 童祭 ～ Innocent Treasures | https://touhou.arrangement-chronicle.com/circle/minimum%20electric%20design/album/TRAIL%20III%20DISC-1 |
+| `2472186` | ryu5150 — Battle Warrior!! | 少女綺想曲; 東方妖恋談 | https://ryu-5150.jp/disc/%E3%82%B7%E3%83%B3%E3%83%95%E3%82%A9%E3%83%8B%E3%83%83%E3%82%AF%E6%9D%B1%E6%96%B9%E2%85%B4/ |
+| `2530670` | tsunamix — stella maris | ネクロファンタジア; 夜が降りてくる ～ Evening Star | https://touhou.arrangement-chronicle.com/circle/AGGRESSIVE%20BEAT%20CIRCLE/album/AGGRESSIVE%20GENERATION |
+
+## Additional configured-source overlaps
+
+- `1128939` — `official_pack_item:FQ40`
+- `1644488` — `official_pack_item:FQ66`, `official_pack_item:R309`
+- `2141740` — `official_pack_item:R334`
+- `2159203` — `official_pack_item:R340`
+- `2220709` — `official_pack_item:R332`
+
+## Accepted IDs
+
+### Class A
+
+- `69173`, `556969`, `579359`, `582888`, `1128939`, `1241481`, `1277845`, `1324962`, `1349838`, `1368759`, `1374425`, `1397832`, `1573417`, `1576656`, `1579075`, `1588466`, `1601650`, `1618365`, `1641141`, `1649093`
+- `1704340`, `1715998`, `1716009`, `1752523`, `1763702`, `1765375`, `1780135`, `1784332`, `1811874`, `1817787`, `1832066`, `1837942`, `1840481`, `1852057`, `1857047`, `1861782`, `1878008`, `1892797`, `1896626`, `1901650`
+- `1909936`, `1913078`, `1913796`, `1914658`, `1915327`, `1921061`, `1921815`, `1929270`, `1931429`, `1941763`, `1942061`, `1953513`, `1958464`, `1969255`, `1971670`, `1972745`, `1984348`, `1990973`, `1999914`, `2006619`
+- `2006943`, `2012401`, `2014469`, `2018806`, `2020167`, `2022219`, `2030543`, `2030733`, `2033193`, `2034075`, `2035737`, `2039084`, `2042736`, `2048946`, `2056468`, `2056650`, `2060837`, `2064066`, `2065149`, `2066130`
+- `2071645`, `2072440`, `2072915`, `2080690`, `2080925`, `2082657`, `2086554`, `2086616`, `2088280`, `2089306`, `2092851`, `2120920`, `2121057`, `2122307`, `2135628`, `2136154`, `2141740`, `2143839`, `2144555`, `2150144`
+- `2150616`, `2155937`, `2159203`, `2159661`, `2166782`, `2170949`, `2174924`, `2176852`, `2192796`, `2194940`, `2197609`, `2197940`, `2198080`, `2217257`, `2220709`, `2223022`, `2226125`, `2227686`, `2231358`, `2239310`
+- `2241785`, `2248177`, `2254348`, `2254629`, `2254847`, `2256857`, `2261894`, `2266294`, `2266612`, `2270937`, `2271637`, `2278914`, `2279370`, `2282096`, `2282117`, `2285652`, `2305050`, `2305505`, `2305788`, `2308851`
+- `2313682`, `2315649`, `2316692`, `2317462`, `2322334`, `2324756`, `2331469`, `2336986`, `2345463`, `2352149`, `2354377`, `2358120`, `2362559`, `2364934`, `2365171`, `2389260`, `2392966`, `2398086`, `2407462`, `2410016`
+- `2410294`, `2414966`, `2415448`, `2416218`, `2417668`, `2418853`, `2424250`, `2441875`, `2455224`, `2458692`, `2465439`, `2483766`, `2489824`, `2497259`, `2497564`, `2500223`, `2503577`, `2508608`, `2509002`, `2516975`
+- `2522131`, `2524492`, `2525930`, `2525946`, `2534821`, `2538196`, `2551839`, `2555232`, `2559045`, `2559071`, `2564142`, `2564859`, `2608197`
+
+### Class B
+
+- `386620`, `399965`, `1550437`, `1635625`, `1644488`, `1928250`, `1942214`, `2120912`, `2149949`, `2320572`, `2322699`, `2472186`, `2530670`
+
+## Explicit rejection boundary
+
+### Quarantined rows not promoted
+
+- `351574` — **t+pazolite & COMP - Sayonara Matane** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `356543` — **Demetori - Higan Kikou ~ View of The River Styx** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `381363` — **Kurenainagi Tabibito - Otenba Koimusume** — `game_no_tag` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `401354` — **Demetori - Youkai no Yama ~ Mysterious Mountain** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `1342305` — **FELT - Songs Compilation** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `1350314` — **dev - lovely freezing tomboy bath** — `generic` — dev - lovely freezing tomboy bath: exact-title THBWiki result names different arrangers (uno / 808sndmindbreak), so artist/composition identity is not safely resolved.
+- `1771472` — **Kobaryo - Outer Occult Occupation** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `2023362` — **ZYTOKINE - Dancing Dollz feat. cold kiss - REDALiCE Remix** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `2049932` — **Knife - Negaigoto Liner 2020** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `2096026` — **Knife - Story** — `generic` — Knife - Story: independent release/live documentation identifies it as a Hifuu image original, not an arrangement; retained as the PR #32 negative boundary.
+- `2109511` — **Knife - Story** — `generic` — Knife - Story: same composition as the reviewed PR #32 false-positive; generic Touhou source / TouhouDB metadata is not sufficient.
+- `2145065` — **GET IN THE RING - Hana wa Sakuragi, Hito wa Kaze** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `2172715` — **TUMENECO VS. GET IN THE RING - Yumeuta - Tokubetsu na Futari no Uta** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `2237688` — **IOSYS - Makudo wa Taihen na Mono o Tsukutte Ikimashita** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `2245252` — **Foxtail-Grass Studio - Shade, Hat, and Wind Chimes** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `2251577` — **TUMENECO VS. GET IN THE RING - Yumeuta - Tokubetsu na Futari no Uta** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `2439565` — **Diao Ye Zong feat. Meramipop - Zettai-teki Ippou Tsuukou ~ Unreachable Message** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+- `2523183` — **BUTAOTOME - Moonstone** — `generic` — withheld: no manually frozen independent release/original relation at the reviewed B-class standard
+
+### Historical-source recovery checked but not used
+
+The recovered Google Published Sheet link for the 2019 first Touhou Tournament was tested through its HTML, XLSX and CSV publication endpoints. All currently return HTTP 410 Gone, so the historical tournament remains a documented lead rather than a reproducible source and contributes no acceptance evidence here.
+
+## Reproduction / validation contract
+
+The temporary branch-only writer runs the full discovery, API/page verification, configured-source re-import, semantic old-row guard, then `make check`, `python -m touhou_osu validate`, `make build`, and `git diff --check`. Temporary writer/workflow files are removed before the PR is opened.


### PR DESCRIPTION
## Summary

Adds **206 Touhou beatmapsets absent from the post-#32 `main`**, growing the canonical catalog from **4,232 → 4,438** entries.

This wave is deliberately stricter than PR #32 after merge review exposed a real generic-source false positive (`Knife - Story`). The 206 rows are split into two evidence classes instead of treating every osu! `source` string equally:

- **Class A — 193 sets**: current osu! `source` names a specific recognized Touhou game; the set is found by at least 2 configured discovery queries; current mapper tags still contain a Touhou/ZUN/Team Shanghai Alice signal; and the current API + public beatmapset page agree exactly.
- **Class B — 13 sets**: generic/quarantined osu! metadata is *not* sufficient. These rows are a manually frozen allowlist with independent track/release evidence that explicitly names the underlying Touhou original(s), plus the same API/page identity checks.

Final batch:

- **206** new beatmapsets
- **202 ranked + 4 loved**
- modes present: **osu=95, taiko=58, mania=37, catch=19**
- catalog: **4,232 → 4,438**

The complete accepted IDs, Class B source table, configured-source overlaps and rejection boundary are recorded in `docs/source-audit-2026-09-wave2-reviewed.md`.

## Discovery breadth

The reviewed writer reran all **89 configured osu! discovery queries**, requesting up to **12 cursor pages per query** against the post-#32 catalog.

- **6,078** unique beatmapsets discovered in the final write run
- **3,343** absent from the post-#32 catalog
- strict Class A natural pool: **193**
- generic / insufficient-tag rows were quarantined instead of being used to pad the target

An independent audit implementation using a slightly different strict game-source policy independently landed at the same ~192–193 range. In other words, the 200 threshold was not reached by loosening Class A; it was reached only after adding independent composition provenance for a small reviewed Class B.

## Live identity verification

Every one of the 206 retained sets was freshly re-fetched *after* the final A/B sets were frozen.

For all **206/206** rows:

1. current osu! API v2 identity matches discovery metadata;
2. ID / artist / title / creator / source / status / modes / last-updated are captured from the fresh API object;
3. a separate `https://osu.ppy.sh/beatmapsets/{id}` fetch parses the embedded canonical beatmapset JSON;
4. public-page identity/metadata matches the API exactly;
5. no unresolved fetch is counted as a pass.

Seven public-page requests temporarily returned HTTP 429. All seven succeeded after explicit backoff; final result is **206/206 API exact + 206/206 public-page exact**.

## Class A — 193 specific-game-source rows

Class A requires all of:

- source is a recognized **specific Touhou game**, not generic `Touhou` / `東方Project`;
- at least **2 configured discovery queries** independently hit the set;
- current mapper tags contain a Touhou / ZUN / Team Shanghai Alice signal;
- current status is ranked or loved;
- API and public canonical page match exactly.

A separate external composition audit queried TouhouDB first and THBWiki as fallback. It found **98/193** Class A rows with an additional unambiguous external original/arrangement relation (61 TouhouDB + 37 THBWiki); database non-coverage or ambiguity was treated as unresolved, not fabricated evidence.

More importantly, a separate **negative-provenance scan** checked all 193 exact title+artist rows against TouhouDB + THBWiki for the failure mode seen in PR #32: an external database explicitly classifying the composition as a non-ZUN `Original` with no underlying Touhou original. Result: **193 checked, 0 contradictory originals, 0 request errors**. 54 rows also produced positive external relations in that stricter exact-match scan.

## Class B — 13 manually reviewed composition relations

Generic `Touhou` / `東方Project` metadata is never enough for Class B. TouhouDB alone is also not considered authoritative for this boundary because it incorrectly presents the already-reviewed `Knife - Story` image-original case as an arrangement.

The 13 Class B rows are frozen only after track/release-level review. Examples include:

- `1635625` — SOUND HOLIC — `PRESERVED VAMPIRE`: SOUND HOLIC's own BOOTH tracklist names `月時計 ～ ルナ・ダイアル` and `フラワリングナイト` as the originals.
- `1928250` — Shibayan feat. Tsubaki Ichimatsu — `GAZE IT`: ShibayanRecords' own BOOTH release names `天空のグリニッジ` as the original.
- `2472186` — ryu5150 — `Battle Warrior!!`: 5150's official release page names `少女綺想曲` and `東方妖恋談`.
- `1942214` / `2149949` — GET IN THE RING — `Midnight Syndrome`: THBWiki names four underlying Touhou originals.
- `2120912` / `2530670` — tsunamix — `stella maris`: 東方編曲録 names `ネクロファンタジア` and `夜が降りてくる ～ Evening Star`.
- `2322699` — minimum electric design — `miscalc`: 東方編曲録 names `童祭 ～ Innocent Treasures`.
- `2320572` — TUMENECO — `Itsuka Kimi to Mukaeru Yoake`: release/track sources name `日本中の不思議を集めて`.

The permanent audit document contains the full 13-row evidence table and source URLs.

## Existing provenance re-import

The final writer also re-imported **all 43 configured live provenance sources (6,977 records)** after the 206 IDs were fixed. Five selected sets independently overlap existing reviewed sources, and that evidence is preserved rather than double-counted:

- `1128939` — `official_pack_item:FQ40`
- `1644488` — `official_pack_item:FQ66`, `official_pack_item:R309`
- `2141740` — `official_pack_item:R334`
- `2159203` — `official_pack_item:R340`
- `2220709` — `official_pack_item:R332`

## Rejection boundary

This wave deliberately keeps questionable rows outside the catalog, including:

- `2096026` / `2109511` — **Knife - Story** — Hifuu image original, not accepted from generic source / TouhouDB metadata.
- `1350314` — **dev - lovely freezing tomboy bath** — exact-title THBWiki results name different arrangers, so composition identity is not safely resolved.
- other generic-source rows without a manually frozen release/original relation remain withheld.

The recovered Google Published Sheet for the 2019 first Touhou Tournament was also re-tested. Its HTML/XLSX/CSV publication endpoints currently return **HTTP 410 Gone**, so it remains a historical lead and contributes no acceptance evidence.

## Semantic integrity

A separate reverse-diff review of the written data verified:

- base catalog: **4,232**
- final catalog: **4,438**
- exactly **206 additions**
- **0 base IDs removed**
- **all 4,232 pre-existing records field-for-field unchanged**
- actual new-ID set exactly equals the permanent audit's `Class A ∪ Class B`
- Class A = exactly 193; Class B = exactly the frozen 13-ID allowlist
- all new rows are `verified`, have >=2 discovery-query evidence items, and use no `manual:*` override

## Validation

The final data tree passed:

- `make check` — **63 tests passed**
- `python -m touhou_osu validate` — **4,438** total (`verified=2,766`)
- `make build` — **2,795 accepted** beatmapsets
- `git diff --check` — clean

Temporary discovery/writer/review harness files are not part of this PR. The branch is squashed to **one formal commit** and the PR diff contains only **18 catalog shard changes + 1 permanent audit document**.

## Interaction with open PR #31

PR #31 still changes only `data/catalog/0000000-0024999.json` and `data/catalog/0025000-0049999.json`. This wave's lowest new beatmapset ID is above that range, so there is no changed-file overlap.