### PR TITLE
fix: make generic Touhou sources conservative

### DIFF
--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -27,10 +27,94 @@ jobs:
             echo "::notice::Set OSU_CLIENT_ID and OSU_CLIENT_SECRET repository secrets to enable discovery."
             exit 0
           fi
+          rm -rf "$RUNNER_TEMP/discovery-base"
+          mkdir -p "$RUNNER_TEMP/discovery-base"
+          git archive HEAD data/catalog | tar -x -C "$RUNNER_TEMP/discovery-base"
           python -m touhou_osu discover --write --max-changes 50
           if [[ -n "$(git status --porcelain --untracked-files=all -- data/catalog)" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            python -m touhou_osu.provenance \
+              --catalog data/catalog \
+              --base-catalog "$RUNNER_TEMP/discovery-base/data/catalog" \
+              --scope changed \
+              --workers 4 \
+              --output "$RUNNER_TEMP/provenance.json"
           fi
+      - name: Summarize external provenance
+        if: steps.discover.outputs.changed == 'true'
+        env:
+          REPORT: ${{ runner.temp }}/provenance.json
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["REPORT"]).read_text(encoding="utf-8"))
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          lines = [
+              "## External composition provenance",
+              "",
+              "Advisory cross-check only: THBWiki/TouhouDB hits do not automatically promote or exclude catalog rows.",
+              "",
+              f"- checked changed rows: **{payload['checked']}**",
+              f"- positive external relations: **{payload['supported']}**",
+              f"- red flags: **{payload['red_flags']}**",
+              f"- ambiguous: **{payload['ambiguous']}**",
+              f"- provider errors: **{payload['provider_errors']}**",
+              f"- unsafe generic-source auto-promotions: **{len(payload['policy_violations'])}**",
+          ]
+          interesting = [
+              row for row in payload["results"]
+              if row["verdict"] != "unknown" or row["errors"]
+          ]
+          if interesting:
+              lines += ["", "### Review hints", ""]
+              for row in interesting[:30]:
+                  lines.append(
+                      f"- `{row['beatmapset_id']}` — {row['artist']} - {row['title']} — "
+                      f"**{row['verdict']}**"
+                  )
+                  for hit in row["hits"][:4]:
+                      originals = ", ".join(hit["originals"])
+                      detail = originals or hit["detail"] or hit["relation"]
+                      lines.append(f"  - {hit['provider']}: {hit['relation']} — {detail}")
+                  for error in row["errors"]:
+                      lines.append(f"  - provider warning: {error}")
+          summary.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          for row in payload["results"]:
+              if row["verdict"] in {"red_flag", "ambiguous"}:
+                  print(
+                      f"::warning::External provenance review needed for beatmapset "
+                      f"{row['beatmapset_id']}: {row['verdict']}"
+                  )
+              for error in row["errors"]:
+                  print(f"::notice::External provider unavailable/ambiguous for {row['beatmapset_id']}: {error}")
+          PY
+      - name: Upload provenance report
+        if: steps.discover.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-provenance-report
+          path: ${{ runner.temp }}/provenance.json
+          retention-days: 30
+      - name: Enforce generic-source verification policy
+        if: steps.discover.outputs.changed == 'true'
+        env:
+          REPORT: ${{ runner.temp }}/provenance.json
+        run: |
+          python - <<'PY'
+          import json, os, sys
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["REPORT"]).read_text(encoding="utf-8"))
+          violations = payload["policy_violations"]
+          if violations:
+              print(
+                  "::error::Unsafe generic-source auto-verification: "
+                  + ", ".join(str(item) for item in violations)
+              )
+              sys.exit(1)
+          PY
       - name: Open or update review PR
         if: steps.discover.outputs.changed == 'true'
         env:
@@ -44,7 +128,7 @@ jobs:
           git commit -m "data: discover Touhou beatmap candidates"
           git push --force origin "$branch"
           pr_number=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
-          body="Automated weekly osu! API discovery, capped at 50 meaningful catalog changes. Review confidence and evidence before merging; remaining matches roll into later weeks."
+          body="Automated weekly osu! API discovery, capped at 50 meaningful catalog changes. Generic Touhou source labels are not sufficient for automatic verification. The generating workflow also runs advisory THBWiki/TouhouDB composition-provenance checks and uploads a JSON report; review red flags and positive hints before merging."
           if [[ -n "$pr_number" ]]; then
             gh pr edit "$pr_number" --title "data: weekly Touhou discovery" --body "$body"
           else

--- a/.github/workflows/provenance-smoke.yml
+++ b/.github/workflows/provenance-smoke.yml
@@ -1,0 +1,48 @@
+name: External provenance smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "29 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check known external relations
+        run: |
+          python - <<'PY'
+          from touhou_osu.models import Entry
+          from touhou_osu.provenance import audit_entries
+
+          probes = [
+              Entry(399965, artist="shio", title="Qronostasis -GABBA vs. Speedcore mix-", source="Touhou"),
+              Entry(2322699, artist="minimum electric design", title="miscalc", source="Touhou"),
+          ]
+          results = audit_entries(probes, workers=2)
+          for result in results:
+              print(result.to_dict())
+              if not result.supports:
+                  print(
+                      f"::warning::Known provenance probe {result.beatmapset_id} "
+                      "did not return a positive relation. Inspect provider availability/API drift."
+                  )
+              if result.contradictions:
+                  print(
+                      f"::warning::Known provenance probe {result.beatmapset_id} "
+                      "returned a contradiction. External provenance is advisory; inspect manually."
+                  )
+              for error in result.errors:
+                  print(
+                      f"::notice::Provider warning for provenance probe "
+                      f"{result.beatmapset_id}: {error}"
+                  )
+          PY

--- a/docs/external-provenance.md
+++ b/docs/external-provenance.md
@@ -1,0 +1,67 @@
+# External composition provenance
+
+osu! `source` metadata is mapper-entered. A concrete Touhou game title is a strong automatic signal, but generic labels such as `Touhou`, `Touhou Project`, `東方`, or `東方Project` do not identify the underlying composition and are not sufficient for automatic `verified` confidence.
+
+The repository therefore treats external music databases as **advisory cross-checks**, not authorities.
+
+## Providers
+
+### Touhou Music Database (TouhouDB)
+
+The audit queries the public songs API with the osu! title, then requires an exact normalized title and compatible artist match before considering a row.
+
+Useful signals:
+
+- `originalVersionId` present: positive arrangement relation;
+- `songType=Original` with ZUN as the matched artist: positive ZUN-original relation;
+- `songType=Original` with a non-ZUN matched artist and no underlying original: review red flag.
+
+A TouhouDB hit alone never promotes or excludes a catalog entry.
+
+### THBWiki music data API
+
+The audit uses the public `album.php` track-search (`st`) and track-detail (`gt`) endpoints. It first requires an exact normalized track title. The detail request retrieves `circle`, `artist`, `arrange`, `ogmusic`, and `ogwork`.
+
+A THBWiki row is reported as a positive composition relation only when:
+
+- `ogmusic` names one or more underlying originals; and
+- the osu! artist is compatible with at least one THBWiki identity from `circle`, `artist`, or `arrange`.
+
+This matters because osu! often stores the circle as the artist while THBWiki stores an individual arranger separately. For example, matching only `arrange` would miss tracks where the osu! artist is a circle name. Rows with an exact title but no usable identity metadata are not claimed as positive evidence. `ogwork` is included in the report as extra review context when available.
+
+THBWiki results are advisory and never auto-promote a row.
+
+## Weekly discovery policy
+
+Weekly discovery runs the external audit only for rows actually changed by that run. The workflow:
+
+1. snapshots the pre-discovery catalog;
+2. runs normal osu! API discovery;
+3. audits the changed rows against TouhouDB and THBWiki;
+4. uploads the JSON report as `weekly-provenance-report`;
+5. writes positive relations, red flags, ambiguity, and provider errors to the Actions job summary.
+
+Provider outages or ambiguous database coverage are warnings rather than hard failures. The hard policy gate is deterministic and local: a **newly verified generic-source row without independent trusted evidence** (`manual:verified`, audited official pack, trusted tournament, or TMC evidence) fails the workflow.
+
+This distinction is deliberate: a transient external outage must not break discovery, while a regression that again treats generic `Touhou` metadata as sufficient proof must fail closed.
+
+## Manual use
+
+Compare a modified catalog with a base snapshot:
+
+```bash
+python -m touhou_osu.provenance \
+  --catalog data/catalog \
+  --base-catalog /path/to/base/data/catalog \
+  --scope changed \
+  --output provenance.json \
+  --fail-on-policy-violation
+```
+
+Audit generic-source rows without changing the catalog:
+
+```bash
+python -m touhou_osu.provenance --scope generic --limit 50
+```
+
+The report fields `supported`, `red_flag`, and `ambiguous` are review hints only. Acceptance should continue to use the repository's stronger provenance hierarchy and manual review for generic-source composition boundaries.

--- a/docs/source-audit-2026-09-generic-source-policy.md
+++ b/docs/source-audit-2026-09-generic-source-policy.md
@@ -1,0 +1,16 @@
+# Generic-source classifier correction (2026-09)
+
+This change follows the manual review of weekly discovery PR #31, which demonstrated that exact generic osu! `source` labels such as `Touhou` / `Touhou Project` / `東方Project` are useful discovery signals but are not sufficient composition provenance.
+
+Policy after this change:
+
+- a recognized concrete Touhou game title in osu! `source` remains an automatic `verified` signal;
+- an exact generic Touhou label may still contribute the existing `osu_source` evidence marker for compatibility, but no longer automatically verifies the row;
+- generic source plus mapper Touhou tags, a known Touhou artist, and curated collection evidence may reach `probable`;
+- manual exclusions/candidate guards and audited official/tournament evidence keep their existing precedence;
+- existing verified catalog rows are not mass-demoted by catalog merging, but newly discovered generic-source rows can no longer be promoted solely by the generic source field;
+- the evidence vocabulary is intentionally not split into new generic/game markers, avoiding a one-time catalog backfill that would consume the weekly meaningful-change cap.
+
+External composition databases are added as an advisory review layer. TouhouDB and THBWiki are queried with strict title/artist matching where possible. Their results are recorded as positive relations, red flags, ambiguity, or provider errors; no single external database automatically changes catalog confidence.
+
+Weekly discovery now snapshots its base catalog, audits changed rows, uploads a JSON provenance artifact, and hard-fails only if a newly verified generic-source row appears without independent trusted evidence. External provider outages remain non-gating warnings.

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -5,10 +5,10 @@ from touhou_osu.models import Entry
 
 
 class ClassifierTests(unittest.TestCase):
-    def test_explicit_source_is_verified(self):
+    def test_generic_touhou_source_stays_candidate(self):
         item = Entry(1, source="東方Project", evidence=["discovery_query:東方"], confidence="candidate")
         apply_classification(item)
-        self.assertEqual(item.confidence, "verified")
+        self.assertEqual(item.confidence, "candidate")
         self.assertIn("osu_source", item.evidence)
 
     def test_known_game_source_is_verified(self):
@@ -22,7 +22,7 @@ class ClassifierTests(unittest.TestCase):
         self.assertEqual(item.confidence, "verified")
         self.assertIn("osu_source", item.evidence)
 
-    def test_touhou_sourced_cross_franchise_mashup_is_verified(self):
+    def test_generic_touhou_cross_franchise_mashup_stays_candidate(self):
         item = Entry(
             20406,
             artist="Nico Nico Douga",
@@ -32,8 +32,21 @@ class ClassifierTests(unittest.TestCase):
             confidence="candidate",
         )
         apply_classification(item, tags="dj yoshitaka evans jubeat u.n. owen was her")
-        self.assertEqual(item.confidence, "verified")
+        self.assertEqual(item.confidence, "candidate")
         self.assertIn("osu_source", item.evidence)
+
+    def test_generic_source_needs_other_signals_for_probable(self):
+        item = Entry(
+            1,
+            artist="ShibayanRecords",
+            source="Touhou",
+            evidence=["osucollector:1402", "discovery_query:Touhou"],
+            confidence="candidate",
+        )
+        apply_classification(item, tags="touhou zun arrangement")
+        self.assertEqual(item.confidence, "probable")
+        self.assertIn("osu_source", item.evidence)
+        self.assertIn("known_touhou_metadata", item.evidence)
 
     def test_unrelated_romanized_touhou_source_stays_candidate(self):
         item = Entry(
@@ -93,7 +106,7 @@ class ClassifierTests(unittest.TestCase):
         apply_classification(item)
         self.assertEqual(item.confidence, "excluded")
 
-    def test_manual_exclusion_beats_explicit_touhou_source(self):
+    def test_manual_exclusion_beats_generic_touhou_source(self):
         item = Entry(1, source="Touhou", evidence=["osu_source", "manual:excluded"], confidence="verified")
         apply_classification(item)
         self.assertEqual(item.confidence, "excluded")
@@ -101,6 +114,17 @@ class ClassifierTests(unittest.TestCase):
     def test_manual_candidate_beats_trusted_tournament(self):
         item = Entry(1, evidence=["manual:candidate", "tournament:google_sheet:fixture"], confidence="verified")
         apply_classification(item)
+        self.assertEqual(item.confidence, "candidate")
+
+    def test_manual_candidate_beats_generic_source_and_tags(self):
+        item = Entry(
+            1,
+            artist="IOSYS",
+            source="Touhou",
+            evidence=["manual:candidate", "osucollector:1402"],
+            confidence="verified",
+        )
+        apply_classification(item, tags="touhou zun team shanghai alice")
         self.assertEqual(item.confidence, "candidate")
 
     def test_known_artist_alone_stays_candidate(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,8 +68,58 @@ class DiscoveryTests(unittest.TestCase):
                 ],
             )
 
+    def test_existing_generic_verified_row_does_not_churn(self):
+        raw = {
+            "id": 42,
+            "artist": "IOSYS",
+            "title": "Known arrangement",
+            "creator": "mapper",
+            "source": "Touhou",
+            "status": "ranked",
+            "tags": "touhou",
+            "last_updated": "2026-01-01T00:00:00Z",
+            "beatmaps": [{"mode": "osu"}],
+        }
+        FakeOsuApi.responses = {"Touhou": [raw]}
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            catalog_path = root / "catalog.json"
+            config_path = root / "seeds.json"
+            original = Entry(
+                42,
+                artist="IOSYS",
+                title="Known arrangement",
+                creator="mapper",
+                source="Touhou",
+                status="ranked",
+                modes=["osu"],
+                evidence=["discovery_query:Touhou", "known_touhou_artist", "mapper_tags", "osu_source"],
+                confidence="verified",
+                last_checked="2026-01-01",
+                osu_last_updated="2026-01-01T00:00:00Z",
+            )
+            Catalog([original]).save(catalog_path)
+            before = catalog_path.read_text(encoding="utf-8")
+            config_path.write_text(json.dumps({"discovery_queries": ["Touhou"]}), encoding="utf-8")
+            args = argparse.Namespace(
+                catalog=catalog_path,
+                config=config_path,
+                max_pages=4,
+                max_changes=50,
+                write=True,
+            )
+
+            with patch("touhou_osu.cli.OsuApi", FakeOsuApi):
+                self.assertEqual(command_discover(args), 0)
+
+            after = catalog_path.read_text(encoding="utf-8")
+            entry = Catalog.load(catalog_path).entries[42]
+            self.assertEqual(entry.confidence, "verified")
+            self.assertEqual(entry.last_checked, "2026-01-01")
+            self.assertEqual(before, after)
+
     def test_caps_meaningful_changes_without_date_only_churn(self):
-        def raw(beatmapset_id, *, source="Touhou Project"):
+        def raw(beatmapset_id, *, source="東方永夜抄 ～ Imperishable Night."):
             return {
                 "id": beatmapset_id,
                 "artist": "ZUN",
@@ -93,7 +143,7 @@ class DiscoveryTests(unittest.TestCase):
                         artist="ZUN",
                         title="Theme 10",
                         creator="mapper",
-                        source="Touhou Project",
+                        source="東方永夜抄 ～ Imperishable Night.",
                         status="ranked",
                         modes=["osu"],
                         evidence=["discovery_query:Touhou", "osu_source"],
@@ -152,7 +202,7 @@ class DiscoveryTests(unittest.TestCase):
             entry = Catalog.load(catalog_path).entries[42]
             self.assertEqual(entry.artist, "ZUN")
             self.assertEqual(entry.title, "Theme")
-            self.assertEqual(entry.confidence, "verified")
+            self.assertEqual(entry.confidence, "probable")
             self.assertIn("osu_source", entry.evidence)
 
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,174 @@
+import unittest
+from unittest.mock import patch
+
+from touhou_osu.catalog import Catalog
+from touhou_osu.http import HttpError
+from touhou_osu.models import Entry
+from touhou_osu.provenance import (
+    audit_entry,
+    new_generic_verification_violations,
+    query_thbwiki,
+    query_touhoudb,
+)
+
+
+class ProvenanceTests(unittest.TestCase):
+    def test_touhoudb_exact_arrangement_supports(self):
+        entry = Entry(1, artist="Shibayan feat. Tsubaki Ichimatsu", title="GAZE IT", source="Touhou")
+        payload = {
+            "items": [
+                {
+                    "id": 123,
+                    "name": "GAZE IT",
+                    "artistString": "Shibayan feat. Tsubaki Ichimatsu",
+                    "artists": [],
+                    "status": "Finished",
+                    "songType": "Arrangement",
+                    "originalVersionId": 456,
+                }
+            ]
+        }
+        with patch("touhou_osu.provenance.get_json", return_value=payload):
+            hits = query_touhoudb(entry)
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0].verdict, "supports")
+        self.assertEqual(hits[0].relation, "arrangement")
+        self.assertIn("originalVersionId=456", hits[0].detail)
+
+    def test_touhoudb_non_zun_original_is_red_flag(self):
+        entry = Entry(1, artist="Some Circle", title="Image Song", source="Touhou")
+        payload = {
+            "items": [
+                {
+                    "id": 123,
+                    "name": "Image Song",
+                    "artistString": "Some Circle",
+                    "artists": [],
+                    "status": "Finished",
+                    "songType": "Original",
+                    "originalVersionId": None,
+                }
+            ]
+        }
+        with patch("touhou_osu.provenance.get_json", return_value=payload):
+            hits = query_touhoudb(entry)
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0].verdict, "contradicts")
+        self.assertEqual(hits[0].relation, "non_zun_original")
+
+    def test_touhoudb_same_title_wrong_artist_is_ignored(self):
+        entry = Entry(1, artist="Expected Artist", title="Same Title", source="Touhou")
+        payload = {
+            "items": [
+                {
+                    "id": 123,
+                    "name": "Same Title",
+                    "artistString": "Different Artist",
+                    "artists": [],
+                    "status": "Finished",
+                    "originalVersionId": 456,
+                }
+            ]
+        }
+        with patch("touhou_osu.provenance.get_json", return_value=payload):
+            self.assertEqual(query_touhoudb(entry), [])
+
+    def test_thbwiki_circle_identity_and_original_supports(self):
+        entry = Entry(1, artist="minimum electric design", title="miscalc", source="Touhou")
+        search = [[123, "miscalc"]]
+        detail = [
+            [
+                ["id", 123],
+                ["name", "miscalc"],
+                ["circle", ["minimum electric design"]],
+                ["artist", ["dalin"]],
+                ["arrange", ["dalin"]],
+                ["ogmusic", ["童祭 ～ Innocent Treasures"]],
+                ["ogwork", ["夢違科学世紀"]],
+            ]
+        ]
+        with patch("touhou_osu.provenance.get_json", side_effect=[search, detail]):
+            hits = query_thbwiki(entry)
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0].verdict, "supports")
+        self.assertEqual(hits[0].relation, "arrangement")
+        self.assertEqual(hits[0].originals, ("童祭 ～ Innocent Treasures",))
+        self.assertIn("circle=minimum electric design", hits[0].detail)
+        self.assertIn("ogwork=夢違科学世紀", hits[0].detail)
+
+    def test_thbwiki_arranger_identity_supports(self):
+        entry = Entry(1, artist="shio", title="Qronostasis", source="Touhou")
+        search = [[123, "Qronostasis"]]
+        detail = [
+            [
+                ["id", 123],
+                ["name", "Qronostasis"],
+                ["circle", ["Other Circle"]],
+                ["arrange", ["shio"]],
+                ["ogmusic", ["天空のグリニッジ"]],
+            ]
+        ]
+        with patch("touhou_osu.provenance.get_json", side_effect=[search, detail]):
+            hits = query_thbwiki(entry)
+        self.assertEqual(len(hits), 1)
+        self.assertIn("arrange=shio", hits[0].detail)
+
+    def test_thbwiki_named_nonmatching_identities_are_not_claimed(self):
+        entry = Entry(1, artist="Expected Artist", title="Same Title", source="Touhou")
+        search = [[123, "Same Title"]]
+        detail = [
+            [
+                ["id", 123],
+                ["name", "Same Title"],
+                ["circle", ["Different Circle"]],
+                ["artist", ["Different Vocalist"]],
+                ["arrange", ["Different Arranger"]],
+                ["ogmusic", ["Touhou Theme"]],
+            ]
+        ]
+        with patch("touhou_osu.provenance.get_json", side_effect=[search, detail]):
+            self.assertEqual(query_thbwiki(entry), [])
+
+    def test_thbwiki_title_only_row_is_not_claimed(self):
+        entry = Entry(1, artist="Expected Artist", title="Common Title", source="Touhou")
+        search = [[123, "Common Title"]]
+        detail = [
+            [
+                ["id", 123],
+                ["name", "Common Title"],
+                ["ogmusic", ["Touhou Theme"]],
+            ]
+        ]
+        with patch("touhou_osu.provenance.get_json", side_effect=[search, detail]):
+            self.assertEqual(query_thbwiki(entry), [])
+
+    def test_provider_failure_is_advisory(self):
+        entry = Entry(1, artist="Artist", title="Title", source="Touhou")
+        with patch("touhou_osu.provenance.query_touhoudb", side_effect=HttpError("down")), patch(
+            "touhou_osu.provenance.query_thbwiki", return_value=[]
+        ):
+            result = audit_entry(entry)
+        self.assertEqual(result.verdict, "unknown")
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn("touhoudb", result.errors[0])
+
+    def test_new_generic_verified_without_independent_evidence_is_violation(self):
+        base = Catalog([Entry(1, source="Touhou", confidence="candidate", evidence=["discovery_query:Touhou"])])
+        current = Catalog([Entry(1, source="Touhou", confidence="verified", evidence=["osu_source"])])
+        self.assertEqual(new_generic_verification_violations(current, base), [1])
+
+    def test_generic_verified_with_official_pack_is_not_violation(self):
+        base = Catalog([Entry(1, source="Touhou", confidence="candidate")])
+        current = Catalog(
+            [Entry(1, source="Touhou", confidence="verified", evidence=["official_pack_item:A16"])]
+        )
+        self.assertEqual(new_generic_verification_violations(current, base), [])
+
+    def test_preexisting_generic_verified_is_not_retroactively_blocked(self):
+        base = Catalog([Entry(1, source="Touhou", confidence="verified")])
+        current = Catalog([Entry(1, source="Touhou", confidence="verified", evidence=["osu_source"])])
+        self.assertEqual(new_generic_verification_violations(current, base), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/touhou_osu/classifier.py
+++ b/touhou_osu/classifier.py
@@ -16,10 +16,9 @@ EXACT_TOUHOU_SOURCES = (
     "東方プロジェクト",
 )
 
-# Source metadata is strong enough for automatic verification only when it
-# names a known Touhou game.  In particular, do not treat arbitrary strings
-# containing the words "Touhou" or "東方" as proof: titles such as
-# "Hakkenden: Touhou Hakken Ibun" are unrelated to Touhou Project.
+# A concrete game title is substantially stronger than a generic "Touhou"
+# label. Generic labels are useful discovery signals, but are not sufficient
+# composition provenance on their own.
 TOUHOU_GAME_TITLE_TOKENS = (
     "highly responsive to prayers",
     "story of eastern wonderland",
@@ -120,11 +119,31 @@ def contains_any(value: str, tokens: tuple[str, ...] | set[str]) -> bool:
     return any(normalize(token) in normalized for token in tokens)
 
 
-def is_explicit_touhou_source(value: str) -> bool:
-    normalized = normalize(value).strip(" .,:：;_-~～")
-    if normalized in {normalize(source) for source in EXACT_TOUHOU_SOURCES}:
-        return True
+def normalized_source(value: str) -> str:
+    return normalize(value).strip(" .,:：;_-~～")
+
+
+def is_generic_touhou_source(value: str) -> bool:
+    normalized = normalized_source(value)
+    return normalized in {normalize(source) for source in EXACT_TOUHOU_SOURCES}
+
+
+def is_touhou_game_source(value: str) -> bool:
+    normalized = normalized_source(value)
+    if not normalized or is_generic_touhou_source(normalized):
+        return False
     return contains_any(normalized, TOUHOU_GAME_TITLE_TOKENS)
+
+
+def is_explicit_touhou_source(value: str) -> bool:
+    """Return whether source metadata explicitly signals Touhou relevance.
+
+    This broad predicate intentionally includes generic labels for discovery and
+    audit purposes. Classification distinguishes generic labels from concrete
+    game titles and only auto-verifies the latter.
+    """
+
+    return is_generic_touhou_source(value) or is_touhou_game_source(value)
 
 
 @dataclass(frozen=True)
@@ -148,9 +167,16 @@ def classify(entry: Entry, *, tags: str = "") -> Classification:
     ):
         return Classification("verified", tuple(sorted(evidence)))
 
-    if is_explicit_touhou_source(entry.source):
+    if is_touhou_game_source(entry.source):
         evidence.add("osu_source")
         return Classification("verified", tuple(sorted(evidence)))
+
+    # Keep the existing evidence vocabulary for compatibility and to avoid a
+    # one-time catalog backfill that would consume the weekly meaningful-change
+    # cap. The current source value itself determines whether this signal is
+    # generic or game-specific.
+    if is_generic_touhou_source(entry.source):
+        evidence.add("osu_source")
 
     curated_queue_match = any(item.startswith("forum_queue:") for item in evidence)
     resolved_metadata = bool(entry.artist and entry.title and not entry.title.startswith("beatmapsets/"))

--- a/touhou_osu/provenance.py
+++ b/touhou_osu/provenance.py
@@ -1,0 +1,448 @@
+"""Advisory external composition-provenance checks.
+
+External music databases are cross-checks, not authorities. A provider hit is
+reported for review but never changes catalog confidence by itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .catalog import Catalog
+from .classifier import is_generic_touhou_source
+from .http import HttpError, get_json
+from .models import Entry
+
+TOUHOUDb_API = "https://touhoudb.com/api/songs"
+THBWIKI_API = "https://thwiki.cc/album.php"
+TRUSTED_VERIFICATION_PREFIXES = (
+    "official_pack:",
+    "official_pack_item:",
+    "tournament:",
+    "tmc:",
+)
+
+
+def compact(value: str) -> str:
+    value = unicodedata.normalize("NFKC", str(value)).casefold()
+    return "".join(char for char in value if char.isalnum())
+
+
+def artist_matches(left: str, right: str) -> bool:
+    left_key, right_key = compact(left), compact(right)
+    if not left_key or not right_key:
+        return False
+    if left_key == right_key:
+        return True
+    return min(len(left_key), len(right_key)) >= 5 and (
+        left_key in right_key or right_key in left_key
+    )
+
+
+def _strings(value) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [part.strip() for part in re.split(r"[,;/]", str(value)) if part.strip()]
+
+
+@dataclass(frozen=True)
+class ProvenanceHit:
+    provider: str
+    verdict: str
+    relation: str
+    originals: tuple[str, ...] = ()
+    provider_id: str = ""
+    detail: str = ""
+    url: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "provider": self.provider,
+            "verdict": self.verdict,
+            "relation": self.relation,
+            "originals": list(self.originals),
+            "provider_id": self.provider_id,
+            "detail": self.detail,
+            "url": self.url,
+        }
+
+
+@dataclass
+class ProvenanceAudit:
+    beatmapset_id: int
+    artist: str
+    title: str
+    source: str
+    confidence: str
+    hits: list[ProvenanceHit] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def supports(self) -> list[ProvenanceHit]:
+        return [hit for hit in self.hits if hit.verdict == "supports"]
+
+    @property
+    def contradictions(self) -> list[ProvenanceHit]:
+        return [hit for hit in self.hits if hit.verdict == "contradicts"]
+
+    @property
+    def verdict(self) -> str:
+        if self.supports and self.contradictions:
+            return "ambiguous"
+        if self.contradictions:
+            return "red_flag"
+        if self.supports:
+            return "supported"
+        return "unknown"
+
+    def to_dict(self) -> dict:
+        return {
+            "beatmapset_id": self.beatmapset_id,
+            "artist": self.artist,
+            "title": self.title,
+            "source": self.source,
+            "confidence": self.confidence,
+            "verdict": self.verdict,
+            "hits": [hit.to_dict() for hit in self.hits],
+            "errors": list(self.errors),
+        }
+
+
+def _touhoudb_names(item: dict) -> list[str]:
+    names = [item.get("name", ""), item.get("defaultName", "")]
+    names.extend(_strings(item.get("additionalNames")))
+    return [name for name in names if name]
+
+
+def _touhoudb_artists(item: dict) -> list[str]:
+    values = [item.get("artistString", "")]
+    for link in item.get("artists", []) or []:
+        if not isinstance(link, dict):
+            continue
+        values.extend([link.get("name", ""), link.get("additionalNames", "")])
+        nested = link.get("artist") or {}
+        if isinstance(nested, dict):
+            values.extend(
+                [
+                    nested.get("name", ""),
+                    nested.get("defaultName", ""),
+                    nested.get("additionalNames", ""),
+                ]
+            )
+    artists: list[str] = []
+    for value in values:
+        artists.extend(_strings(value))
+    return artists
+
+
+def _song_type(item: dict) -> str:
+    value = item.get("songType")
+    if isinstance(value, dict):
+        value = value.get("name") or value.get("value") or ""
+    return str(value or "")
+
+
+def query_touhoudb(entry: Entry) -> list[ProvenanceHit]:
+    params = urllib.parse.urlencode(
+        {
+            "query": entry.title,
+            "nameMatchMode": "Exact",
+            "fields": "Artists,AdditionalNames,Albums",
+            "maxResults": "30",
+            "getTotalCount": "true",
+        }
+    )
+    payload = get_json(f"{TOUHOUDb_API}?{params}")
+    wanted_title = compact(entry.title)
+    hits: list[ProvenanceHit] = []
+    for item in payload.get("items", []) if isinstance(payload, dict) else []:
+        if not isinstance(item, dict):
+            continue
+        if wanted_title not in {compact(name) for name in _touhoudb_names(item)}:
+            continue
+        artists = _touhoudb_artists(item)
+        if not any(artist_matches(entry.artist, artist) for artist in artists):
+            continue
+        if item.get("status") not in (None, "Finished", "Approved", "Locked"):
+            continue
+
+        provider_id = str(item.get("id", ""))
+        url = f"https://touhoudb.com/S/{provider_id}" if provider_id else "https://touhoudb.com/"
+        original_id = item.get("originalVersionId")
+        if original_id:
+            hits.append(
+                ProvenanceHit(
+                    provider="touhoudb",
+                    verdict="supports",
+                    relation="arrangement",
+                    provider_id=provider_id,
+                    detail=f"originalVersionId={original_id}",
+                    url=url,
+                )
+            )
+        elif _song_type(item).casefold() == "original":
+            if any(compact(artist) == "zun" for artist in artists):
+                hits.append(
+                    ProvenanceHit(
+                        provider="touhoudb",
+                        verdict="supports",
+                        relation="zun_original",
+                        provider_id=provider_id,
+                        url=url,
+                    )
+                )
+            else:
+                hits.append(
+                    ProvenanceHit(
+                        provider="touhoudb",
+                        verdict="contradicts",
+                        relation="non_zun_original",
+                        provider_id=provider_id,
+                        detail=str(item.get("artistString", "")),
+                        url=url,
+                    )
+                )
+    return hits
+
+
+def _thbwiki_detail(payload) -> list[dict]:
+    parsed: list[dict] = []
+    for item in payload if isinstance(payload, list) else []:
+        if not isinstance(item, list):
+            continue
+        obj: dict = {}
+        for pair in item:
+            if isinstance(pair, list) and len(pair) == 2:
+                obj[str(pair[0])] = pair[1]
+        parsed.append(obj)
+    return parsed
+
+
+def query_thbwiki(entry: Entry) -> list[ProvenanceHit]:
+    search_params = urllib.parse.urlencode(
+        {"m": "st", "v": entry.title, "o": "1", "d": "0", "g": "0", "l": "30"}
+    )
+    rows = get_json(f"{THBWIKI_API}?{search_params}")
+    exact_rows = [
+        row
+        for row in rows if isinstance(rows, list) and isinstance(row, list) and len(row) >= 2
+        if isinstance(row[0], int) and compact(row[1]) == compact(entry.title)
+    ]
+    if not exact_rows:
+        return []
+
+    detail_params = urllib.parse.urlencode(
+        {
+            "m": "gt",
+            "p": "name circle artist arrange ogmusic ogwork",
+            "d": "0",
+            "g": "0",
+            "i": ",".join(str(row[0]) for row in exact_rows),
+        }
+    )
+    candidates: list[tuple[dict, list[str], list[str], list[str], tuple[str, ...], list[str]]] = []
+    for obj in _thbwiki_detail(get_json(f"{THBWIKI_API}?{detail_params}")):
+        originals = tuple(_strings(obj.get("ogmusic")))
+        if not originals:
+            continue
+        circles = _strings(obj.get("circle"))
+        artists = _strings(obj.get("artist"))
+        arrangers = _strings(obj.get("arrange"))
+        works = _strings(obj.get("ogwork"))
+        identities = circles + artists + arrangers
+        if identities and not any(artist_matches(entry.artist, identity) for identity in identities):
+            continue
+        # A row with no identity metadata is not promoted to a positive relation:
+        # exact title alone is too weak for common track names.
+        if not identities:
+            continue
+        candidates.append((obj, circles, artists, arrangers, originals, works))
+
+    hits: list[ProvenanceHit] = []
+    for obj, circles, artists, arrangers, originals, works in candidates:
+        provider_id = str(obj.get("id", ""))
+        details: list[str] = []
+        if circles:
+            details.append("circle=" + ", ".join(circles))
+        if artists:
+            details.append("artist=" + ", ".join(artists))
+        if arrangers:
+            details.append("arrange=" + ", ".join(arrangers))
+        if works:
+            details.append("ogwork=" + ", ".join(works))
+        hits.append(
+            ProvenanceHit(
+                provider="thbwiki",
+                verdict="supports",
+                relation="arrangement",
+                originals=originals,
+                provider_id=provider_id,
+                detail="; ".join(details),
+                url="https://thwiki.cc/",
+            )
+        )
+    return hits
+
+
+def audit_entry(entry: Entry) -> ProvenanceAudit:
+    audit = ProvenanceAudit(
+        beatmapset_id=entry.beatmapset_id,
+        artist=entry.artist,
+        title=entry.title,
+        source=entry.source,
+        confidence=entry.confidence,
+    )
+    for provider, function in (("touhoudb", query_touhoudb), ("thbwiki", query_thbwiki)):
+        try:
+            audit.hits.extend(function(entry))
+        except (HttpError, RuntimeError, ValueError, TypeError) as exc:
+            audit.errors.append(f"{provider}: {exc}")
+    return audit
+
+
+def audit_entries(entries: list[Entry], *, workers: int = 4) -> list[ProvenanceAudit]:
+    if workers < 1:
+        raise RuntimeError("provenance workers must be at least 1")
+    results: list[ProvenanceAudit] = []
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(audit_entry, entry): entry.beatmapset_id for entry in entries}
+        for future in as_completed(futures):
+            beatmapset_id = futures[future]
+            try:
+                results.append(future.result())
+            except Exception as exc:  # defensive: preserve the report if one worker fails
+                results.append(
+                    ProvenanceAudit(
+                        beatmapset_id=beatmapset_id,
+                        artist="",
+                        title="",
+                        source="",
+                        confidence="candidate",
+                        errors=[f"audit: {exc}"],
+                    )
+                )
+    return sorted(results, key=lambda item: item.beatmapset_id)
+
+
+def has_independent_verification(entry: Entry) -> bool:
+    evidence = set(entry.evidence)
+    if "manual:verified" in evidence:
+        return True
+    return any(item.startswith(TRUSTED_VERIFICATION_PREFIXES) for item in evidence)
+
+
+def new_generic_verification_violations(current: Catalog, base: Catalog) -> list[int]:
+    """Return newly verified generic-source rows without independent evidence."""
+
+    violations: list[int] = []
+    for beatmapset_id, entry in current.entries.items():
+        if not is_generic_touhou_source(entry.source) or entry.confidence != "verified":
+            continue
+        previous = base.entries.get(beatmapset_id)
+        if previous is not None and previous.confidence == "verified":
+            continue
+        if has_independent_verification(entry):
+            continue
+        violations.append(beatmapset_id)
+    return sorted(violations)
+
+
+def _changed_entries(current: Catalog, base: Catalog) -> list[Entry]:
+    return [
+        current.entries[beatmapset_id]
+        for beatmapset_id in sorted(current.entries)
+        if base.entries.get(beatmapset_id) is None
+        or base.entries[beatmapset_id].to_dict() != current.entries[beatmapset_id].to_dict()
+    ]
+
+
+def _report_payload(audits: list[ProvenanceAudit], violations: list[int]) -> dict:
+    return {
+        "checked": len(audits),
+        "supported": sum(audit.verdict == "supported" for audit in audits),
+        "red_flags": sum(audit.verdict == "red_flag" for audit in audits),
+        "ambiguous": sum(audit.verdict == "ambiguous" for audit in audits),
+        "unknown": sum(audit.verdict == "unknown" for audit in audits),
+        "provider_errors": sum(bool(audit.errors) for audit in audits),
+        "policy_violations": violations,
+        "results": [audit.to_dict() for audit in audits],
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--catalog", type=Path, default=Path("data/catalog"))
+    result.add_argument("--base-catalog", type=Path)
+    result.add_argument(
+        "--scope",
+        choices=("changed", "generic", "verified", "all"),
+        default="changed",
+        help="rows to query; changed requires --base-catalog",
+    )
+    result.add_argument("--workers", type=int, default=4)
+    result.add_argument("--limit", type=int, default=0, help="maximum rows; 0 means unlimited")
+    result.add_argument("--output", type=Path, help="write JSON report to this path")
+    result.add_argument("--fail-on-policy-violation", action="store_true")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    current = Catalog.load(args.catalog)
+    base = Catalog.load(args.base_catalog) if args.base_catalog else None
+
+    if args.scope == "changed":
+        if base is None:
+            print("error: --scope changed requires --base-catalog", file=sys.stderr)
+            return 2
+        targets = _changed_entries(current, base)
+    elif args.scope == "generic":
+        targets = [entry for entry in current.entries.values() if is_generic_touhou_source(entry.source)]
+    elif args.scope == "verified":
+        targets = [entry for entry in current.entries.values() if entry.confidence == "verified"]
+    else:
+        targets = list(current.entries.values())
+
+    targets = sorted(targets, key=lambda entry: entry.beatmapset_id)
+    if args.limit:
+        targets = targets[: args.limit]
+
+    violations = new_generic_verification_violations(current, base) if base is not None else []
+    audits = audit_entries(targets, workers=args.workers)
+    payload = _report_payload(audits, violations)
+    text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+
+    print(
+        "Provenance: "
+        f"checked={payload['checked']} supported={payload['supported']} "
+        f"red_flags={payload['red_flags']} ambiguous={payload['ambiguous']} "
+        f"unknown={payload['unknown']} provider_errors={payload['provider_errors']} "
+        f"policy_violations={len(violations)}",
+        file=sys.stderr,
+    )
+    if args.fail_on_policy_violation and violations:
+        print(
+            "unsafe generic-source auto-verification: " + ", ".join(map(str, violations)),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes the weekly-discovery classifier boundary exposed by the manual review of PR #31 and adds advisory external composition-provenance checks.

### Classifier policy

- exact generic osu! sources such as `Touhou`, `Touhou Project`, `東方`, and `東方Project` no longer auto-promote a row to `verified`;
- generic labels may retain the existing `osu_source` evidence marker for compatibility, but classification now distinguishes generic labels from concrete game titles using the current `source` value;
- recognized concrete Touhou game titles remain a strong automatic `verified` signal;
- manual guards and audited official/tournament evidence retain precedence;
- no new generic/game evidence-marker migration is introduced, avoiding one-time catalog churn that would consume the weekly 50-change cap;
- catalog merge semantics mean existing historical verified rows are not mass-demoted, while new generic-source discoveries can no longer be promoted solely by the generic source field.

### External provenance layer

Adds `touhou_osu.provenance`, an advisory audit engine for:

- TouhouDB exact title+artist matches, including `originalVersionId`, ZUN originals, and non-ZUN-original red flags;
- THBWiki `album.php` track search/detail lookups. THBWiki positives require exact normalized title, non-empty `ogmusic`, and compatible identity from `circle`, `artist`, or `arrange`; `ogwork` is retained as review context.

A single external database result never changes catalog confidence automatically.

### CI integration

Weekly discovery now:

1. snapshots the pre-discovery catalog;
2. runs normal osu! API discovery;
3. audits rows actually changed by that run against TouhouDB and THBWiki;
4. writes advisory positives/red flags/provider errors to the Actions summary;
5. uploads the full JSON report as `weekly-provenance-report` for 30 days;
6. only after the report is available, hard-fails if a newly verified generic-source row appears without independent trusted evidence.

This ordering intentionally preserves the review evidence when the policy gate fails. Provider outages remain non-gating because external services are advisory. A separate scheduled/manual non-gating smoke workflow probes known relations to surface API drift.

### Tests/docs

- reverses the old regression test that explicitly treated `東方Project` as automatically verified;
- adds cross-franchise generic-source regression coverage;
- adds THBWiki/TouhouDB parser and policy-gate tests;
- covers circle-vs-arranger THBWiki identity matching;
- adds a no-churn regression for pre-existing generic-source verified rows;
- updates discovery/hydration expectations;
- documents the provenance trust model and the PR #31 policy correction.

### Live verification

The final implementation was exercised against both live providers:

- TouhouDB reproduced `Ayakura Mei - Romantic Fall` as an arrangement via `originalVersionId` relations;
- THBWiki reproduced `minimum electric design - miscalc` -> `童祭 ～ Innocent Treasures` while matching the osu! artist through `circle=minimum electric design`;
- a separate THBWiki probe reproduced `shio - Qronostasis -GABBA vs. Speedcore mix-` -> `天空のグリニッジ`.

No catalog data is changed by this PR.