### PR TITLE
ci: add reusable catalog deep review

### DIFF
--- a/.github/workflows/deep-review.yml
+++ b/.github/workflows/deep-review.yml
@@ -1,0 +1,169 @@
+name: Deep review
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/deep-review.yml"
+      - "Makefile"
+      - "data/catalog/**"
+      - "docs/source-audit-*.md"
+      - "tests/**"
+      - "touhou_osu/**"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Review layer to run
+        required: true
+        default: all
+        type: choice
+        options:
+          - structural
+          - provenance
+          - live-osu
+          - all
+      ref:
+        description: Repository branch or ref to review
+        required: true
+        default: main
+        type: string
+      base_ref:
+        description: Base branch or ref; manual deep reviews require it to be an ancestor
+        required: true
+        default: main
+        type: string
+      scope:
+        description: Rows used by live review layers
+        required: true
+        default: changed
+        type: choice
+        options:
+          - changed
+          - added
+      audit_doc:
+        description: Optional source-audit Markdown file whose accepted IDs must equal additions
+        required: false
+        type: string
+      expected_additions:
+        description: Optional exact number of added beatmapsets
+        required: false
+        type: string
+      forbid_existing_changes:
+        description: Fail if any pre-existing catalog row changed
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deep-review-${{ github.event.pull_request.number || inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.pull_request.head.sha }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Resolve review parameters
+        id: config
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          INPUT_BASE_REF: ${{ inputs.base_ref }}
+          INPUT_MODE: ${{ inputs.mode }}
+          INPUT_SCOPE: ${{ inputs.scope }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            echo "base_ref=$PR_BASE_SHA" >> "$GITHUB_OUTPUT"
+            echo "mode=structural" >> "$GITHUB_OUTPUT"
+            echo "scope=changed" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags origin "$INPUT_BASE_REF"
+          echo "base_ref=$(git rev-parse FETCH_HEAD)" >> "$GITHUB_OUTPUT"
+          echo "mode=$INPUT_MODE" >> "$GITHUB_OUTPUT"
+          echo "scope=$INPUT_SCOPE" >> "$GITHUB_OUTPUT"
+      - name: Run catalog review
+        env:
+          AUDIT_DOC: ${{ inputs.audit_doc }}
+          BASE_REF: ${{ steps.config.outputs.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          EXPECTED_ADDITIONS: ${{ inputs.expected_additions }}
+          FORBID_EXISTING_CHANGES: ${{ inputs.forbid_existing_changes }}
+          MODE: ${{ steps.config.outputs.mode }}
+          OSU_CLIENT_ID: ${{ github.event_name == 'workflow_dispatch' && (inputs.mode == 'live-osu' || inputs.mode == 'all') && secrets.OSU_CLIENT_ID || '' }}
+          OSU_CLIENT_SECRET: ${{ github.event_name == 'workflow_dispatch' && (inputs.mode == 'live-osu' || inputs.mode == 'all') && secrets.OSU_CLIENT_SECRET || '' }}
+          SCOPE: ${{ steps.config.outputs.scope }}
+        run: |
+          set -euo pipefail
+          args=(
+            --base-ref "$BASE_REF"
+            --mode "$MODE"
+            --scope "$SCOPE"
+            --output deep-review-report.json
+          )
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            args+=(--require-base-ancestor)
+          fi
+          if [[ -n "$AUDIT_DOC" ]]; then
+            args+=(--audit-doc "$AUDIT_DOC")
+          fi
+          if [[ -n "$EXPECTED_ADDITIONS" ]]; then
+            args+=(--expected-additions "$EXPECTED_ADDITIONS")
+          fi
+          if [[ "$FORBID_EXISTING_CHANGES" == "true" ]]; then
+            args+=(--forbid-existing-changes)
+          fi
+          python -m touhou_osu.pr_audit "${args[@]}"
+      - name: Write job summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report_path = Path("deep-review-report.json")
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          if not report_path.exists():
+              summary.write_text("## Deep review\n\nNo report was produced; inspect the failed step.\n", encoding="utf-8")
+              raise SystemExit()
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+          lines = ["## Deep review", "", f"- status: **{report['status']}**", f"- mode: `{report['mode']}`"]
+          structural = report.get("structural")
+          if structural:
+              lines.append(
+                  f"- catalog diff: +{len(structural['added'])} / "
+                  f"~{len(structural['modified'])} / -{len(structural['removed'])}"
+              )
+          provenance = report.get("provenance")
+          if provenance:
+              lines.append(
+                  f"- provenance: checked={provenance['checked']}, "
+                  f"supported={provenance['supported']}, review_flags={len(provenance['review_flags'])}, "
+                  f"provider_errors={provenance['provider_errors']}"
+              )
+          live = report.get("live_osu")
+          if live:
+              lines.append(f"- live osu!: checked={live['checked']}, failures={len(live['failures'])}")
+          if report["errors"]:
+              lines += ["", "### Errors", ""] + [f"- {item}" for item in report["errors"]]
+          summary.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+      - name: Upload review report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deep-review-report-${{ github.run_id }}
+          path: deep-review-report.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/deep-review.yml
+++ b/.github/workflows/deep-review.yml
@@ -65,11 +65,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Resolve review parameters
@@ -161,7 +161,7 @@ jobs:
           PY
       - name: Upload review report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: deep-review-report-${{ github.run_id }}
           path: deep-review-report.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,11 @@ provenance. Please keep changes small and evidence-backed.
    by evidence. Do not guess from a character background.
 6. Run `make check` and `make build`.
 
+For a catalog pull request, also run `make audit-pr BASE=main`. Large
+addition-only passes should supply their audit document, expected addition
+count, and `FORBID_EXISTING_CHANGES=1`; see
+[`docs/deep-review.md`](docs/deep-review.md).
+
 For composition-centered completeness passes, follow
 [`docs/systematic-theme-audit-workflow.md`](docs/systematic-theme-audit-workflow.md).
 Theme/title search results are discovery evidence only: lock the composition

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: build assemble check test validate import-seeds audit-sources hydrate clean
+.PHONY: build assemble check test validate audit-pr import-seeds audit-sources hydrate clean
+
+BASE ?= main
+MODE ?= structural
+SCOPE ?= changed
+WORKERS ?= 4
 
 build:
 	python3 -m touhou_osu build
@@ -13,6 +18,15 @@ test:
 
 validate:
 	python3 -m touhou_osu validate
+
+audit-pr:
+	python3 -m touhou_osu.pr_audit --base-ref "$(BASE)" --mode "$(MODE)" --scope "$(SCOPE)" --workers "$(WORKERS)" \
+		$(if $(AUDIT_DOC),--audit-doc "$(AUDIT_DOC)") \
+		$(if $(EXPECTED_ADDITIONS),--expected-additions "$(EXPECTED_ADDITIONS)") \
+		$(if $(filter 1 true yes,$(FORBID_EXISTING_CHANGES)),--forbid-existing-changes) \
+		$(if $(filter 1 true yes,$(ALLOW_REMOVALS)),--allow-removals) \
+		$(if $(filter 1 true yes,$(REQUIRE_BASE_ANCESTOR)),--require-base-ancestor) \
+		$(if $(AUDIT_OUTPUT),--output "$(AUDIT_OUTPUT)")
 
 import-seeds:
 	python3 -m touhou_osu import-seeds --write

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Requires Python 3.11+ and otherwise uses only the standard library.
 make check          # schema validation and tests
 make build          # generate site, JSON, and CSV
 make assemble       # combine all shards into dist/catalog-full.json
+make audit-pr        # compare this catalog with a Git base (BASE=main by default)
 make audit-sources  # query every configured source without changing the catalog
 make import-seeds   # merge every configured source into the catalog
 make hydrate        # resolve incomplete public beatmapset metadata (no OAuth)
@@ -112,6 +113,10 @@ Source definitions, canonical URLs, safety floors, and trust policy live in
 floor so an upstream format change or truncated response fails closed instead
 of silently deleting coverage. See [SOURCES.md](SOURCES.md) for the complete
 inventory and current source audit.
+
+For large catalog changes, [`docs/deep-review.md`](docs/deep-review.md) documents
+base-aware structural checks, audit-document matching, and optional live
+provenance/osu! review.
 
 ## Automated discovery
 

--- a/docs/deep-review.md
+++ b/docs/deep-review.md
@@ -1,0 +1,40 @@
+# Catalog deep review
+
+`audit-pr` compares the working catalog with a Git base without modifying either tree. It keeps fast deterministic checks separate from live network review.
+
+## Local use
+
+The default structural review reports added, modified, and removed IDs. Removals fail closed unless explicitly allowed.
+
+```sh
+make audit-pr BASE=main
+```
+
+Large addition-only audits can lock their expected boundary and compare the `## Accepted beatmapsets` table in a source-audit document with the exact added-ID set:
+
+```sh
+make audit-pr \
+  BASE=main \
+  AUDIT_DOC=docs/source-audit-example.md \
+  EXPECTED_ADDITIONS=100 \
+  FORBID_EXISTING_CHANGES=1
+```
+
+Optional live modes are selected with `MODE=provenance`, `MODE=live-osu`, or `MODE=all`. `SCOPE=changed` checks additions and modified rows; `SCOPE=added` limits network work to new rows. Live osu! review requires `OSU_CLIENT_ID` and `OSU_CLIENT_SECRET`.
+
+## Review layers
+
+- `structural` is local and deterministic. It validates both catalogs, compares their ID sets and fields, rejects unapproved removals, and optionally checks exact audit-document IDs and expected counts.
+- `provenance` reuses the THBWiki and TouhouDB cross-checks for changed rows. Provider transport failures remain advisory, while actual red/ambiguous results and unsafe generic-source verification require review and fail this deep-review run.
+- `live-osu` requires every selected catalog row to exactly match both osu! API v2 and the public beatmapset page for ID, artist, title, creator, source, status, modes, and osu! last-updated timestamp.
+- `all` runs the layers in that order and skips expensive network checks when an earlier hard gate fails.
+
+An evidence item matching `provenance:*-multi-original` is an explicit component-level claim. Such a row must be `mixed` and retain at least two original themes. Multiple themes without that explicit claim remain valid for arrangement lineages such as Night of Knights.
+
+## GitHub Actions
+
+The `Deep review` workflow automatically runs the structural layer on relevant pull requests. Its manual `workflow_dispatch` entry exposes all four modes plus base, target ref, scope, audit-document, and expected-addition controls.
+
+The workflow is deliberately read-only. It never pushes a commit or updates a pull request, so its result does not depend on recursive workflow triggering. Manual deep review also requires the selected base to be an ancestor of the target ref; update stale review branches before spending network calls.
+
+The live mode executes code from the selected repository ref with repository secrets. Only dispatch it for trusted branches in this repository; pull-request-triggered runs never select a live mode.

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -151,6 +151,28 @@ class CatalogTests(unittest.TestCase):
         with self.assertRaisesRegex(CatalogError, "evidence"):
             entry(evidence=[]).validate()
 
+    def test_explicit_multi_original_provenance_requires_mixed_kind(self):
+        with self.assertRaisesRegex(CatalogError, "requires mixed kind"):
+            entry(
+                evidence=["provenance:arrangement-chronicle-multi-original"],
+                touhou_kind="arrangement",
+                original_themes=["Theme A", "Theme B"],
+            ).validate()
+
+    def test_explicit_multi_original_provenance_requires_multiple_themes(self):
+        with self.assertRaisesRegex(CatalogError, "requires multiple themes"):
+            entry(
+                evidence=["provenance:arrangement-chronicle-multi-original"],
+                touhou_kind="mixed",
+                original_themes=["Theme A"],
+            ).validate()
+
+    def test_multiple_themes_do_not_imply_mixed_without_explicit_component_evidence(self):
+        entry(
+            touhou_kind="arrangement",
+            original_themes=["Flowering Night", "Lunar Clock"],
+        ).validate()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pr_audit.py
+++ b/tests/test_pr_audit.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from touhou_osu.catalog import Catalog
+from touhou_osu.http import HttpError
 from touhou_osu.models import Entry
 from touhou_osu.pr_audit import (
     AuditError,
@@ -131,6 +132,25 @@ class PrAuditTests(unittest.TestCase):
         ):
             report = live_osu_audit(Catalog([item]), diff, scope="added", workers=1)
         self.assertIn("API/public-page drift: creator", report["failures"][0]["error"])
+
+    def test_live_osu_retries_public_page_rate_limit(self):
+        item = entry(2)
+        FakeApi.raw = {2: raw(item)}
+        page = '<script id="json-beatmapset" type="application/json">' + json.dumps(raw(item)) + "</script>"
+        diff = catalog_diff(Catalog(), Catalog([item]))
+        with patch("touhou_osu.pr_audit.OsuApi", FakeApi), patch(
+            "touhou_osu.pr_audit.get_text",
+            side_effect=[HttpError("HTTP 429 from public page"), page],
+        ):
+            report = live_osu_audit(
+                Catalog([item]),
+                diff,
+                scope="added",
+                workers=1,
+                public_interval=0,
+                rate_limit_backoff=0,
+            )
+        self.assertEqual(report, {"checked": 1, "failures": [], "errors": []})
 
 
 if __name__ == "__main__":

--- a/tests/test_pr_audit.py
+++ b/tests/test_pr_audit.py
@@ -1,0 +1,137 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from touhou_osu.catalog import Catalog
+from touhou_osu.models import Entry
+from touhou_osu.pr_audit import (
+    AuditError,
+    accepted_ids_from_audit_document,
+    catalog_diff,
+    live_osu_audit,
+    structural_audit,
+)
+
+
+def entry(beatmapset_id, **changes):
+    values = {
+        "beatmapset_id": beatmapset_id,
+        "artist": "ZUN",
+        "title": f"Theme {beatmapset_id}",
+        "creator": "Mapper",
+        "source": "Touhou Project",
+        "status": "ranked",
+        "modes": ["osu"],
+        "evidence": ["manual:verified"],
+        "confidence": "verified",
+        "last_checked": "2026-09-06",
+        "osu_last_updated": "2026-09-01T00:00:00Z",
+    }
+    values.update(changes)
+    return Entry(**values)
+
+
+class FakeApi:
+    raw = {}
+
+    @classmethod
+    def from_env(cls):
+        return cls()
+
+    def token(self):
+        return "token"
+
+    def beatmapset(self, beatmapset_id):
+        return self.raw[beatmapset_id]
+
+
+def raw(item):
+    return {
+        "id": item.beatmapset_id,
+        "artist": item.artist,
+        "title": item.title,
+        "creator": item.creator,
+        "source": item.source,
+        "status": item.status,
+        "last_updated": item.osu_last_updated,
+        "tags": "touhou",
+        "beatmaps": [{"mode": mode} for mode in item.modes],
+    }
+
+
+class PrAuditTests(unittest.TestCase):
+    def test_catalog_diff_reports_added_removed_and_changed_fields(self):
+        base = Catalog([entry(1), entry(2)])
+        current = Catalog([entry(2, title="Changed"), entry(3)])
+        diff = catalog_diff(base, current)
+        self.assertEqual(diff["added"], [3])
+        self.assertEqual(diff["removed"], [1])
+        self.assertEqual(diff["modified"], [2])
+        self.assertEqual(diff["changed_fields"], {"2": ["title"]})
+
+    def test_structural_audit_is_fail_closed_for_removals(self):
+        diff = catalog_diff(Catalog([entry(1)]), Catalog())
+        result = structural_audit(diff)
+        self.assertIn("removals", result["errors"][0])
+
+    def test_structural_audit_can_forbid_existing_row_changes(self):
+        diff = catalog_diff(Catalog([entry(1)]), Catalog([entry(1, title="Changed")]))
+        result = structural_audit(diff, forbid_existing_changes=True)
+        self.assertIn("pre-existing rows changed", result["errors"][0])
+
+    def test_audit_document_ids_must_equal_additions(self):
+        document = """# Audit\n\n## Accepted beatmapsets\n\n| ID | Title |\n| ---: | --- |\n| 2 | Two |\n| 3 | Three |\n\n## Boundary\n"""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "audit.md"
+            path.write_text(document, encoding="utf-8")
+            self.assertEqual(accepted_ids_from_audit_document(path), [2, 3])
+            diff = catalog_diff(Catalog([entry(1)]), Catalog([entry(1), entry(2), entry(3)]))
+            self.assertEqual(structural_audit(diff, audit_document=path)["errors"], [])
+
+    def test_audit_document_rejects_duplicate_ids(self):
+        document = """## Accepted beatmapsets\n\n| ID |\n| ---: |\n| 2 |\n| 2 |\n"""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "audit.md"
+            path.write_text(document, encoding="utf-8")
+            with self.assertRaisesRegex(AuditError, "duplicate"):
+                accepted_ids_from_audit_document(path)
+
+    def test_live_osu_requires_catalog_api_and_public_page_to_match(self):
+        item = entry(2)
+        FakeApi.raw = {2: raw(item)}
+        page = '<script id="json-beatmapset" type="application/json">' + json.dumps(raw(item)) + "</script>"
+        diff = catalog_diff(Catalog(), Catalog([item]))
+        with patch("touhou_osu.pr_audit.OsuApi", FakeApi), patch(
+            "touhou_osu.pr_audit.get_text", return_value=page
+        ):
+            report = live_osu_audit(Catalog([item]), diff, scope="added", workers=1)
+        self.assertEqual(report, {"checked": 1, "failures": [], "errors": []})
+
+    def test_live_osu_reports_catalog_drift(self):
+        item = entry(2)
+        api_item = entry(2, title="Live title")
+        FakeApi.raw = {2: raw(api_item)}
+        diff = catalog_diff(Catalog(), Catalog([item]))
+        with patch("touhou_osu.pr_audit.OsuApi", FakeApi):
+            report = live_osu_audit(Catalog([item]), diff, scope="added", workers=1)
+        self.assertEqual(report["checked"], 1)
+        self.assertEqual(report["failures"][0]["beatmapset_id"], 2)
+        self.assertIn("catalog/API drift: title", report["failures"][0]["error"])
+
+    def test_live_osu_reports_public_page_drift(self):
+        item = entry(2)
+        page_item = entry(2, creator="Other mapper")
+        FakeApi.raw = {2: raw(item)}
+        page = '<script id="json-beatmapset" type="application/json">' + json.dumps(raw(page_item)) + "</script>"
+        diff = catalog_diff(Catalog(), Catalog([item]))
+        with patch("touhou_osu.pr_audit.OsuApi", FakeApi), patch(
+            "touhou_osu.pr_audit.get_text", return_value=page
+        ):
+            report = live_osu_audit(Catalog([item]), diff, scope="added", workers=1)
+        self.assertIn("API/public-page drift: creator", report["failures"][0]["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/touhou_osu/models.py
+++ b/touhou_osu/models.py
@@ -106,6 +106,19 @@ class Entry:
             raise CatalogError(f"beatmapset {self.beatmapset_id}: unknown confidence {self.confidence!r}")
         if not self.evidence:
             raise CatalogError(f"beatmapset {self.beatmapset_id}: evidence is required")
+        multi_original = [
+            item
+            for item in self.evidence
+            if item.startswith("provenance:") and item.endswith("-multi-original")
+        ]
+        if multi_original and self.touhou_kind != "mixed":
+            raise CatalogError(
+                f"beatmapset {self.beatmapset_id}: explicit multi-original provenance requires mixed kind"
+            )
+        if multi_original and len(self.original_themes) < 2:
+            raise CatalogError(
+                f"beatmapset {self.beatmapset_id}: explicit multi-original provenance requires multiple themes"
+            )
         _validate_date(self.last_checked, "last_checked")
         _validate_date(self.osu_last_updated, "osu_last_updated", timestamp=True)
 

--- a/touhou_osu/pr_audit.py
+++ b/touhou_osu/pr_audit.py
@@ -8,12 +8,14 @@ import re
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
 from .catalog import Catalog
-from .http import get_text
+from .http import HttpError, get_text
 from .osu_api import OsuApi, entry_from_osu
 from .provenance import _report_payload, audit_entries, new_generic_verification_violations
 from .sources import parse_beatmapset_page
@@ -32,6 +34,27 @@ AUDIT_ROW_RE = re.compile(r"^\|\s*(\d+)\s*\|")
 
 class AuditError(RuntimeError):
     pass
+
+
+class RequestPacer:
+    """Reserve globally spaced request slots across worker threads."""
+
+    def __init__(self, interval: float) -> None:
+        self.interval = interval
+        self.next_request = 0.0
+        self.lock = threading.Lock()
+
+    def wait(self) -> None:
+        with self.lock:
+            now = time.monotonic()
+            delay = max(0.0, self.next_request - now)
+            self.next_request = max(now, self.next_request) + self.interval
+        if delay:
+            time.sleep(delay)
+
+    def defer(self, delay: float) -> None:
+        with self.lock:
+            self.next_request = max(self.next_request, time.monotonic() + delay)
 
 
 @dataclass(frozen=True)
@@ -219,13 +242,40 @@ def _identity_mismatches(left, right) -> list[str]:
     return [field for field in left_identity if left_identity[field] != right_identity[field]]
 
 
-def live_osu_audit(current: Catalog, diff: dict, *, scope: str, workers: int) -> dict:
+def live_osu_audit(
+    current: Catalog,
+    diff: dict,
+    *,
+    scope: str,
+    workers: int,
+    public_interval: float = 0.5,
+    rate_limit_backoff: float = 30.0,
+) -> dict:
     ids = _target_ids(diff, scope)
     if not ids:
         return {"checked": 0, "failures": [], "errors": []}
 
     api = OsuApi.from_env()
     api.token()
+    public_pacer = RequestPacer(public_interval)
+
+    def public_entry(beatmapset_id: int, stored):
+        for attempt in range(2):
+            public_pacer.wait()
+            try:
+                page_raw = parse_beatmapset_page(
+                    get_text(f"https://osu.ppy.sh/beatmapsets/{beatmapset_id}")
+                )
+                return entry_from_osu(
+                    page_raw,
+                    evidence=stored.evidence,
+                    confidence=stored.confidence,
+                )
+            except HttpError as exc:
+                if "HTTP 429" not in str(exc) or attempt == 1:
+                    raise
+                public_pacer.defer(rate_limit_backoff)
+        raise AssertionError("unreachable")
 
     def verify(beatmapset_id: int) -> dict:
         stored = current.entries[beatmapset_id]
@@ -238,18 +288,14 @@ def live_osu_audit(current: Catalog, diff: dict, *, scope: str, workers: int) ->
         if stored_mismatches:
             raise AuditError("catalog/API drift: " + ", ".join(stored_mismatches))
 
-        page_raw = parse_beatmapset_page(get_text(f"https://osu.ppy.sh/beatmapsets/{beatmapset_id}"))
-        page_entry = entry_from_osu(
-            page_raw,
-            evidence=stored.evidence,
-            confidence=stored.confidence,
-        )
+        page_entry = public_entry(beatmapset_id, stored)
         page_mismatches = _identity_mismatches(api_entry, page_entry)
         if page_mismatches:
             raise AuditError("API/public-page drift: " + ", ".join(page_mismatches))
         return {"beatmapset_id": beatmapset_id, "status": "exact"}
 
     failures: list[dict] = []
+    completed = 0
     with ThreadPoolExecutor(max_workers=workers) as executor:
         futures = {executor.submit(verify, item): item for item in ids}
         for future in as_completed(futures):
@@ -258,6 +304,9 @@ def live_osu_audit(current: Catalog, diff: dict, *, scope: str, workers: int) ->
                 future.result()
             except Exception as exc:
                 failures.append({"beatmapset_id": beatmapset_id, "error": str(exc)})
+            completed += 1
+            if completed % 50 == 0 or completed == len(ids):
+                print(f"Live osu!: checked={completed}/{len(ids)} failures={len(failures)}", flush=True)
     failures.sort(key=lambda item: item["beatmapset_id"])
     errors = [f"live osu! identity failures: {[item['beatmapset_id'] for item in failures[:20]]}"] if failures else []
     return {"checked": len(ids), "failures": failures, "errors": errors}
@@ -336,6 +385,7 @@ def main(argv: list[str] | None = None) -> int:
         diff = catalog_diff(base, current)
 
         if args.mode in {"structural", "all"}:
+            print("Running structural catalog review...", flush=True)
             audit_document = args.audit_doc
             if audit_document is not None and not audit_document.is_absolute():
                 audit_document = repository / audit_document
@@ -349,12 +399,14 @@ def main(argv: list[str] | None = None) -> int:
             report["errors"].extend(report["structural"]["errors"])
 
         if not report["errors"] and args.mode in {"provenance", "all"}:
+            print(f"Running provenance review for {len(_target_ids(diff, args.scope))} rows...", flush=True)
             report["provenance"] = provenance_audit(
                 base, current, diff, scope=args.scope, workers=args.workers
             )
             report["errors"].extend(report["provenance"]["errors"])
 
         if not report["errors"] and args.mode in {"live-osu", "all"}:
+            print(f"Running live osu! review for {len(_target_ids(diff, args.scope))} rows...", flush=True)
             report["live_osu"] = live_osu_audit(
                 current, diff, scope=args.scope, workers=args.workers
             )

--- a/touhou_osu/pr_audit.py
+++ b/touhou_osu/pr_audit.py
@@ -1,0 +1,375 @@
+"""Base-aware structural, provenance, and live osu! review for catalog changes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+from .catalog import Catalog
+from .http import get_text
+from .osu_api import OsuApi, entry_from_osu
+from .provenance import _report_payload, audit_entries, new_generic_verification_violations
+from .sources import parse_beatmapset_page
+
+IDENTITY_FIELDS = (
+    "beatmapset_id",
+    "artist",
+    "title",
+    "creator",
+    "source",
+    "status",
+    "osu_last_updated",
+)
+AUDIT_ROW_RE = re.compile(r"^\|\s*(\d+)\s*\|")
+
+
+class AuditError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RevisionContext:
+    head: str
+    base_tip: str
+    merge_base: str
+
+    @property
+    def base_is_ancestor(self) -> bool:
+        return self.base_tip == self.merge_base
+
+
+def _git(repository: Path, *args: str, text: bool = True):
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(repository), *args],
+            text=text,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() if isinstance(exc.stderr, str) else ""
+        raise AuditError(f"git {' '.join(args)} failed: {detail or exc}") from exc
+
+
+def revision_context(repository: Path, base_ref: str) -> RevisionContext:
+    repository = repository.resolve()
+    head = _git(repository, "rev-parse", "HEAD").strip()
+    base_tip = _git(repository, "rev-parse", "--verify", f"{base_ref}^{{commit}}").strip()
+    merge_base = _git(repository, "merge-base", head, base_tip).strip()
+    return RevisionContext(head=head, base_tip=base_tip, merge_base=merge_base)
+
+
+def _catalog_relative_path(repository: Path, catalog_path: Path) -> Path:
+    absolute = catalog_path.resolve() if catalog_path.is_absolute() else (repository / catalog_path).resolve()
+    try:
+        return absolute.relative_to(repository.resolve())
+    except ValueError as exc:
+        raise AuditError("catalog must be inside the Git repository") from exc
+
+
+def load_catalog_at(repository: Path, revision: str, catalog_path: Path) -> Catalog:
+    """Materialize one catalog directory from Git without checking it out."""
+
+    relative = _catalog_relative_path(repository, catalog_path)
+    paths = [
+        line
+        for line in _git(
+            repository,
+            "ls-tree",
+            "-r",
+            "--name-only",
+            revision,
+            "--",
+            relative.as_posix(),
+        ).splitlines()
+        if line.endswith(".json")
+    ]
+    if not paths:
+        raise AuditError(f"no catalog JSON files found at {revision}:{relative}")
+
+    with tempfile.TemporaryDirectory(prefix="touhou-osu-audit-") as directory:
+        root = Path(directory)
+        for path_text in paths:
+            target = root / path_text
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(_git(repository, "show", f"{revision}:{path_text}", text=False))
+        return Catalog.load(root / relative)
+
+
+def catalog_diff(base: Catalog, current: Catalog) -> dict:
+    base_ids = set(base.entries)
+    current_ids = set(current.entries)
+    added = sorted(current_ids - base_ids)
+    removed = sorted(base_ids - current_ids)
+    changed_fields: dict[str, list[str]] = {}
+    for beatmapset_id in sorted(base_ids & current_ids):
+        before = base.entries[beatmapset_id].to_dict()
+        after = current.entries[beatmapset_id].to_dict()
+        fields = sorted(field for field in set(before) | set(after) if before.get(field) != after.get(field))
+        if fields:
+            changed_fields[str(beatmapset_id)] = fields
+    return {
+        "base_entries": len(base.entries),
+        "current_entries": len(current.entries),
+        "added": added,
+        "removed": removed,
+        "modified": [int(item) for item in changed_fields],
+        "changed_fields": changed_fields,
+    }
+
+
+def accepted_ids_from_audit_document(path: Path) -> list[int]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    try:
+        start = lines.index("## Accepted beatmapsets") + 1
+    except ValueError as exc:
+        raise AuditError(f"{path}: missing '## Accepted beatmapsets' section") from exc
+
+    accepted: list[int] = []
+    for line in lines[start:]:
+        if line.startswith("## "):
+            break
+        match = AUDIT_ROW_RE.match(line)
+        if match:
+            accepted.append(int(match.group(1)))
+    if not accepted:
+        raise AuditError(f"{path}: accepted beatmapset table is empty")
+    duplicates = sorted(item for item in set(accepted) if accepted.count(item) > 1)
+    if duplicates:
+        raise AuditError(f"{path}: duplicate accepted IDs: {duplicates}")
+    return accepted
+
+
+def structural_audit(
+    diff: dict,
+    *,
+    audit_document: Path | None = None,
+    expected_additions: int | None = None,
+    allow_removals: bool = False,
+    forbid_existing_changes: bool = False,
+) -> dict:
+    errors: list[str] = []
+    if diff["removed"] and not allow_removals:
+        errors.append(f"catalog removals require explicit approval: {diff['removed'][:20]}")
+    if expected_additions is not None and len(diff["added"]) != expected_additions:
+        errors.append(f"expected {expected_additions} additions, found {len(diff['added'])}")
+    if forbid_existing_changes and diff["modified"]:
+        errors.append(f"pre-existing rows changed: {diff['modified'][:20]}")
+
+    audit_ids: list[int] | None = None
+    if audit_document is not None:
+        try:
+            audit_ids = accepted_ids_from_audit_document(audit_document)
+            if sorted(audit_ids) != diff["added"]:
+                missing = sorted(set(diff["added"]) - set(audit_ids))
+                extra = sorted(set(audit_ids) - set(diff["added"]))
+                errors.append(
+                    "audit document accepted IDs do not match catalog additions: "
+                    f"missing={missing[:20]} extra={extra[:20]}"
+                )
+        except (AuditError, OSError) as exc:
+            errors.append(str(exc))
+
+    return {
+        **diff,
+        "audit_document": str(audit_document) if audit_document else None,
+        "audit_document_ids": audit_ids,
+        "errors": errors,
+    }
+
+
+def _target_ids(diff: dict, scope: str) -> list[int]:
+    if scope == "added":
+        return diff["added"]
+    return sorted(set(diff["added"]) | set(diff["modified"]))
+
+
+def provenance_audit(base: Catalog, current: Catalog, diff: dict, *, scope: str, workers: int) -> dict:
+    targets = [current.entries[item] for item in _target_ids(diff, scope)]
+    audits = audit_entries(targets, workers=workers)
+    violations = new_generic_verification_violations(current, base)
+    payload = _report_payload(audits, violations)
+    review_flags = [
+        audit.beatmapset_id for audit in audits if audit.verdict in {"red_flag", "ambiguous"}
+    ]
+    errors: list[str] = []
+    if violations:
+        errors.append(f"unsafe generic-source verification: {violations[:20]}")
+    if review_flags:
+        errors.append(f"external provenance needs review: {review_flags[:20]}")
+    payload["review_flags"] = review_flags
+    payload["errors"] = errors
+    return payload
+
+
+def _identity(entry) -> dict:
+    result = {field: getattr(entry, field) for field in IDENTITY_FIELDS}
+    result["modes"] = sorted(entry.modes)
+    return result
+
+
+def _identity_mismatches(left, right) -> list[str]:
+    left_identity, right_identity = _identity(left), _identity(right)
+    return [field for field in left_identity if left_identity[field] != right_identity[field]]
+
+
+def live_osu_audit(current: Catalog, diff: dict, *, scope: str, workers: int) -> dict:
+    ids = _target_ids(diff, scope)
+    if not ids:
+        return {"checked": 0, "failures": [], "errors": []}
+
+    api = OsuApi.from_env()
+    api.token()
+
+    def verify(beatmapset_id: int) -> dict:
+        stored = current.entries[beatmapset_id]
+        api_entry = entry_from_osu(
+            api.beatmapset(beatmapset_id),
+            evidence=stored.evidence,
+            confidence=stored.confidence,
+        )
+        stored_mismatches = _identity_mismatches(stored, api_entry)
+        if stored_mismatches:
+            raise AuditError("catalog/API drift: " + ", ".join(stored_mismatches))
+
+        page_raw = parse_beatmapset_page(get_text(f"https://osu.ppy.sh/beatmapsets/{beatmapset_id}"))
+        page_entry = entry_from_osu(
+            page_raw,
+            evidence=stored.evidence,
+            confidence=stored.confidence,
+        )
+        page_mismatches = _identity_mismatches(api_entry, page_entry)
+        if page_mismatches:
+            raise AuditError("API/public-page drift: " + ", ".join(page_mismatches))
+        return {"beatmapset_id": beatmapset_id, "status": "exact"}
+
+    failures: list[dict] = []
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(verify, item): item for item in ids}
+        for future in as_completed(futures):
+            beatmapset_id = futures[future]
+            try:
+                future.result()
+            except Exception as exc:
+                failures.append({"beatmapset_id": beatmapset_id, "error": str(exc)})
+    failures.sort(key=lambda item: item["beatmapset_id"])
+    errors = [f"live osu! identity failures: {[item['beatmapset_id'] for item in failures[:20]]}"] if failures else []
+    return {"checked": len(ids), "failures": failures, "errors": errors}
+
+
+def _write_report(path: Path | None, report: dict) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _print_summary(report: dict) -> None:
+    print(f"Deep review: status={report['status']} mode={report['mode']}")
+    structural = report.get("structural")
+    if structural:
+        print(
+            "Catalog diff: "
+            f"base={structural['base_entries']} current={structural['current_entries']} "
+            f"added={len(structural['added'])} modified={len(structural['modified'])} "
+            f"removed={len(structural['removed'])}"
+        )
+    provenance = report.get("provenance")
+    if provenance:
+        print(
+            "Provenance: "
+            f"checked={provenance['checked']} supported={provenance['supported']} "
+            f"review_flags={len(provenance['review_flags'])} "
+            f"provider_errors={provenance['provider_errors']}"
+        )
+    live = report.get("live_osu")
+    if live:
+        print(f"Live osu!: checked={live['checked']} failures={len(live['failures'])}")
+    for error in report["errors"]:
+        print(f"error: {error}", file=sys.stderr)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--repository", type=Path, default=Path("."))
+    result.add_argument("--catalog", type=Path, default=Path("data/catalog"))
+    result.add_argument("--base-ref", default="main")
+    result.add_argument("--mode", choices=("structural", "provenance", "live-osu", "all"), default="structural")
+    result.add_argument("--scope", choices=("added", "changed"), default="changed")
+    result.add_argument("--workers", type=int, default=4)
+    result.add_argument("--audit-doc", type=Path)
+    result.add_argument("--expected-additions", type=int)
+    result.add_argument("--allow-removals", action="store_true")
+    result.add_argument("--forbid-existing-changes", action="store_true")
+    result.add_argument("--require-base-ancestor", action="store_true")
+    result.add_argument("--output", type=Path)
+    result.add_argument("--json", action="store_true", help="print the complete report to stdout")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    report: dict = {"mode": args.mode, "status": "failed", "errors": []}
+    try:
+        if args.workers < 1:
+            raise AuditError("workers must be at least 1")
+        repository = args.repository.resolve()
+        context = revision_context(repository, args.base_ref)
+        report["revision"] = {
+            "head": context.head,
+            "base_tip": context.base_tip,
+            "merge_base": context.merge_base,
+            "base_is_ancestor": context.base_is_ancestor,
+        }
+        if args.require_base_ancestor and not context.base_is_ancestor:
+            raise AuditError(f"{args.base_ref} is not an ancestor of HEAD; update the review branch first")
+
+        current_path = args.catalog if args.catalog.is_absolute() else repository / args.catalog
+        current = Catalog.load(current_path)
+        base = load_catalog_at(repository, context.merge_base, args.catalog)
+        diff = catalog_diff(base, current)
+
+        if args.mode in {"structural", "all"}:
+            audit_document = args.audit_doc
+            if audit_document is not None and not audit_document.is_absolute():
+                audit_document = repository / audit_document
+            report["structural"] = structural_audit(
+                diff,
+                audit_document=audit_document,
+                expected_additions=args.expected_additions,
+                allow_removals=args.allow_removals,
+                forbid_existing_changes=args.forbid_existing_changes,
+            )
+            report["errors"].extend(report["structural"]["errors"])
+
+        if not report["errors"] and args.mode in {"provenance", "all"}:
+            report["provenance"] = provenance_audit(
+                base, current, diff, scope=args.scope, workers=args.workers
+            )
+            report["errors"].extend(report["provenance"]["errors"])
+
+        if not report["errors"] and args.mode in {"live-osu", "all"}:
+            report["live_osu"] = live_osu_audit(
+                current, diff, scope=args.scope, workers=args.workers
+            )
+            report["errors"].extend(report["live_osu"]["errors"])
+    except Exception as exc:
+        report["errors"].append(str(exc))
+
+    report["status"] = "passed" if not report["errors"] else "failed"
+    _write_report(args.output, report)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        _print_summary(report)
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a reusable, base-aware catalog audit and a read-only Deep Review workflow.

- structural catalog diff with fail-closed removals
- optional exact audit-document/addition matching
- advisory external provenance review with hard review flags
- exact osu! API and public-page identity verification
- source-aware multi-original regression invariant
- automatic structural PR check plus manual structural/provenance/live-osu/all modes

Local verification:
- 88 tests pass
- make build passes
- actionlint passes
- PR #36 historical replay confirms 356 additions, zero old-row changes, and exact audit-document ID parity