### PR TITLE
feat: acknowledge reviewed provenance exceptions

### DIFF
--- a/.github/workflows/deep-review.yml
+++ b/.github/workflows/deep-review.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/deep-review.yml"
       - "Makefile"
+      - "config/provenance-review-exceptions.json"
       - "data/catalog/**"
       - "docs/source-audit-*.md"
       - "tests/**"
@@ -150,6 +151,7 @@ jobs:
               lines.append(
                   f"- provenance: checked={provenance['checked']}, "
                   f"supported={provenance['supported']}, review_flags={len(provenance['review_flags'])}, "
+                  f"acknowledged={len(provenance['acknowledged_review_flags'])}, "
                   f"provider_errors={provenance['provider_errors']}"
               )
           live = report.get("live_osu")

--- a/config/provenance-review-exceptions.json
+++ b/config/provenance-review-exceptions.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "exceptions": [
+    {
+      "beatmapset_id": 397764,
+      "artist": "Akiyama Uni",
+      "title": "Kaoru Juyouka",
+      "provider": "touhoudb",
+      "provider_id": "636",
+      "relation": "non_zun_original",
+      "reason": "Official Touhou 10.5 / Scarlet Weather Rhapsody original composed by Akiyama Uni; non-ZUN authorship is expected here, not evidence of a non-Touhou composition.",
+      "evidence_urls": [
+        "https://thwiki.cc/%E6%95%A3%E5%8F%91%E7%9D%80%E9%A6%99%E6%B0%94%E7%9A%84%E6%A0%91%E5%8F%B6%E8%8A%B1",
+        "https://shop.akbh.jp/products/2100000000203"
+      ]
+    }
+  ]
+}

--- a/docs/deep-review.md
+++ b/docs/deep-review.md
@@ -29,6 +29,17 @@ Optional live modes are selected with `MODE=provenance`, `MODE=live-osu`, or `MO
 - `live-osu` requires every selected catalog row to exactly match both osu! API v2 and the public beatmapset page for ID, artist, title, creator, source, status, modes, and osu! last-updated timestamp.
 - `all` runs the layers in that order and skips expensive network checks when an earlier hard gate fails.
 
+Exact, manually resolved provider contradictions can be recorded in
+`config/provenance-review-exceptions.json`. Each reviewed exception is bound to
+the beatmapset ID and expected artist/title plus the provider, provider record
+ID, and relation. A match remains visible under `acknowledged_review_flags` but
+does not block the next review layer. Any identity change, new provider signal,
+or unmatched contradiction still fails closed. Exceptions require a review
+reason and supporting HTTP(S) evidence URLs; do not add unresolved or transient
+provider results. The registry is an optional overlay, not a complete source of
+truth: if it is absent, Deep Review runs with zero acknowledgements, and any
+unlisted provider contradiction continues to fail closed.
+
 An evidence item matching `provenance:*-multi-original` is an explicit component-level claim. Such a row must be `mixed` and retain at least two original themes. Multiple themes without that explicit claim remain valid for arrangement lineages such as Night of Knights.
 
 ## GitHub Actions

--- a/docs/external-provenance.md
+++ b/docs/external-provenance.md
@@ -18,6 +18,12 @@ Useful signals:
 
 A TouhouDB hit alone never promotes or excludes a catalog entry.
 
+Deep Review may acknowledge a stable false-positive provider relation through
+the version-controlled `config/provenance-review-exceptions.json` registry. The
+raw provider verdict remains in the report. A reviewed exception suppresses
+only its exact beatmapset identity, provider record, and relation; it is not a
+general provider allowlist or a complete catalog of legitimate edge cases.
+
 ### THBWiki music data API
 
 The audit uses the public `album.php` track-search (`st`) and track-detail (`gt`) endpoints. It first requires an exact normalized track title. The detail request retrieves `circle`, `artist`, `arrange`, `ogmusic`, and `ogwork`.

--- a/tests/test_pr_audit.py
+++ b/tests/test_pr_audit.py
@@ -9,11 +9,16 @@ from touhou_osu.http import HttpError
 from touhou_osu.models import Entry
 from touhou_osu.pr_audit import (
     AuditError,
+    ProvenanceReviewException,
     accepted_ids_from_audit_document,
     catalog_diff,
     live_osu_audit,
+    load_provenance_review_exceptions,
+    provenance_audit,
+    resolve_provenance_review_exceptions,
     structural_audit,
 )
+from touhou_osu.provenance import ProvenanceAudit, ProvenanceHit
 
 
 def entry(beatmapset_id, **changes):
@@ -62,6 +67,41 @@ def raw(item):
     }
 
 
+def review_exception(**changes):
+    values = {
+        "beatmapset_id": 2,
+        "artist": "Akiyama Uni",
+        "title": "Kaoru Juyouka",
+        "provider": "touhoudb",
+        "provider_id": "636",
+        "relation": "non_zun_original",
+        "reason": "Reviewed official Touhou original.",
+        "evidence_urls": ("https://example.test/evidence",),
+    }
+    values.update(changes)
+    return ProvenanceReviewException(**values)
+
+
+def contradiction_audit(*hits):
+    return ProvenanceAudit(
+        beatmapset_id=2,
+        artist="Akiyama Uni",
+        title="Kaoru Juyouka",
+        source="Touhou Project",
+        confidence="verified",
+        hits=list(hits),
+    )
+
+
+def contradiction(provider="touhoudb", provider_id="636", relation="non_zun_original"):
+    return ProvenanceHit(
+        provider=provider,
+        verdict="contradicts",
+        relation=relation,
+        provider_id=provider_id,
+    )
+
+
 class PrAuditTests(unittest.TestCase):
     def test_catalog_diff_reports_added_removed_and_changed_fields(self):
         base = Catalog([entry(1), entry(2)])
@@ -98,6 +138,124 @@ class PrAuditTests(unittest.TestCase):
             path.write_text(document, encoding="utf-8")
             with self.assertRaisesRegex(AuditError, "duplicate"):
                 accepted_ids_from_audit_document(path)
+
+    def test_repository_provenance_exception_is_valid_and_exact(self):
+        path = Path(__file__).resolve().parents[1] / "config/provenance-review-exceptions.json"
+        exceptions = load_provenance_review_exceptions(path)
+        self.assertEqual(len(exceptions), 1)
+        self.assertEqual(
+            exceptions[0].key,
+            (397764, "touhoudb", "636", "non_zun_original"),
+        )
+        self.assertEqual(exceptions[0].artist, "Akiyama Uni")
+        self.assertEqual(exceptions[0].title, "Kaoru Juyouka")
+
+    def test_provenance_exception_acknowledges_only_exact_contradiction(self):
+        item = entry(2, artist="Akiyama Uni", title="Kaoru Juyouka")
+        base, current = Catalog(), Catalog([item])
+        diff = catalog_diff(base, current)
+        audit = contradiction_audit(contradiction())
+        with patch("touhou_osu.pr_audit.audit_entries", return_value=[audit]):
+            report = provenance_audit(
+                base,
+                current,
+                diff,
+                scope="added",
+                workers=1,
+                exceptions=(review_exception(),),
+            )
+        self.assertEqual(report["review_flags"], [])
+        self.assertEqual(report["errors"], [])
+        self.assertEqual(report["red_flags"], 1)
+        self.assertEqual(report["acknowledged_review_flags"], [review_exception().to_dict()])
+
+    def test_provenance_exception_mismatch_remains_fail_closed(self):
+        item = entry(2, artist="Akiyama Uni", title="Kaoru Juyouka")
+        base, current = Catalog(), Catalog([item])
+        diff = catalog_diff(base, current)
+        mismatches = (
+            review_exception(beatmapset_id=3),
+            review_exception(artist="Other Artist"),
+            review_exception(title="Other Title"),
+            review_exception(provider="thbwiki"),
+            review_exception(provider_id="999"),
+            review_exception(relation="other_relation"),
+        )
+        for exception in mismatches:
+            with self.subTest(exception=exception), patch(
+                "touhou_osu.pr_audit.audit_entries",
+                return_value=[contradiction_audit(contradiction())],
+            ):
+                report = provenance_audit(
+                    base,
+                    current,
+                    diff,
+                    scope="added",
+                    workers=1,
+                    exceptions=(exception,),
+                )
+                self.assertEqual(report["review_flags"], [2])
+                self.assertEqual(report["acknowledged_review_flags"], [])
+                self.assertIn("external provenance needs review", report["errors"][0])
+
+    def test_new_contradiction_still_fails_beside_acknowledged_one(self):
+        item = entry(2, artist="Akiyama Uni", title="Kaoru Juyouka")
+        base, current = Catalog(), Catalog([item])
+        diff = catalog_diff(base, current)
+        audit = contradiction_audit(
+            contradiction(),
+            contradiction(provider="other-provider", provider_id="new", relation="new_relation"),
+        )
+        with patch("touhou_osu.pr_audit.audit_entries", return_value=[audit]):
+            report = provenance_audit(
+                base,
+                current,
+                diff,
+                scope="added",
+                workers=1,
+                exceptions=(review_exception(),),
+            )
+        self.assertEqual(report["review_flags"], [2])
+        self.assertEqual(report["acknowledged_review_flags"], [review_exception().to_dict()])
+        self.assertIn("external provenance needs review", report["errors"][0])
+
+    def test_provenance_exception_file_rejects_unsafe_records(self):
+        valid = review_exception().to_dict()
+        invalid_records = (
+            {**valid, "reason": ""},
+            {**valid, "evidence_urls": []},
+            {**valid, "evidence_urls": ["not-a-url"]},
+            {**valid, "provider": "TouhouDB"},
+            {**valid, "unexpected": "field"},
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "exceptions.json"
+            for record in invalid_records:
+                with self.subTest(record=record):
+                    path.write_text(
+                        json.dumps({"schema_version": 1, "exceptions": [record]}),
+                        encoding="utf-8",
+                    )
+                    with self.assertRaises(AuditError):
+                        load_provenance_review_exceptions(path)
+
+    def test_provenance_exception_file_rejects_duplicate_keys(self):
+        record = review_exception().to_dict()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "exceptions.json"
+            path.write_text(
+                json.dumps({"schema_version": 1, "exceptions": [record, record]}),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(AuditError, "duplicate provenance exception"):
+                load_provenance_review_exceptions(path)
+
+    def test_missing_default_exception_registry_means_no_exceptions(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repository = Path(directory)
+            self.assertEqual(resolve_provenance_review_exceptions(repository, None), ())
+            with self.assertRaisesRegex(AuditError, "cannot load provenance exceptions"):
+                resolve_provenance_review_exceptions(repository, Path("missing.json"))
 
     def test_live_osu_requires_catalog_api_and_public_page_to_match(self):
         item = entry(2)

--- a/touhou_osu/pr_audit.py
+++ b/touhou_osu/pr_audit.py
@@ -13,11 +13,18 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .catalog import Catalog
 from .http import HttpError, get_text
 from .osu_api import OsuApi, entry_from_osu
-from .provenance import _report_payload, audit_entries, new_generic_verification_violations
+from .provenance import (
+    ProvenanceAudit,
+    ProvenanceHit,
+    _report_payload,
+    audit_entries,
+    new_generic_verification_violations,
+)
 from .sources import parse_beatmapset_page
 
 IDENTITY_FIELDS = (
@@ -30,10 +37,136 @@ IDENTITY_FIELDS = (
     "osu_last_updated",
 )
 AUDIT_ROW_RE = re.compile(r"^\|\s*(\d+)\s*\|")
+PROVENANCE_EXCEPTION_SCHEMA_VERSION = 1
+DEFAULT_PROVENANCE_EXCEPTIONS = Path("config/provenance-review-exceptions.json")
 
 
 class AuditError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class ProvenanceReviewException:
+    beatmapset_id: int
+    artist: str
+    title: str
+    provider: str
+    provider_id: str
+    relation: str
+    reason: str
+    evidence_urls: tuple[str, ...]
+
+    @property
+    def key(self) -> tuple[int, str, str, str]:
+        return (self.beatmapset_id, self.provider, self.provider_id, self.relation)
+
+    def matches(self, audit: ProvenanceAudit, hit: ProvenanceHit) -> bool:
+        return (
+            hit.verdict == "contradicts"
+            and audit.beatmapset_id == self.beatmapset_id
+            and audit.artist == self.artist
+            and audit.title == self.title
+            and hit.provider == self.provider
+            and hit.provider_id == self.provider_id
+            and hit.relation == self.relation
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "beatmapset_id": self.beatmapset_id,
+            "artist": self.artist,
+            "title": self.title,
+            "provider": self.provider,
+            "provider_id": self.provider_id,
+            "relation": self.relation,
+            "reason": self.reason,
+            "evidence_urls": list(self.evidence_urls),
+        }
+
+
+def _exception_string(item: dict, field: str, index: int) -> str:
+    value = item.get(field)
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise AuditError(f"provenance exception {index} has invalid {field}")
+    return value
+
+
+def load_provenance_review_exceptions(path: Path) -> tuple[ProvenanceReviewException, ...]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AuditError(f"cannot load provenance exceptions from {path}: {exc}") from exc
+
+    if not isinstance(payload, dict) or set(payload) != {"schema_version", "exceptions"}:
+        raise AuditError("provenance exceptions must contain only schema_version and exceptions")
+    if payload["schema_version"] != PROVENANCE_EXCEPTION_SCHEMA_VERSION:
+        raise AuditError(
+            f"unsupported provenance exception schema_version: {payload['schema_version']!r}"
+        )
+    if not isinstance(payload["exceptions"], list):
+        raise AuditError("provenance exceptions must be a list")
+
+    required = {
+        "beatmapset_id",
+        "artist",
+        "title",
+        "provider",
+        "provider_id",
+        "relation",
+        "reason",
+        "evidence_urls",
+    }
+    exceptions: list[ProvenanceReviewException] = []
+    seen: set[tuple[int, str, str, str]] = set()
+    for index, item in enumerate(payload["exceptions"]):
+        if not isinstance(item, dict) or set(item) != required:
+            raise AuditError(f"provenance exception {index} must contain exactly {sorted(required)}")
+        beatmapset_id = item["beatmapset_id"]
+        if type(beatmapset_id) is not int or beatmapset_id <= 0:
+            raise AuditError(f"provenance exception {index} has invalid beatmapset_id")
+        urls = item["evidence_urls"]
+        if not isinstance(urls, list) or not urls or not all(isinstance(url, str) for url in urls):
+            raise AuditError(f"provenance exception {index} has invalid evidence_urls")
+        if len(urls) != len(set(urls)):
+            raise AuditError(f"provenance exception {index} has duplicate evidence_urls")
+        for url in urls:
+            parsed = urlparse(url)
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise AuditError(f"provenance exception {index} has invalid evidence URL")
+
+        exception = ProvenanceReviewException(
+            beatmapset_id=beatmapset_id,
+            artist=_exception_string(item, "artist", index),
+            title=_exception_string(item, "title", index),
+            provider=_exception_string(item, "provider", index),
+            provider_id=_exception_string(item, "provider_id", index),
+            relation=_exception_string(item, "relation", index),
+            reason=_exception_string(item, "reason", index),
+            evidence_urls=tuple(urls),
+        )
+        if exception.provider != exception.provider.casefold():
+            raise AuditError(f"provenance exception {index} provider must be lowercase")
+        if exception.relation != exception.relation.casefold():
+            raise AuditError(f"provenance exception {index} relation must be lowercase")
+        if exception.key in seen:
+            raise AuditError(f"duplicate provenance exception: {exception.key}")
+        seen.add(exception.key)
+        exceptions.append(exception)
+    return tuple(exceptions)
+
+
+def resolve_provenance_review_exceptions(
+    repository: Path,
+    path: Path | None,
+) -> tuple[ProvenanceReviewException, ...]:
+    if path is None:
+        default_path = repository / DEFAULT_PROVENANCE_EXCEPTIONS
+        if not default_path.exists():
+            return ()
+        return load_provenance_review_exceptions(default_path)
+    if not path.is_absolute():
+        path = repository / path
+    return load_provenance_review_exceptions(path)
 
 
 class RequestPacer:
@@ -213,20 +346,52 @@ def _target_ids(diff: dict, scope: str) -> list[int]:
     return sorted(set(diff["added"]) | set(diff["modified"]))
 
 
-def provenance_audit(base: Catalog, current: Catalog, diff: dict, *, scope: str, workers: int) -> dict:
+def _resolve_review_flags(
+    audits: list[ProvenanceAudit],
+    exceptions: tuple[ProvenanceReviewException, ...],
+) -> tuple[list[int], list[dict]]:
+    review_flags: list[int] = []
+    acknowledged: list[dict] = []
+    acknowledged_keys: set[tuple[int, str, str, str]] = set()
+    for audit in audits:
+        unacknowledged = False
+        for hit in audit.contradictions:
+            exception = next(
+                (candidate for candidate in exceptions if candidate.matches(audit, hit)),
+                None,
+            )
+            if exception is None:
+                unacknowledged = True
+                continue
+            if exception.key not in acknowledged_keys:
+                acknowledged.append(exception.to_dict())
+                acknowledged_keys.add(exception.key)
+        if unacknowledged:
+            review_flags.append(audit.beatmapset_id)
+    return review_flags, acknowledged
+
+
+def provenance_audit(
+    base: Catalog,
+    current: Catalog,
+    diff: dict,
+    *,
+    scope: str,
+    workers: int,
+    exceptions: tuple[ProvenanceReviewException, ...] = (),
+) -> dict:
     targets = [current.entries[item] for item in _target_ids(diff, scope)]
     audits = audit_entries(targets, workers=workers)
     violations = new_generic_verification_violations(current, base)
     payload = _report_payload(audits, violations)
-    review_flags = [
-        audit.beatmapset_id for audit in audits if audit.verdict in {"red_flag", "ambiguous"}
-    ]
+    review_flags, acknowledged = _resolve_review_flags(audits, exceptions)
     errors: list[str] = []
     if violations:
         errors.append(f"unsafe generic-source verification: {violations[:20]}")
     if review_flags:
         errors.append(f"external provenance needs review: {review_flags[:20]}")
     payload["review_flags"] = review_flags
+    payload["acknowledged_review_flags"] = acknowledged
     payload["errors"] = errors
     return payload
 
@@ -335,6 +500,7 @@ def _print_summary(report: dict) -> None:
             "Provenance: "
             f"checked={provenance['checked']} supported={provenance['supported']} "
             f"review_flags={len(provenance['review_flags'])} "
+            f"acknowledged={len(provenance['acknowledged_review_flags'])} "
             f"provider_errors={provenance['provider_errors']}"
         )
     live = report.get("live_osu")
@@ -357,6 +523,14 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--allow-removals", action="store_true")
     result.add_argument("--forbid-existing-changes", action="store_true")
     result.add_argument("--require-base-ancestor", action="store_true")
+    result.add_argument(
+        "--provenance-exceptions",
+        type=Path,
+        help=(
+            "exact reviewed exceptions for provider contradictions; defaults to the "
+            "repository registry when present"
+        ),
+    )
     result.add_argument("--output", type=Path)
     result.add_argument("--json", action="store_true", help="print the complete report to stdout")
     return result
@@ -399,9 +573,18 @@ def main(argv: list[str] | None = None) -> int:
             report["errors"].extend(report["structural"]["errors"])
 
         if not report["errors"] and args.mode in {"provenance", "all"}:
+            exceptions = resolve_provenance_review_exceptions(
+                repository,
+                args.provenance_exceptions,
+            )
             print(f"Running provenance review for {len(_target_ids(diff, args.scope))} rows...", flush=True)
             report["provenance"] = provenance_audit(
-                base, current, diff, scope=args.scope, workers=args.workers
+                base,
+                current,
+                diff,
+                scope=args.scope,
+                workers=args.workers,
+                exceptions=exceptions,
             )
             report["errors"].extend(report["provenance"]["errors"])
 


### PR DESCRIPTION
## Summary

- add an optional, version-controlled registry for narrowly reviewed provider contradictions
- require exact beatmapset identity, provider record, and relation matching; every unlisted or changed signal still fails closed
- preserve raw provider red flags while reporting matched entries separately as `acknowledged_review_flags`
- record the reviewed TouhouDB false-positive relation for beatmapset 397764 with supporting sources

The registry is supplementary rather than authoritative: if the default file is absent, Deep Review runs with zero acknowledgements. Structural and standalone live-osu review do not depend on it.

## Verification

- `make check` — 96 tests pass
- `make build`
- `python3 -m compileall -q touhou_osu tests`
- `git diff --check`
- `actionlint` v1.7.7
- real PR #38 provenance, with registry: 50 checked / 24 supported / 1 raw red flag / 1 acknowledged / 0 blocking flags / 0 provider errors / pass
- same PR #38 provenance, without registry: blocking flag 397764 / exit 1 / fail
